### PR TITLE
Fix/solidity formatting

### DIFF
--- a/packages/hardhat/.prettierrc.json
+++ b/packages/hardhat/.prettierrc.json
@@ -1,6 +1,19 @@
 {
-    "arrowParens": "avoid",
-    "printWidth": 120,
-    "tabWidth": 2,
-    "trailingComma": "all"
-  }
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "printWidth": 80,
+        "tabWidth": 4,
+        "useTabs": true,
+        "singleQuote": false,
+        "bracketSpacing": true,
+        "explicitTypes": "always"
+      }
+    }
+  ]
+}

--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0 <0.9.0;
 
 // Useful for debugging. Remove when deploying to a live network.
 import "hardhat/console.sol";
+
 // Use openzeppelin to inherit battle-tested implementations (ERC20, ERC721, etc)
 // import "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -12,67 +13,75 @@ import "hardhat/console.sol";
  * @author BuidlGuidl
  */
 contract YourContract {
+	// State Variables
+	address public immutable owner;
+	string public greeting = "Building Unstoppable Apps!!!";
+	bool public premium = false;
+	uint256 public totalCounter = 0;
+	mapping(address => uint) public userGreetingCounter;
 
-    // State Variables
-    address public immutable owner;
-    string public greeting = "Building Unstoppable Apps!!!";
-    bool public premium = false;
-    uint256 public totalCounter = 0;
-    mapping(address => uint) public userGreetingCounter;
+	// Events: a way to emit log statements from smart contract that can be listened to by external parties
+	event GreetingChange(
+		address indexed greetingSetter,
+		string newGreeting,
+		bool premium,
+		uint256 value
+	);
 
-    // Events: a way to emit log statements from smart contract that can be listened to by external parties
-    event GreetingChange(address indexed greetingSetter, string newGreeting, bool premium, uint256 value);
+	// Constructor: Called once on contract deployment
+	// Check packages/hardhat/deploy/00_deploy_your_contract.ts
+	constructor(address _owner) {
+		owner = _owner;
+	}
 
-    // Constructor: Called once on contract deployment
-    // Check packages/hardhat/deploy/00_deploy_your_contract.ts
-    constructor(address _owner) {
-        owner = _owner;
-    }
+	// Modifier: used to define a set of rules that must be met before or after a function is executed
+	// Check the withdraw() function
+	modifier isOwner() {
+		// msg.sender: predefined variable that represents address of the account that called the current function
+		require(msg.sender == owner, "Not the Owner");
+		_;
+	}
 
-    // Modifier: used to define a set of rules that must be met before or after a function is executed
-    // Check the withdraw() function
-    modifier isOwner() {
-        // msg.sender: predefined variable that represents address of the account that called the current function
-        require(msg.sender == owner, "Not the Owner");
-        _;
-    }
+	/**
+	 * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
+	 *
+	 * @param _newGreeting (string memory) - new greeting to save on the contract
+	 */
+	function setGreeting(string memory _newGreeting) public payable {
+		// Print data to the hardhat chain console. Remove when deploying to a live network.
+		console.log(
+			"Setting new greeting '%s' from %s",
+			_newGreeting,
+			msg.sender
+		);
 
-    /**
-     * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
-     *
-     * @param _newGreeting (string memory) - new greeting to save on the contract
-     */
-    function setGreeting(string memory _newGreeting) public payable {
-        // Print data to the hardhat chain console. Remove when deploying to a live network.
-        console.log("Setting new greeting '%s' from %s",  _newGreeting, msg.sender);
+		// Change state variables
+		greeting = _newGreeting;
+		totalCounter += 1;
+		userGreetingCounter[msg.sender] += 1;
 
-        // Change state variables
-        greeting = _newGreeting;
-        totalCounter += 1;
-        userGreetingCounter[msg.sender] += 1;
+		// msg.value: built-in global variable that represents the amount of ether sent with the transaction
+		if (msg.value > 0) {
+			premium = true;
+		} else {
+			premium = false;
+		}
 
-        // msg.value: built-in global variable that represents the amount of ether sent with the transaction
-        if (msg.value > 0) {
-            premium = true;
-        } else {
-            premium = false;
-        }
+		// emit: keyword used to trigger an event
+		emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
+	}
 
-        // emit: keyword used to trigger an event
-        emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
-    }
+	/**
+	 * Function that allows the owner to withdraw all the Ether in the contract
+	 * The function can only be called by the owner of the contract as defined by the isOwner modifier
+	 */
+	function withdraw() public isOwner {
+		(bool success, ) = owner.call{ value: address(this).balance }("");
+		require(success, "Failed to send Ether");
+	}
 
-    /**
-     * Function that allows the owner to withdraw all the Ether in the contract
-     * The function can only be called by the owner of the contract as defined by the isOwner modifier
-     */
-    function withdraw() isOwner public {
-        (bool success,) = owner.call{value: address(this).balance}("");
-        require(success, "Failed to send Ether");
-    }
-
-    /**
-     * Function that allows the contract to receive ETH
-     */
-    receive() external payable {}
+	/**
+	 * Function that allows the contract to receive ETH
+	 */
+	receive() external payable {}
 }


### PR DESCRIPTION
## Description

This PR changes the packages/hardhat/.prettierrc.json file from:
`{
    "arrowParens": "avoid",
    "printWidth": 120,
    "tabWidth": 2,
    "trailingComma": "all"
  }
`
to
`{
  "arrowParens": "avoid",
  "printWidth": 120,
  "tabWidth": 2,
  "trailingComma": "all",
  "overrides": [
    {
      "files": "*.sol",
      "options": {
        "printWidth": 80,
        "tabWidth": 4,
        "useTabs": true,
        "singleQuote": false,
        "bracketSpacing": true,
        "explicitTypes": "always"
      }
    }
  ]
}
`
, adding the default configuration used by prettier-plugin-solidity [https://github.com/prettier-solidity/prettier-plugin-solidity](url)
It also formats the default contract YourContract.sol with the new settings.
More information can be found in issue #401 

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes  #401 


Your ENS/address: portdev.eth

I am open to any criticism/feedback.


