### PR TITLE
lock the version of viem and wagmi

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -30,8 +30,8 @@
     "react-hot-toast": "^2.4.0",
     "use-debounce": "^8.0.4",
     "usehooks-ts": "^2.7.2",
-    "viem": "^1.2.1",
-    "wagmi": "^1.3.2",
+    "viem": "1.2.1",
+    "wagmi": "1.3.2",
     "zustand": "^4.1.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,8 +1828,8 @@ __metadata:
     use-debounce: ^8.0.4
     usehooks-ts: ^2.7.2
     vercel: ^28.15.1
-    viem: ^1.2.1
-    wagmi: ^1.3.2
+    viem: 1.2.1
+    wagmi: 1.3.2
     zustand: ^4.1.2
   languageName: unknown
   linkType: soft
@@ -13375,7 +13375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:^1.0.0, viem@npm:^1.2.1":
+"viem@npm:1.2.1, viem@npm:^1.0.0":
   version: 1.2.1
   resolution: "viem@npm:1.2.1"
   dependencies:
@@ -13394,7 +13394,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wagmi@npm:^1.3.2":
+"wagmi@npm:1.3.2":
   version: 1.3.2
   resolution: "wagmi@npm:1.3.2"
   dependencies:


### PR DESCRIPTION
## Description

Locked the version of `viem` and `wagmi` is obviously not the best solution 

I have also raised the issue on https://github.com/wagmi-dev/wagmi/issues/2736

Maybe we can also wait until they fix it....just wanted to reference this fix for #419 if anyone gets stuck 🙌
