### PR TITLE
add pr and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_repot.yml
+++ b/.github/ISSUE_TEMPLATE/bug_repot.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: File a bug/issue
+title: 'bug: <title>'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! The more info you provide, the more we can help you 🙌
+
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps or code snippets to reproduce the behavior.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Browser info? Screenshots? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask Question
-    url: https://github.com/scaffold-eth/scaffold-eth-2/discussions/categories/q-a 
+    url: https://github.com/scaffold-eth/scaffold-eth-2/discussions/new?category=q-a
     about: Ask questions and discuss with other community members
   - name: Request Feature
-    url: https://github.com/scaffold-eth/scaffold-eth-2/discussions/categories/ideas 
+    url: https://github.com/scaffold-eth/scaffold-eth-2/discussions/new?category=ideas 
     about: Requests features or brainstorm ideas for new functionality

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask Question
+    url: https://github.com/scaffold-eth/scaffold-eth-2/discussions/categories/q-a 
+    about: Ask questions and discuss with other community members
+  - name: Request Feature
+    url: https://github.com/scaffold-eth/scaffold-eth-2/discussions/categories/ideas 
+    about: Requests features or brainstorm ideas for new functionality

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Description
+
+_Concise description of proposed changes, We recommend using screenshots and videos for better description_
+
+## Additional Information
+
+- [ ] I read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
+
+Your ENS/address:


### PR DESCRIPTION
#### Description 
This might end up in the trash / maybe an early optimization...please feel free to suggest improvements also happy to close for now 🙌

**Some questions / thoughts**
1. Hopefully this don't have a lot of restriction while creating issue in bad way, having some restriction/template will be good maybe we make it more minimal ?  
2. It points you to discussion for questions/ideas, do we plan to open up discussions or handle it via issue? 

### Flow 

https://user-images.githubusercontent.com/80153681/235199691-3c7927af-f020-407d-9597-dbf31b620771.mov

Btw the text-area in issue template support markdown. 

You can also try out the actual flow by creating issue / pr's to https://github.com/technophile-04/se-2 

Heavily inspired by https://github.com/wagmi-dev/wagmi