### PR TITLE
Preinstalled openzeppelin remapping configs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,6 @@
 	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/forge-std"]
 	branch = v1.5.5
+[submodule "packages/foundry/lib/openzeppelin-contracts"]
+	path = packages/foundry/lib/openzeppelin-contracts
+	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/packages/foundry/remappings.txt
+++ b/packages/foundry/remappings.txt
@@ -1,0 +1,4 @@
+ds-test/=lib/forge-std/lib/ds-test/src/
+erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/
+forge-std/=lib/forge-std/src/
+openzeppelin/=lib/openzeppelin-contracts/contracts/

--- a/packages/foundry/src/YourContract.sol
+++ b/packages/foundry/src/YourContract.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import "forge-std/console.sol";
 
 // Use openzeppelin to inherit battle-tested implementations (ERC20, ERC721, etc)
-// import "@openzeppelin/contracts/access/Ownable.sol";
+// import "openzeppelin/access/Ownable.sol";
 
 /**
  * A smart contract that allows changing a state variable of the contract and tracking the changes

--- a/packages/foundry/test/YourContract.t.sol
+++ b/packages/foundry/test/YourContract.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../src/YourContract.sol";
-
+import "openzeppelin/token/ERc20/ERC20.sol";
 contract YourContractTest is Test {
     YourContract public yourContract;
 

--- a/packages/foundry/test/YourContract.t.sol
+++ b/packages/foundry/test/YourContract.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../src/YourContract.sol";
-import "openzeppelin/token/ERc20/ERC20.sol";
+import "openzeppelin/token/ERC20/ERC20.sol";
 contract YourContractTest is Test {
     YourContract public yourContract;
 


### PR DESCRIPTION
## Description

Programmers who are new to the  foundry ecosystem often get stuck where they. can't import openzeppelin libraries due to remapping errors. This PR is to enhance their experience by pre-configuring it for them.
## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)



Your ENS/address:
[supernovahs.eth](https://etherscan.io/address/0x1b37B1EC6B7faaCbB9AddCCA4043824F36Fb88D8)