### PR TITLE
Gitignore subgraph package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 .eslintcache
 .vscode/**
 .DS_Store
+packages/subgraph/graph-node/data/

--- a/packages/subgraph/graph-node/docker-compose.yml
+++ b/packages/subgraph/graph-node/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3"
 services:
+  anvil:
+    image: ghcr.io/foundry-rs/foundry
+    entrypoint: '/usr/local/bin/anvil --block-time 5 --host 0.0.0.0'
+    ports:
+      - "8545:8545"
   graph-node:
     image: graphprotocol/graph-node:latest
     ports:
@@ -17,7 +22,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: "ipfs:5001"
-      ethereum: "localhost:http://host.docker.internal:8545"
+      ethereum: "localhost:http://anvil:8545"
       GRAPH_LOG: info
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## Description

The follwing is annoying, espically when you run `git add .` in the right directory 
``` bash
➜  scaffold-eth-2 git:(gitignore-subgraph-package) ✗ git status
warning: could not open directory 'packages/subgraph/graph-node/data/postgres/': Permission denied
On branch gitignore-subgraph-package
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        packages/subgraph/graph-node/data/

nothing added to commit but untracked files present (use "git add" to track)
➜  scaffold-eth-2 git:(gitignore-subgraph-package) ✗ 
```

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

[Closes Discussion #388](https://github.com/scaffold-eth/scaffold-eth-2/discussions/388)

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:

dentropy.eth
