### PR TITLE
Added optional override for custom  gas limit when using useScaffoldContractWrite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ const { writeAsync, isLoading, isMining } = useScaffoldContractWrite({
   args: ["The value to set"],
   // For payable functions, expressed in ETH
   value: "0.01",
+  // An Optional overide for setting custom gasLimit.
+  gasLimit: "500000",
 });
 ```
 

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Abi, ExtractAbiFunctionNames } from "abitype";
-import { utils } from "ethers";
+import { BigNumber, utils } from "ethers";
 import { useContractWrite, useNetwork } from "wagmi";
 import { getParsedEthersError } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useTransactor } from "~~/hooks/scaffold-eth";
@@ -23,6 +23,7 @@ export const useScaffoldContractWrite = <
   functionName,
   args,
   value,
+  gasLimit,
   ...writeConfig
 }: UseScaffoldWriteConfig<TContractName, TFunctionName>) => {
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
@@ -40,6 +41,7 @@ export const useScaffoldContractWrite = <
     functionName: functionName as any,
     overrides: {
       value: value ? utils.parseEther(value) : undefined,
+      gasLimit: gasLimit ? BigNumber.from(gasLimit) : undefined // include gasLimit if provided
     },
     ...writeConfig,
   });

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -143,7 +143,8 @@ export type UseScaffoldWriteConfig<
   TFunctionName extends ExtractAbiFunctionNames<ContractAbi<TContractName>, WriteAbiStateMutability>,
 > = {
   contractName: TContractName;
-  value?: string;
+    value?: string;
+    gasLimit?: string;
 } & IsContractsFileMissing<
   Partial<UseContractWriteConfig> & { args?: unknown[] },
   {


### PR DESCRIPTION
While hacking with Scaffold-Eth 2, I wanted to call my contract with 0.002 ETH which will be required to call another contract, I wanted a way to set a custom gas so I can set the gas and send 0.002 ETH without sending more ETH value.

Yes, I could just send in more ETH, but I didn't want to have to send in more 🥸 .

This PR is the improvise I used to add another optional override for setting a custom gas limit, which made sense to me👀.

Also tested to make sure this addition didn't break anything. 

Updated the README.md to include this usage in the useScaffoldWrite example. 

This is optional so if there is no need for a builder to customise their gas limit they can just ignore it.

The drawback to this was that I had to import BigNumber from ethers to handle the gas limit value which is a pretty heavy addition to the useScaffoldContractWrite hook.

Please take a look and let me know if this will be useful. 
