### PR TITLE
feat: display eth price as per target network

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -10,17 +10,17 @@ import { getTargetNetwork } from "~~/utils/scaffold-eth";
  * Site footer
  */
 export const Footer = () => {
-  const ethPrice = useAppStore(state => state.ethPrice);
+  const nativeCurrencyPrice = useAppStore(state => state.nativeCurrencyPrice);
 
   return (
     <div className="min-h-0 p-5 mb-11 lg:mb-0">
       <div>
         <div className="fixed flex justify-between items-center w-full z-20 p-4 bottom-0 left-0 pointer-events-none">
           <div className="flex space-x-2 pointer-events-auto">
-            {ethPrice > 0 && (
+            {nativeCurrencyPrice > 0 && (
               <div className="btn btn-primary btn-sm font-normal cursor-auto">
                 <CurrencyDollarIcon className="h-4 w-4 mr-0.5" />
-                <span>{ethPrice}</span>
+                <span>{nativeCurrencyPrice}</span>
               </div>
             )}
             {getTargetNetwork().id === hardhat.id && <Faucet />}

--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -5,30 +5,33 @@ import { useAppStore } from "~~/services/store/store";
 
 const MAX_DECIMALS_USD = 2;
 
-function etherValueToDisplayValue(usdMode: boolean, etherValue: string, ethPrice: number) {
-  if (usdMode && ethPrice) {
+function etherValueToDisplayValue(usdMode: boolean, etherValue: string, nativeCurrencyPrice: number) {
+  if (usdMode && nativeCurrencyPrice) {
     const parsedEthValue = parseFloat(etherValue);
     if (Number.isNaN(parsedEthValue)) {
       return etherValue;
     } else {
       // We need to round the value rather than use toFixed,
       // since otherwise a user would not be able to modify the decimal value
-      return (Math.round(parsedEthValue * ethPrice * 10 ** MAX_DECIMALS_USD) / 10 ** MAX_DECIMALS_USD).toString();
+      return (
+        Math.round(parsedEthValue * nativeCurrencyPrice * 10 ** MAX_DECIMALS_USD) /
+        10 ** MAX_DECIMALS_USD
+      ).toString();
     }
   } else {
     return etherValue;
   }
 }
 
-function displayValueToEtherValue(usdMode: boolean, displayValue: string, ethPrice: number) {
-  if (usdMode && ethPrice) {
+function displayValueToEtherValue(usdMode: boolean, displayValue: string, nativeCurrencyPrice: number) {
+  if (usdMode && nativeCurrencyPrice) {
     const parsedDisplayValue = parseFloat(displayValue);
     if (Number.isNaN(parsedDisplayValue)) {
       // Invalid number.
       return displayValue;
     } else {
       // Compute the ETH value if a valid number.
-      return (parsedDisplayValue / ethPrice).toString();
+      return (parsedDisplayValue / nativeCurrencyPrice).toString();
     }
   } else {
     return displayValue;
@@ -42,20 +45,20 @@ function displayValueToEtherValue(usdMode: boolean, displayValue: string, ethPri
  */
 export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputProps) => {
   const [transitoryDisplayValue, setTransitoryDisplayValue] = useState<string>();
-  const ethPrice = useAppStore(state => state.ethPrice);
+  const nativeCurrencyPrice = useAppStore(state => state.nativeCurrencyPrice);
   const [usdMode, setUSDMode] = useState(false);
 
   // The displayValue is derived from the ether value that is controlled outside of the component
   // In usdMode, it is converted to its usd value, in regular mode it is unaltered
   const displayValue = useMemo(() => {
-    const newDisplayValue = etherValueToDisplayValue(usdMode, value, ethPrice);
+    const newDisplayValue = etherValueToDisplayValue(usdMode, value, nativeCurrencyPrice);
     if (transitoryDisplayValue && parseFloat(newDisplayValue) === parseFloat(transitoryDisplayValue)) {
       return transitoryDisplayValue;
     }
     // Clear any transitory display values that might be set
     setTransitoryDisplayValue(undefined);
     return newDisplayValue;
-  }, [ethPrice, transitoryDisplayValue, usdMode, value]);
+  }, [nativeCurrencyPrice, transitoryDisplayValue, usdMode, value]);
 
   const handleChangeNumber = (newValue: string) => {
     if (newValue && !SIGNED_NUMBER_REGEX.test(newValue)) {
@@ -79,7 +82,7 @@ export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputPr
       setTransitoryDisplayValue(undefined);
     }
 
-    const newEthValue = displayValueToEtherValue(usdMode, newValue, ethPrice);
+    const newEthValue = displayValueToEtherValue(usdMode, newValue, nativeCurrencyPrice);
     onChange(newEthValue);
   };
 
@@ -98,7 +101,7 @@ export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputPr
         <button
           className="btn btn-primary h-[2.2rem] min-h-[2.2rem]"
           onClick={toggleMode}
-          disabled={!usdMode && !ethPrice}
+          disabled={!usdMode && !nativeCurrencyPrice}
         >
           <ArrowsRightLeftIcon className="h-3 w-3 cursor-pointer" aria-hidden="true" />
         </button>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -65,7 +65,7 @@ export const RainbowKitCustomConnectButton = () => {
               return (
                 <div className="px-2 flex justify-end items-center">
                   <div className="flex justify-center items-center border-1 rounded-lg">
-                    <div className="flex flex-col items-center">
+                    <div className="flex flex-col items-center mr-2">
                       <Balance address={account.address} className="min-h-0 h-auto" />
                       <span className="text-xs" style={{ color: networkColor }}>
                         {chain.name}

--- a/packages/nextjs/hooks/scaffold-eth/index.ts
+++ b/packages/nextjs/hooks/scaffold-eth/index.ts
@@ -3,7 +3,7 @@ export * from "./useAnimationConfig";
 export * from "./useAutoConnect";
 export * from "./useBurnerWallet";
 export * from "./useDeployedContractInfo";
-export * from "./useEthPrice";
+export * from "./useNativeCurrencyPrice";
 export * from "./useNetworkColor";
 export * from "./useOutsideClick";
 export * from "./useScaffoldContract";

--- a/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
@@ -6,7 +6,7 @@ import { getTargetNetwork } from "~~/utils/scaffold-eth";
 export function useAccountBalance(address?: string) {
   const [isEthBalance, setIsEthBalance] = useState(true);
   const [balance, setBalance] = useState<number | null>(null);
-  const price = useAppStore(state => state.ethPrice);
+  const price = useAppStore(state => state.nativeCurrencyPrice);
 
   const {
     data: fetchedBalanceData,

--- a/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
@@ -19,7 +19,9 @@ export function useAccountBalance(address?: string) {
   });
 
   const onToggleBalance = useCallback(() => {
-    setIsEthBalance(!isEthBalance);
+    if (price > 0) {
+      setIsEthBalance(!isEthBalance);
+    }
   }, [isEthBalance]);
 
   useEffect(() => {

--- a/packages/nextjs/hooks/scaffold-eth/useNativeCurrencyPrice.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNativeCurrencyPrice.ts
@@ -8,17 +8,17 @@ const enablePolling = false;
 
 /**
  * Get the price of ETH based on ETH/DAI trading pair from Uniswap SDK
- * @returns ethPrice: number
+ * @returns nativeCurrencyPrice: number
  */
-export const useEthPrice = () => {
+export const useNativeCurrency = () => {
   const provider = useProvider({ chainId: 1 });
-  const [ethPrice, setEthPrice] = useState(0);
+  const [nativeCurrencyPrice, setNativeCurrency] = useState(0);
 
   // Get the price of ETH from Uniswap on mount
   useEffect(() => {
     (async () => {
       const price = await fetchPriceFromUniswap(provider);
-      setEthPrice(price);
+      setNativeCurrency(price);
     })();
   }, [provider]);
 
@@ -26,10 +26,10 @@ export const useEthPrice = () => {
   useInterval(
     async () => {
       const price = await fetchPriceFromUniswap(provider);
-      setEthPrice(price);
+      setNativeCurrency(price);
     },
     enablePolling ? scaffoldConfig.pollingInterval : null,
   );
 
-  return ethPrice;
+  return nativeCurrencyPrice;
 };

--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -9,24 +9,24 @@ import { WagmiConfig } from "wagmi";
 import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
-import { useEthPrice } from "~~/hooks/scaffold-eth";
+import { useNativeCurrency } from "~~/hooks/scaffold-eth";
 import { useAppStore } from "~~/services/store/store";
 import { wagmiClient } from "~~/services/web3/wagmiClient";
 import { appChains } from "~~/services/web3/wagmiConnectors";
 import "~~/styles/globals.css";
 
 const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
-  const price = useEthPrice();
-  const setEthPrice = useAppStore(state => state.setEthPrice);
+  const price = useNativeCurrency();
+  const setNativeCurrency = useAppStore(state => state.setNativeCurrency);
   // This variable is required for initial client side rendering of correct theme for RainbowKit
   const [isDarkTheme, setIsDarkTheme] = useState(true);
   const { isDarkMode } = useDarkMode();
 
   useEffect(() => {
     if (price > 0) {
-      setEthPrice(price);
+      setNativeCurrency(price);
     }
-  }, [setEthPrice, price]);
+  }, [setNativeCurrency, price]);
 
   useEffect(() => {
     setIsDarkTheme(isDarkMode);

--- a/packages/nextjs/services/store/store.ts
+++ b/packages/nextjs/services/store/store.ts
@@ -10,11 +10,11 @@ import create from "zustand";
  */
 
 type TAppStore = {
-  ethPrice: number;
-  setEthPrice: (newEthPriceState: number) => void;
+  nativeCurrencyPrice: number;
+  setNativeCurrency: (newNativeCurrencyState: number) => void;
 };
 
 export const useAppStore = create<TAppStore>(set => ({
-  ethPrice: 0,
-  setEthPrice: (newValue: number): void => set(() => ({ ethPrice: newValue })),
+  nativeCurrencyPrice: 0,
+  setNativeCurrency: (newValue: number): void => set(() => ({ nativeCurrencyPrice: newValue })),
 }));

--- a/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
+++ b/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
@@ -4,10 +4,14 @@ import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 export const fetchPriceFromUniswap = async (provider: Provider): Promise<number> => {
   const configuredNetwork = getTargetNetwork();
-  if (configuredNetwork.tokenAddress) {
+  if (configuredNetwork.nativeCurrency.symbol == "ETH" || configuredNetwork.tokenAddress) {
     try {
       const DAI = new Token(1, "0x6B175474E89094C44Da98b954EedeAC495271d0F", 18);
-      const TOKEN = await Fetcher.fetchTokenData(1, configuredNetwork.tokenAddress, provider);
+      const TOKEN = await Fetcher.fetchTokenData(
+        1,
+        configuredNetwork.tokenAddress ? configuredNetwork.tokenAddress : "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        provider,
+      );
       const pair = await Fetcher.fetchPairData(DAI, TOKEN, provider);
       const route = new Route([pair], TOKEN);
       const price = parseFloat(route.midPrice.toSignificant(6));

--- a/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
+++ b/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
@@ -1,15 +1,22 @@
-import { Fetcher, Route, Token, WETH } from "@uniswap/sdk";
+import { Fetcher, Route, Token } from "@uniswap/sdk";
 import { Provider } from "@wagmi/core";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 export const fetchPriceFromUniswap = async (provider: Provider): Promise<number> => {
-  try {
-    const DAI = new Token(1, "0x6B175474E89094C44Da98b954EedeAC495271d0F", 18);
-    const pair = await Fetcher.fetchPairData(DAI, WETH[DAI.chainId], provider);
-    const route = new Route([pair], WETH[DAI.chainId]);
-    const price = parseFloat(route.midPrice.toSignificant(6));
-    return price;
-  } catch (error) {
-    console.error("useEthPrice - Error fetching ETH price from Uniswap: ", error);
+  const configuredNetwork = getTargetNetwork();
+  if (configuredNetwork.tokenAddress) {
+    try {
+      const DAI = new Token(1, "0x6B175474E89094C44Da98b954EedeAC495271d0F", 18);
+      const TOKEN = await Fetcher.fetchTokenData(1, configuredNetwork.tokenAddress, provider);
+      const pair = await Fetcher.fetchPairData(DAI, TOKEN, provider);
+      const route = new Route([pair], TOKEN);
+      const price = parseFloat(route.midPrice.toSignificant(6));
+      return price;
+    } catch (error) {
+      console.error("useEthPrice - Error fetching ETH price from Uniswap: ", error);
+      return 0;
+    }
+  } else {
     return 0;
   }
 };

--- a/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
+++ b/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
@@ -13,7 +13,7 @@ export const fetchPriceFromUniswap = async (provider: Provider): Promise<number>
       const price = parseFloat(route.midPrice.toSignificant(6));
       return price;
     } catch (error) {
-      console.error("useEthPrice - Error fetching ETH price from Uniswap: ", error);
+      console.error("useNativeCurrency - Error fetching ETH price from Uniswap: ", error);
       return 0;
     }
   } else {

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -5,47 +5,61 @@ import scaffoldConfig from "~~/scaffold.config";
 export type TChainAttributes = {
   // color | [lightThemeColor, darkThemeColor]
   color: string | [string, string];
+  tokenAddress?: string;
 };
 
 export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
   [chains.hardhat.id]: {
     color: "#b8af0c",
+    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.mainnet.id]: {
     color: "#ff8b9e",
+    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.sepolia.id]: {
     color: ["#5f4bb6", "#87ff65"],
+    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.goerli.id]: {
     color: "#0975F6",
+    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.gnosis.id]: {
     color: "#48a9a6",
+    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.polygon.id]: {
     color: "#2bbdf7",
+    tokenAddress: "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
   },
   [chains.polygonMumbai.id]: {
     color: "#92D9FA",
+    tokenAddress: "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
   },
   [chains.optimismGoerli.id]: {
     color: "#f01a37",
+    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.optimism.id]: {
     color: "#f01a37",
+    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.arbitrumGoerli.id]: {
     color: "#28a0f0",
+    tokenAddress: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
   },
   [chains.arbitrum.id]: {
     color: "#28a0f0",
+    tokenAddress: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
   },
   [chains.fantom.id]: {
     color: "#1969ff",
+    tokenAddress: "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
   },
   [chains.fantomTestnet.id]: {
     color: "#1969ff",
+    tokenAddress: "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
   },
 };
 

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -40,19 +40,15 @@ export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
   },
   [chains.arbitrumGoerli.id]: {
     color: "#28a0f0",
-    tokenAddress: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
   },
   [chains.arbitrum.id]: {
     color: "#28a0f0",
-    tokenAddress: "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
   },
   [chains.fantom.id]: {
     color: "#1969ff",
-    tokenAddress: "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
   },
   [chains.fantomTestnet.id]: {
     color: "#1969ff",
-    tokenAddress: "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
   },
 };
 

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -11,23 +11,18 @@ export type TChainAttributes = {
 export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
   [chains.hardhat.id]: {
     color: "#b8af0c",
-    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.mainnet.id]: {
     color: "#ff8b9e",
-    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.sepolia.id]: {
     color: ["#5f4bb6", "#87ff65"],
-    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.goerli.id]: {
     color: "#0975F6",
-    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.gnosis.id]: {
     color: "#48a9a6",
-    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.polygon.id]: {
     color: "#2bbdf7",
@@ -39,11 +34,9 @@ export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
   },
   [chains.optimismGoerli.id]: {
     color: "#f01a37",
-    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.optimism.id]: {
     color: "#f01a37",
-    tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   [chains.arbitrumGoerli.id]: {
     color: "#28a0f0",


### PR DESCRIPTION
Solves #323

My matic balance:
![image](https://user-images.githubusercontent.com/62877695/233978604-6e39336b-8a9f-4dc5-bf58-7c57bdee77ae.png)

My USD balance for the same:
![image](https://user-images.githubusercontent.com/62877695/233978526-1d5bed88-2103-4c80-a30e-89a7f713bad3.png)

# Discussion

For `arbitrum` and `fantom` uniswap SDK is unable to fetch data and throws an error. The price is shown on uniswaps dapp not sure how but maybe they are using coinbase's api for it. Current solution:
1. Remove the tokenAddresses for these two chains and the price for these chains won't be displayed and there won't be any error
2. Let the error be thrown in the terminal