### PR TITLE
fix: moved disabled to commonInputProps

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -11,7 +11,7 @@ const isENS = (address = "") => address.endsWith(".eth") || address.endsWith(".x
 /**
  * Address input with ENS name resolution
  */
-export const AddressInput = ({ value, name, placeholder, onChange }: CommonInputProps<Address | string>) => {
+export const AddressInput = ({ value, name, placeholder, onChange, disabled }: CommonInputProps<Address | string>) => {
   const { data: ensAddress, isLoading: isEnsAddressLoading } = useEnsAddress({
     name: value,
     enabled: isENS(value),
@@ -58,7 +58,7 @@ export const AddressInput = ({ value, name, placeholder, onChange }: CommonInput
       error={ensAddress === null}
       value={value}
       onChange={handleChange}
-      disabled={isEnsAddressLoading || isEnsNameLoading}
+      disabled={isEnsAddressLoading || isEnsNameLoading || disabled}
       prefix={
         ensName && (
           <div className="flex bg-base-300 rounded-l-full items-center">

--- a/packages/nextjs/components/scaffold-eth/Input/Bytes32Input.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/Bytes32Input.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { hexToString, isHex, stringToHex } from "viem";
 import { CommonInputProps, InputBase } from "~~/components/scaffold-eth";
 
-export const Bytes32Input = ({ value, onChange, name, placeholder }: CommonInputProps) => {
+export const Bytes32Input = ({ value, onChange, name, placeholder, disabled }: CommonInputProps) => {
   const convertStringToBytes32 = useCallback(() => {
     if (!value) {
       return;
@@ -16,6 +16,7 @@ export const Bytes32Input = ({ value, onChange, name, placeholder }: CommonInput
       value={value}
       placeholder={placeholder}
       onChange={onChange}
+      disabled={disabled}
       suffix={
         <div
           className="self-center cursor-pointer text-xl font-semibold px-4 text-accent"

--- a/packages/nextjs/components/scaffold-eth/Input/BytesInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/BytesInput.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { bytesToString, isHex, toBytes, toHex } from "viem";
 import { CommonInputProps, InputBase } from "~~/components/scaffold-eth";
 
-export const BytesInput = ({ value, onChange, name, placeholder }: CommonInputProps) => {
+export const BytesInput = ({ value, onChange, name, placeholder, disabled }: CommonInputProps) => {
   const convertStringToBytes = useCallback(() => {
     onChange(isHex(value) ? bytesToString(toBytes(value)) : toHex(toBytes(value)));
   }, [onChange, value]);
@@ -13,6 +13,7 @@ export const BytesInput = ({ value, onChange, name, placeholder }: CommonInputPr
       value={value}
       placeholder={placeholder}
       onChange={onChange}
+      disabled={disabled}
       suffix={
         <div
           className="self-center cursor-pointer text-xl font-semibold px-4 text-accent"

--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -43,7 +43,7 @@ function displayValueToEtherValue(usdMode: boolean, displayValue: string, native
  *
  * onChange will always be called with the value in ETH
  */
-export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputProps) => {
+export const EtherInput = ({ value, name, placeholder, onChange, disabled }: CommonInputProps) => {
   const [transitoryDisplayValue, setTransitoryDisplayValue] = useState<string>();
   const nativeCurrencyPrice = useGlobalState(state => state.nativeCurrencyPrice);
   const [usdMode, setUSDMode] = useState(false);
@@ -96,6 +96,7 @@ export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputPr
       value={displayValue}
       placeholder={placeholder}
       onChange={handleChangeNumber}
+      disabled={disabled}
       prefix={<span className="pl-4 -mr-2 text-accent self-center">{usdMode ? "$" : "Ξ"}</span>}
       suffix={
         <button

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -3,7 +3,6 @@ import { CommonInputProps } from "~~/components/scaffold-eth";
 
 type InputBaseProps<T> = CommonInputProps<T> & {
   error?: boolean;
-  disabled?: boolean;
   prefix?: ReactNode;
   suffix?: ReactNode;
 };

--- a/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
@@ -10,6 +10,7 @@ export const IntegerInput = ({
   onChange,
   name,
   placeholder,
+  disabled,
   variant = IntegerVariant.UINT256,
 }: IntegerInputProps) => {
   const [inputError, setInputError] = useState(false);
@@ -38,13 +39,18 @@ export const IntegerInput = ({
       placeholder={placeholder}
       error={inputError}
       onChange={onChange}
+      disabled={disabled}
       suffix={
         !inputError && (
           <div
             className="space-x-4 flex tooltip tooltip-top tooltip-secondary before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
             data-tip="Multiply by 10^18 (wei)"
           >
-            <button className="cursor-pointer font-semibold px-4 text-accent" onClick={multiplyBy1e18}>
+            <button
+              className={`${disabled ? "cursor-not-allowed" : "cursor-pointer"} font-semibold px-4 text-accent`}
+              onClick={multiplyBy1e18}
+              disabled={disabled}
+            >
               ∗
             </button>
           </div>

--- a/packages/nextjs/components/scaffold-eth/Input/utils.ts
+++ b/packages/nextjs/components/scaffold-eth/Input/utils.ts
@@ -3,6 +3,7 @@ export interface CommonInputProps<T = string> {
   onChange: (newValue: T) => void;
   name?: string;
   placeholder?: string;
+  disabled?: boolean;
 }
 
 export enum IntegerVariant {


### PR DESCRIPTION
## Description

Moves `disabled` prop to `CommonInputProps`, so it becomes possible to disable all inputs,  not only `InputBase`

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: 0xrinat
