### PR TITLE
added size prop to address component

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -13,12 +13,13 @@ type TAddressProps = {
   address?: string;
   disableAddressLink?: boolean;
   format?: "short" | "long";
+  size?: "xl" | "lg" | "md" | "sm" | "xs";
 };
 
 /**
  * Displays an address (or ENS) with a Blockie image and option to copy address.
  */
-export const Address = ({ address, disableAddressLink, format }: TAddressProps) => {
+export const Address = ({ address, disableAddressLink, format, size = "md" }: TAddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
@@ -77,14 +78,14 @@ export const Address = ({ address, disableAddressLink, format }: TAddressProps) 
         )}
       </div>
       {disableAddressLink ? (
-        <span className="ml-1.5 text-lg font-normal">{displayAddress}</span>
+        <span className={`ml-1.5 text-${size} font-normal`}>{displayAddress}</span>
       ) : getTargetNetwork().id === hardhat.id ? (
-        <span className="ml-1.5 text-lg font-normal">
+        <span className={`ml-1.5 text-${size} font-normal`}>
           <Link href={blockExplorerAddressLink}>{displayAddress}</Link>
         </span>
       ) : (
         <a
-          className="ml-1.5 text-lg font-normal"
+          className={`ml-1.5 text-${size} font-normal`}
           target="_blank"
           href={blockExplorerAddressLink}
           rel="noopener noreferrer"


### PR DESCRIPTION
## Description
Address size prop
the size prop is an optional prop that changes the text size of the address
![Screenshot from 2023-06-05 08-21-12](https://github.com/scaffold-eth/scaffold-eth-2/assets/64108987/92f15677-9460-4763-b74e-ab1b3862c9bb)
![Screenshot from 2023-06-05 08-21-37](https://github.com/scaffold-eth/scaffold-eth-2/assets/64108987/b88011c8-1a29-4005-8f67-96dbd17992f6)

_Concise description of proposed changes, We recommend using screenshots and videos for better description_

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
kcpele.eth