### PR TITLE
Fix bug with findFilesRecursiveSync

### DIFF
--- a/src/tasks/copy-template-files.ts
+++ b/src/tasks/copy-template-files.ts
@@ -36,7 +36,7 @@ const copyExtensionsFiles = async (
   { extensions }: Options,
   targetDir: string
 ) => {
-  extensions.forEach(async (extension) => {
+  await Promise.all(extensions.map(async (extension) => {
     const extensionPath = extensionDict[extension].path;
     // copy root files
     await copy(extensionPath, path.join(targetDir), {
@@ -89,7 +89,7 @@ const copyExtensionsFiles = async (
         );
       });
     }
-  });
+  }));
 };
 
 const processTemplatedFiles = async (


### PR DESCRIPTION
## Description
Fix a bug that made `copyExtensionsFiles` work async, so when later code tried to access extension files, they weren't there yet. That caused a bug with `findFilesRecursiveSync`, where files that should've been found weren't returned.