### PR TITLE
Resolve Foundry 'yarn deploy' and 'yarn deploy:verify' module not found error

### DIFF
--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -7,8 +7,8 @@
     "fork": "anvil --fork-url ${0:-mainnet} --config-out localhost.json",
     "compile": "forge compile",
     "generate": "node script/generateAccount.ts",
-    "deploy": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${0:-default_network} --broadcast && node script/generateTsAbis.ts",
-    "deploy:verify": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${0:-default_network} --broadcast --verify && node script/generateTsAbis.ts",
+    "deploy": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${0:-default_network} --broadcast && node script/generateTsAbis.js",
+    "deploy:verify": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${0:-default_network} --broadcast --verify && node script/generateTsAbis.js",
     "lint": "forge fmt",
     "test": "forge test"
   },


### PR DESCRIPTION
Resolve Foundry 'yarn deploy' and 'yarn deploy:verify' module not found error

## Description

In packages/foundry/package.json
Change the script name from 'generateTsAbis.ts' (.typescript) to 'generateTsAbis.js' (.javascript)

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

- See Discussion here: https://github.com/scaffold-eth/scaffold-eth-2/issues/394#issuecomment-1618272065