### PR TITLE
update writeAsync to take in updated args while calling it

### DIFF
--- a/packages/nextjs/components/example-ui/ContractInteraction.tsx
+++ b/packages/nextjs/components/example-ui/ContractInteraction.tsx
@@ -66,7 +66,7 @@ export const ContractInteraction = () => {
                   className={`btn btn-primary rounded-full capitalize font-normal font-white w-24 flex items-center gap-1 hover:gap-2 transition-all tracking-widest ${
                     isLoading ? "loading" : ""
                   }`}
-                  onClick={writeAsync}
+                  onClick={() => writeAsync()}
                 >
                   {!isLoading && (
                     <>


### PR DESCRIPTION
## Description

Sometimes there is a situation where you need to calculate some stuff just before calling `writeAsync` and currently I think there is no way to pass that calculated value as args  before calling the function (are there any good ways of doing this ?)

Current non-working example : 
```javascript
const [uploadedItemHash, setUploadedItemHash] = useState("")

const { writeAsync: mintItem } = useScaffoldContractWrite({
  ...,
  args : [connectedAddress,uploadedItemHash] 
  // here the args are not updated while calling the writeAsync
});
  
const handleMintItem = async () => {
  const uploadedItem = await ipfsClient.add(JSON.stringify(currentTokenMetaData));
  setUploadedItemHash(uploadedItem.path)
  await mintItem();
 }  
```


New Working example : 
```javascript

const { writeAsync: mintItem } = useScaffoldContractWrite({...});
  
const handleMintItem = async () => {
  const uploadedItem = await ipfsClient.add(JSON.stringify(currentTokenMetaData));
  await mintItem({
    args: [connectedAddress, uploadedItem.path],
  });
};

```


## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


Your ENS/address: shivbhonde.eth
