### PR TITLE
fix listner types error when contracts missing

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -178,7 +178,7 @@ export type UseScaffoldEventConfig<
 > = {
   contractName: TContractName;
 } & IsContractDeclarationMissing<
-  UseContractEventConfig,
+  UseContractEventConfig & { listener: (...args: any[]) => void },
   {
     eventName: TEventName;
     listener: (...args: TEventInputs) => void;


### PR DESCRIPTION
## Description

When you are using arguments values from `listner`  in `useScaffoldEventSubsciber` and if the `deployedContract = null` it gives the error : 
![Screenshot 2023-06-16 at 9 23 20 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/857905b6-3762-428e-9433-f58bad77f659)

Similar to other hooks it should resolve to `any` when `deployedContract = null`  

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: shivbhonde.eth
