### PR TITLE
Change scaffoldEthDark secondary color from #2A3655 to #323f61

### DIFF
--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -36,7 +36,7 @@ module.exports = {
         scaffoldEthDark: {
           primary: "#212638",
           "primary-content": "#F9FBFF",
-          secondary: "#2A3655",
+          secondary: "#323f61",
           "secondary-content": "#F9FBFF",
           accent: "#4969A6",
           "accent-content": "#F9FBFF",


### PR DESCRIPTION

## Description

This pull request changes the scaffoldEthDark secondary color from #2A3655 to #323f61.
Please refer to this issue for more information about the problem: [https://github.com/scaffold-eth/scaffold-eth-2/issues/397](url)

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{397}_

Your ENS/address: portdev.eth
