### PR TITLE
Added environment variable to Postgres container causing graph-node t…

### DIFF
--- a/packages/subgraph/graph-node/docker-compose.yml
+++ b/packages/subgraph/graph-node/docker-compose.yml
@@ -40,5 +40,6 @@ services:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in
       POSTGRES_DB: graph-node
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
Please see [bug: Subgraph docker-compose error · Issue #387 · scaffold-eth/scaffold-eth-2](https://github.com/scaffold-eth/scaffold-eth-2/issues/387)

## Description

graph-node container within docker-compose crashes

## Additional Information

- [X ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

[bug: Subgraph docker-compose error · Issue #387 · scaffold-eth/scaffold-eth-2](https://github.com/scaffold-eth/scaffold-eth-2/issues/387)

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:

dentropy.eth
