### PR TITLE
Update checksums if changed

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+checksumBehavior: "update"
+
 enableColors: true
 
 nmHoistingLimits: workspaces


### PR DESCRIPTION
After cloning a fresh copy and running `yarn`, I ran into the following problem:

```
ethereumjs-abi@https://github.com/ethereumjs/ethereumjs-abi.git#commit=ee3994657fa7a427238e6ba92a84d0b529bbcde0: The remote archive doesn't match the expected checksum
```

Quick research revealed that this issue also appeared on scaffold-eth-typescript: https://github.com/scaffold-eth/scaffold-eth-typescript/issues/76 and the solution is to simply add `checksumBehavior: "update"` to `.yarnrc.yml`.

Although, this setting includes some security concerns, the correct way to approach it would be to update the packages in the dependency tree:
```
└─ @se-2/nextjs@workspace:packages/nextjs
   └─ wagmi@npm:0.10.15 [ef549] (via npm:^0.10.15 [ef549])
      ├─ @coinbase/wallet-sdk@npm:3.6.3 (via npm:^3.6.0)
      │  └─ eth-json-rpc-filters@npm:4.2.2 (via npm:4.2.2)
      │     └─ eth-json-rpc-middleware@npm:6.0.0 (via npm:^6.0.0)
      │        └─ eth-sig-util@npm:1.4.2 (via npm:^1.4.2)
      │           └─ ethereumjs-abi@https://github.com/ethereumjs/ethereumjs-abi.git#commit=ee3994657fa7a427238e6ba92a84d0b529bbcde0 (via git+https://github.com/ethereumjs/ethereumjs-abi.git)
```

Since this is deeply nested and hard to reach out to all these authors probably, another solution would be to use Yarn resolutions: (https://yarnpkg.com/cli/set/resolution, https://yarnpkg.com/configuration/manifest/#resolutions)

```json
"resolutions": {
  "ethereumjs-abi": "0.6.8",
}
```

Happy to test and change this PR accordingly if needed. 