### PR TITLE
fix: type issues when multiple contracts deployed

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { AbiEvent, ExtractAbiEventNames } from "abitype";
+import { Abi, AbiEvent, ExtractAbiEventNames } from "abitype";
 import { Hash } from "viem";
 import { usePublicClient } from "wagmi";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
@@ -42,7 +42,7 @@ export const useScaffoldEventHistory = <
           throw new Error("Contract not found");
         }
 
-        const event = deployedContractData.abi.find(
+        const event = (deployedContractData.abi as Abi).find(
           part => part.type === "event" && part.name === eventName,
         ) as AbiEvent;
 

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
@@ -1,4 +1,4 @@
-import { ExtractAbiEventNames } from "abitype";
+import { Abi, ExtractAbiEventNames } from "abitype";
 import { Log } from "viem";
 import { useContractEvent } from "wagmi";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
@@ -24,7 +24,7 @@ export const useScaffoldEventSubscriber = <
 
   return useContractEvent({
     address: deployedContractData?.address,
-    abi: deployedContractData?.abi,
+    abi: deployedContractData?.abi as Abi,
     chainId: getTargetNetwork().id,
     listener: listener as (logs: Log[]) => void,
     eventName,


### PR DESCRIPTION
## Description

Typescript has issues to infer the type of the `part` variable in the `find` call because the array is `readonly [...] | readonly [...]`. Since we don't depend on the actual inferred type in this internal hook, we can just assert the abi to it's general `Abi` type.

The other type issue in `eventSubscriber` is similar. Typescript can't infer which of the two abis is to be used in the `useContractEvent` call, and thus doesn't understand that the `eventName` should always be valid. It's possible that a more complex method exists to make typescript infer a more narrow abi, but since it's just internals and is passed down to `useContractEvent`, I think the proposed fix more than suffices. The types that are exposed (param and return type) work fine, so shouldn't really be of concern to the users of the `useScaffoldEventSubscriber` hook) 

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Fixes #409 

Your ENS/address: solidixen.eth
