### PR TITLE
fix(contract.ts): very long abi's now no longer go over type instantiation limit

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -121,6 +121,10 @@ type RestConfigParam<TAbiStateMutability extends AbiStateMutability> = Partial<
   >
 >;
 
+type Expand<T> = T extends object ? (T extends infer O ? { [K in keyof O]: O[K] } : never) : T;
+
+type UnionToIntersection<U> = Expand<(U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never>;
+
 type OptionalTupple<T> = T extends readonly [infer H, ...infer R] ? readonly [H | undefined, ...OptionalTupple<R>] : T;
 
 type UseScaffoldArgsParam<
@@ -129,7 +133,7 @@ type UseScaffoldArgsParam<
   TFunctionName extends ExtractAbiFunctionNames<ContractAbi<TContractName>, TAbiStateMutability>,
 > = TFunctionName extends FunctionNamesWithInputs<ContractAbi<TContractName>, TAbiStateMutability>
   ? {
-      args: OptionalTupple<AbiFunctionArguments<ContractAbi<TContractName>, TFunctionName>>;
+      args: OptionalTupple<UnionToIntersection<AbiFunctionArguments<ContractAbi<TContractName>, TFunctionName>>>;
     }
   : {
       args?: never;


### PR DESCRIPTION
Fixes #374

## Description

Make a very long contract.ts file by just copy-pasting the `greeting` view function (no need to actually deploy or make a valid Abi). At a certain length, TypeScript starts returning errors when running `yarn next:check-types`.

## Findings

Contract abi's well over 2000 lines long can hit the typescript type instantiation limit (see [context of this limit](https://github.com/microsoft/TypeScript/issues/34933)). A workaround is described [here](https://stackoverflow.com/a/74292294/5000057).

Applying it does seem to resolve the issue.