### PR TITLE
Fix autoConnect when contract not deployed

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ If you want to redeploy to the same production URL you can run `yarn vercel --pr
 
 **Hint**: We recommend connecting the project GitHub repo to Vercel so you the gets automatically deployed when pushing to `main`
 
-**Hint**: If you don't have any contract deployed through SE-2 and plan to just deploy NextJS app maybe only with "connect wallet" functionality you can do so by just setting `targetNetwork : chains.mainnet` or your preferred network in `packages/nextjs/scaffold.config.ts`, rest all instruction remains same as [above](#deploying-your-nextjs-app)
-
 ## Hook Example
 
 - [useScaffoldContractRead](#usescaffoldcontractread)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ If you want to redeploy to the same production URL you can run `yarn vercel --pr
 
 **Hint**: We recommend connecting the project GitHub repo to Vercel so you the gets automatically deployed when pushing to `main`
 
+**Hint**: If you don't have any contract deployed through SE-2 and plan to just deploy NextJS app maybe only with "connect wallet" functionality you can do so by just setting `targetNetwork : chains.mainnet` or your preferred network in `packages/nextjs/scaffold.config.ts`, rest all instruction remains same as [above](#deploying-your-nextjs-app)
+
 ## Hook Example
 
 - [useScaffoldContractRead](#usescaffoldcontractread)

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -25,23 +25,18 @@ export const Faucet = () => {
   const faucetTxn = useTransactor(signer);
 
   useEffect(() => {
-    const getFaucetAddress = async () => {
-      try {
-        if (provider) {
-          const accounts = await provider.listAccounts();
-          setFaucetAddress(accounts[FAUCET_ACCOUNT_INDEX]);
-        }
-      } catch (error) {
+    provider
+      ?.listAccounts()
+      .then(accounts => setFaucetAddress(accounts[FAUCET_ACCOUNT_INDEX]))
+      .catch(error => {
         notification.error(
           <>
             <p className="font-bold mt-0 mb-1">Cannot connect to local provider</p>
             <p className="m-0">Did you forget to run `yarn chain`?</p>
           </>,
         );
-        console.error("⚡️ ~ file: Faucet.tsx:getFaucetAddress ~ error", error);
-      }
-    };
-    getFaucetAddress();
+        console.error("⚡️ ~ file: Faucet.tsx:useEffect ~ error", error);
+      });
   }, [provider]);
 
   const sendETH = async () => {

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ethers } from "ethers";
 import { useNetwork } from "wagmi";
 import { hardhat, localhost } from "wagmi/chains";
@@ -20,7 +20,7 @@ export const Faucet = () => {
   const [sendValue, setSendValue] = useState("");
 
   const { chain: ConnectedChain } = useNetwork();
-  const provider = getLocalProvider(localhost);
+  const provider = useMemo(() => getLocalProvider(localhost), []);
   const signer = provider?.getSigner(FAUCET_ACCOUNT_INDEX);
   const faucetTxn = useTransactor(signer);
 
@@ -34,7 +34,7 @@ export const Faucet = () => {
       } catch (error) {
         notification.error(
           <>
-            <p className="font-bold mt-0 mb-1gi">Cannot connect to local provider</p>
+            <p className="font-bold mt-0 mb-1">Cannot connect to local provider</p>
             <p className="m-0">Did you forget to run `yarn chain`?</p>
           </>,
         );
@@ -42,8 +42,7 @@ export const Faucet = () => {
       }
     };
     getFaucetAddress();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(provider)]);
+  }, [provider]);
 
   const sendETH = async () => {
     try {

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -32,7 +32,13 @@ export const Faucet = () => {
         notification.error(
           <>
             <p className="font-bold mt-0 mb-1">Cannot connect to local provider</p>
-            <p className="m-0">Did you forget to run `yarn chain`?</p>
+            <p className="m-0">
+              - Did you forget to run <code className="italic bg-base-300 text-base font-bold">yarn chain</code> ?
+            </p>
+            <p className="mt-1 break-normal">
+              - Or you can change <code className="italic bg-base-300 text-base font-bold">targetNetwork</code> in{" "}
+              <code className="italic bg-base-300 text-base font-bold">scaffold.config.ts</code>
+            </p>
           </>,
         );
         console.error("⚡️ ~ file: Faucet.tsx:useEffect ~ error", error);

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { ethers } from "ethers";
 import { useNetwork } from "wagmi";
 import { hardhat, localhost } from "wagmi/chains";
@@ -10,6 +10,8 @@ import { getLocalProvider, notification } from "~~/utils/scaffold-eth";
 // Account index to use from generated hardhat accounts.
 const FAUCET_ACCOUNT_INDEX = 0;
 
+const provider = getLocalProvider(localhost);
+
 /**
  * Faucet modal which lets you send ETH to any address.
  */
@@ -20,7 +22,6 @@ export const Faucet = () => {
   const [sendValue, setSendValue] = useState("");
 
   const { chain: ConnectedChain } = useNetwork();
-  const provider = useMemo(() => getLocalProvider(localhost), []);
   const signer = provider?.getSigner(FAUCET_ACCOUNT_INDEX);
   const faucetTxn = useTransactor(signer);
 
@@ -48,7 +49,7 @@ export const Faucet = () => {
       }
     };
     getFaucetAddress();
-  }, [provider]);
+  }, []);
 
   const sendETH = async () => {
     try {

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -25,10 +25,13 @@ export const Faucet = () => {
   const faucetTxn = useTransactor(signer);
 
   useEffect(() => {
-    provider
-      ?.listAccounts()
-      .then(accounts => setFaucetAddress(accounts[FAUCET_ACCOUNT_INDEX]))
-      .catch(error => {
+    const getFaucetAddress = async () => {
+      try {
+        if (provider) {
+          const accounts = await provider.listAccounts();
+          setFaucetAddress(accounts[FAUCET_ACCOUNT_INDEX]);
+        }
+      } catch (error) {
         notification.error(
           <>
             <p className="font-bold mt-0 mb-1">Cannot connect to local provider</p>
@@ -41,8 +44,10 @@ export const Faucet = () => {
             </p>
           </>,
         );
-        console.error("⚡️ ~ file: Faucet.tsx:useEffect ~ error", error);
-      });
+        console.error("⚡️ ~ file: Faucet.tsx:getFaucetAddress ~ error", error);
+      }
+    };
+    getFaucetAddress();
   }, [provider]);
 
   const sendETH = async () => {

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -6,7 +6,6 @@ import { BanknotesIcon } from "@heroicons/react/24/outline";
 import { Address, AddressInput, Balance, EtherInput, getParsedEthersError } from "~~/components/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 import { getLocalProvider, notification } from "~~/utils/scaffold-eth";
-import { contracts } from "~~/utils/scaffold-eth/contract";
 
 // Account index to use from generated hardhat accounts.
 const FAUCET_ACCOUNT_INDEX = 0;
@@ -28,7 +27,7 @@ export const Faucet = () => {
   useEffect(() => {
     const getFaucetAddress = async () => {
       try {
-        if (provider && contracts) {
+        if (provider) {
           const accounts = await provider.listAccounts();
           setFaucetAddress(accounts[FAUCET_ACCOUNT_INDEX]);
         }
@@ -43,7 +42,8 @@ export const Faucet = () => {
       }
     };
     getFaucetAddress();
-  }, [provider]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(provider)]);
 
   const sendETH = async () => {
     try {

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -5,7 +5,6 @@ import { hardhat } from "wagmi/chains";
 import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletId, defaultBurnerChainId } from "~~/services/web3/wagmi-burner/BurnerConnector";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
-import { contracts } from "~~/utils/scaffold-eth/contract";
 
 const walletIdStorageKey = "scaffoldEth2.wallet";
 
@@ -65,10 +64,6 @@ export const useAutoConnect = (): void => {
   }, [accountState.isConnected, accountState.connector?.name]);
 
   useEffectOnce(() => {
-    if (!contracts) {
-      return;
-    }
-
     const initialConnector = getInitialConnector(walletId, connectState.connectors);
 
     if (initialConnector?.connector) {


### PR DESCRIPTION
### Issue : 
It seems that due to the below check autoConnect does not work if you use SE-2 that doesn't use deployed contract : 
https://github.com/scaffold-eth/se-2/blob/ce83d166df62083a3aac86a6dda1802737a02fa8/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts#L68

### Demo not working : 
Selected Mainnet as `targetNetwork`

https://user-images.githubusercontent.com/80153681/230662110-f12dac45-13b0-444b-bcb2-0c552a10504a.mov



--- 

Fixed by removing the `if(contract)` from both `useAutoConnect` & `Faucet`, it seems that check was added due console getting bloated with errors and warning but I think it was fixed in other commits 

checkout OG comment : https://github.com/scaffold-eth/se-2/pull/255/files/43f82e58bab2f624b60f520e68cfff749fe541e7#r1147414048

#### Demo with only `yarn chain` runnig and deployed contract is null : 

https://user-images.githubusercontent.com/80153681/230661918-c66089cb-5b29-4914-a59d-7588a0818ebe.mov

#### Demo with `yarn chain` not running : 

https://user-images.githubusercontent.com/80153681/230662002-1fd3e69f-b790-4e40-b534-db8f6e537a1f.mov



