### PR TITLE
Memoize filters to avoid infinite rendering

### DIFF
--- a/packages/nextjs/components/example-ui/ContractData.tsx
+++ b/packages/nextjs/components/example-ui/ContractData.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Marquee from "react-fast-marquee";
 import { useAccount } from "wagmi";
 import {
@@ -38,6 +38,10 @@ export const ContractData = () => {
     },
   });
 
+  const filters = useMemo(() => {
+    return { greetingSetter: address };
+  }, [address]);
+
   const {
     data: myGreetingChangeEvents,
     isLoading: isLoadingEvents,
@@ -46,7 +50,7 @@ export const ContractData = () => {
     contractName: "YourContract",
     eventName: "GreetingChange",
     fromBlock: Number(process.env.NEXT_PUBLIC_DEPLOY_BLOCK) || 0,
-    filters: { greetingSetter: address },
+    filters: filters,
     blockData: true,
   });
 

--- a/packages/nextjs/components/example-ui/ContractData.tsx
+++ b/packages/nextjs/components/example-ui/ContractData.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Marquee from "react-fast-marquee";
 import { useAccount } from "wagmi";
 import {
@@ -38,10 +38,6 @@ export const ContractData = () => {
     },
   });
 
-  const filters = useMemo(() => {
-    return { greetingSetter: address };
-  }, [address]);
-
   const {
     data: myGreetingChangeEvents,
     isLoading: isLoadingEvents,
@@ -50,7 +46,7 @@ export const ContractData = () => {
     contractName: "YourContract",
     eventName: "GreetingChange",
     fromBlock: Number(process.env.NEXT_PUBLIC_DEPLOY_BLOCK) || 0,
-    filters: filters,
+    filters: { greetingSetter: address },
     blockData: true,
   });
 

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -109,6 +109,7 @@ export const useScaffoldEventHistory = <
     if (!deployedContractLoading) {
       readEvents();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     provider,
     fromBlock,
@@ -118,7 +119,8 @@ export const useScaffoldEventHistory = <
     deployedContractData?.address,
     contract,
     deployedContractData,
-    filters,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    JSON.stringify(filters),
     blockData,
     transactionData,
     receiptData,


### PR DESCRIPTION
## Description

Hey guys,

I've noticed that the Example UI page keeps re-rendering (see the console logs), because the filters object is used as a dependency of the useEffect hook.
Memoizing the object solved the issue for me.

Cheers,
Tamas

https://github.com/scaffold-eth/scaffold-eth-2/assets/1397179/acacd893-a745-4c8c-aaaa-aa335fa01f82


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


Your ENS/address:
monyo.eth
