### PR TITLE
fix(Balance): font-size of symbol should be relative to current font-size, not document root

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -27,7 +27,7 @@ export const Balance = ({ address, className = "" }: TBalanceProps) => {
   if (isError) {
     return (
       <div className={`border-2 border-gray-400 rounded-md px-2 flex flex-col items-center max-w-fit cursor-pointer`}>
-        <div className="text-warning text-xs">Error</div>
+        <div className="text-warning">Error</div>
       </div>
     );
   }
@@ -41,11 +41,11 @@ export const Balance = ({ address, className = "" }: TBalanceProps) => {
         {isEthBalance ? (
           <>
             <span>{balance?.toFixed(4)}</span>
-            <span className="text-xs font-bold ml-1">{configuredNetwork.nativeCurrency.symbol}</span>
+            <span className="text-[0.8em] font-bold ml-1">{configuredNetwork.nativeCurrency.symbol}</span>
           </>
         ) : (
           <>
-            <span className="text-xs font-bold mr-1">$</span>
+            <span className="text-[0.8em] font-bold mr-1">$</span>
             <span>{(balance * price).toFixed(2)}</span>
           </>
         )}


### PR DESCRIPTION
## Issue

When displaying Balance component with larger font-size, the ETH / $ symbol remains `text-xs`
<img width="567" alt="image" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/15879327/a175caac-aa55-4102-a72a-093d0770ed32">

## Fix

Use `text-[...em]` instead of `text-xs`. This sets an `em` value instead of a `rem` value, to ensure the symbol size is modified relative to the local font-size rather than that of the document root.
<img width="567" alt="image" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/15879327/24ff8fc5-4746-423b-b4e6-a8e4041d08c7">

