### PR TITLE
Change Switch Network modal for a dropdown with only the target network

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -39,7 +39,7 @@ export const RainbowKitCustomConnectButton = () => {
                       <span>Wrong network</span>
                       <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
                     </button>
-                    <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box">
+                    <ul tabIndex={0} className="dropdown-content menu p-2 mt-1 shadow-lg bg-base-100 rounded-box">
                       <li>
                         <button
                           className="menu-item"

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -41,9 +41,9 @@ export const RainbowKitCustomConnectButton = () => {
                     </button>
                     <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-56">
                       <li>
-                        <a
+                        <button
                           className="menu-item"
-                          href="#"
+                          type="button"
                           onClick={() => {
                             if (switchNetwork) {
                               switchNetwork(configuredNetwork.id);
@@ -54,20 +54,18 @@ export const RainbowKitCustomConnectButton = () => {
                           <span>
                             Switch to <span style={{ color: networkColor }}>{configuredNetwork.name}</span>
                           </span>
-                        </a>
+                        </button>
                       </li>
                       <li>
-                        <a
-                          className="menu-item text-red-500" // Add the 'text-red-500' class
-                          href="#"
+                        <button
+                          className="menu-item text-red-500"
+                          type="button"
                           onClick={() => {
                             disconnect();
                           }}
                         >
-                          <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0 text-red-500" />{" "}
-                          {/* Add the 'text-red-500' class */}
-                          <span className="text-red-500">Disconnect</span> {/* Add the 'text-red-500' class */}
-                        </a>
+                          <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
+                        </button>
                       </li>
                     </ul>
                   </div>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -39,31 +39,21 @@ export const RainbowKitCustomConnectButton = () => {
                       <span>Wrong network</span>
                       <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
                     </button>
-                    <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-56">
+                    <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box">
                       <li>
                         <button
                           className="menu-item"
                           type="button"
-                          onClick={() => {
-                            if (switchNetwork) {
-                              switchNetwork(configuredNetwork.id);
-                            }
-                          }}
+                          onClick={() => switchNetwork?.(configuredNetwork.id)}
                         >
                           <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
-                          <span>
+                          <span className="whitespace-nowrap">
                             Switch to <span style={{ color: networkColor }}>{configuredNetwork.name}</span>
                           </span>
                         </button>
                       </li>
                       <li>
-                        <button
-                          className="menu-item text-red-500"
-                          type="button"
-                          onClick={() => {
-                            disconnect();
-                          }}
-                        >
+                        <button className="menu-item text-red-500" type="button" onClick={() => disconnect()}>
                           <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
                         </button>
                       </li>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -53,7 +53,7 @@ export const RainbowKitCustomConnectButton = () => {
                         </button>
                       </li>
                       <li>
-                        <button className="menu-item text-red-500" type="button" onClick={() => disconnect()}>
+                        <button className="menu-item text-error" type="button" onClick={() => disconnect()}>
                           <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
                         </button>
                       </li>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -1,5 +1,6 @@
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { ChevronDownIcon } from "@heroicons/react/24/solid";
+import { useDisconnect, useSwitchNetwork } from "wagmi";
+import { ArrowLeftOnRectangleIcon, ArrowsRightLeftIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
 import { Balance, BlockieAvatar } from "~~/components/scaffold-eth";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
@@ -12,10 +13,12 @@ export const RainbowKitCustomConnectButton = () => {
 
   const networkColor = useNetworkColor();
   const configuredNetwork = getTargetNetwork();
+  const { disconnect } = useDisconnect();
+  const { switchNetwork } = useSwitchNetwork();
 
   return (
     <ConnectButton.Custom>
-      {({ account, chain, openAccountModal, openConnectModal, openChainModal, mounted }) => {
+      {({ account, chain, openAccountModal, openConnectModal, mounted }) => {
         const connected = mounted && account && chain;
 
         return (
@@ -31,15 +34,43 @@ export const RainbowKitCustomConnectButton = () => {
 
               if (chain.unsupported || chain.id !== configuredNetwork.id) {
                 return (
-                  <>
-                    <span className="text-xs" style={{ color: networkColor }}>
-                      {configuredNetwork.name}
-                    </span>
-                    <button className="btn btn-sm btn-error ml-2" onClick={openChainModal} type="button">
+                  <div className="dropdown dropdown-end">
+                    <button tabIndex={0} className="btn btn-error btn-sm dropdown-toggle">
                       <span>Wrong network</span>
                       <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
                     </button>
-                  </>
+                    <ul tabIndex={0} className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-56">
+                      <li>
+                        <a
+                          className="menu-item"
+                          href="#"
+                          onClick={() => {
+                            if (switchNetwork) {
+                              switchNetwork(configuredNetwork.id);
+                            }
+                          }}
+                        >
+                          <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
+                          <span>
+                            Switch to <span style={{ color: networkColor }}>{configuredNetwork.name}</span>
+                          </span>
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          className="menu-item text-red-500" // Add the 'text-red-500' class
+                          href="#"
+                          onClick={() => {
+                            disconnect();
+                          }}
+                        >
+                          <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0 text-red-500" />{" "}
+                          {/* Add the 'text-red-500' class */}
+                          <span className="text-red-500">Disconnect</span> {/* Add the 'text-red-500' class */}
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
                 );
               }
 


### PR DESCRIPTION
As commented here: [issue 300](https://github.com/scaffold-eth/se-2/issues/300#issuecomment-1512725914) to improve the user experience and simplify the network switching (which had networks that may confuse the user) I've replaced the existing modal with a dropdown menu that appears when the user is on the wrong network. 

The dropdown menu only includes the target network switch option and the disconnect option. Here is a video of the new behaviour: [PR se-2 issue-300 - Watch Video](https://www.loom.com/share/82e23277107548479d26afbd3c019eea)
