### PR TITLE
hotfix: remove prepareWrite from useScaffoldContractWrite

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -1,5 +1,5 @@
 import { utils } from "ethers";
-import { useContractWrite, useNetwork, usePrepareContractWrite } from "wagmi";
+import { useContractWrite, useNetwork } from "wagmi";
 import { getParsedEthersError } from "~~/components/scaffold-eth/Contract/utilsContract";
 import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth/useTransactor";
@@ -18,7 +18,8 @@ export const useScaffoldContractWrite = (contractName: string, functionName: str
   const { chain } = useNetwork();
   const writeTx = useTransactor();
 
-  const { config } = usePrepareContractWrite({
+  const wagmiContractWrite = useContractWrite({
+    mode: "recklesslyUnprepared",
     chainId: configuredChain.id,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi,
@@ -28,8 +29,6 @@ export const useScaffoldContractWrite = (contractName: string, functionName: str
       value: value ? utils.parseEther(value) : undefined,
     },
   });
-
-  const wagmiContractWrite = useContractWrite(config);
 
   const sendContractWriteTx = async () => {
     if (!deployedContractData) {


### PR DESCRIPTION
### Description 
Demo : 

https://user-images.githubusercontent.com/80153681/221653225-e89fd76b-c5ff-4245-8d1d-acd3327dfedc.mov

The above video usees this contract -> https://gist.github.com/austintgriffith/e0b42ffa08e98e98b9e5d5f0f05e5dff
It has `checkIn` function which only let's you checkin if you send `0.001 ETH` and we can see that if click `checkIn` but it gives 'Contract writer error. Try again' instead it should have shown contract reverted error. 

Also if we try to `checkout` immediately, after `checkin` it says `Not checked in'` in the `console` and we get not usefull error `Contract writter error. Try again` in UI. 

created a branch if anyone wants to try out and reproduce -> https://github.com/scaffold-eth/se-2/tree/bug/usePrepareContract-in-customHook

### Reasons : 
1. We are not using `usePrepareContractWrite` properly currently, ideally we should also return the return values from `usePrepareContractWrite` for the developer to handle and show error on inputs. currently, we are spreading values only from `useContractWrite`
2. It creates a bad DX as well as UX if we don't use it properly. 

We can iterate/discuss more on this in Custom Hooks issue Or create a new discussion for it.  
