### PR TITLE
Add .env.example for nextjs env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ The configuration parameters are described below, make sure to update the values
 
 - **alchemyApiKey**  
   Default Alchemy API key from Scaffold ETH 2 for local testing purposes.  
-  It's recommended to obtain your own API key from the [Alchemy Dashboard](https://dashboard.alchemyapi.io/) and store it in an environment variable: `NEXT_PUBLIC_ALCHEMY_API_KEY` at `\packages\nextjs\.env` file.
+  It's recommended to obtain your own API key from the [Alchemy Dashboard](https://dashboard.alchemyapi.io/) and store it in an environment variable: `NEXT_PUBLIC_ALCHEMY_API_KEY` at `\packages\nextjs\.env.local` file.
 
 - **walletConnectProjectId**  
   WalletConnect's default project ID from Scaffold ETH 2 for local testing purposes.
-  It's recommended to obtain your own project ID from the [WalletConnect website](https://cloud.walletconnect.com) and store it in an environment variable: `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` at `\packages\nextjs\.env` file.
+  It's recommended to obtain your own project ID from the [WalletConnect website](https://cloud.walletconnect.com) and store it in an environment variable: `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` at `\packages\nextjs\.env.local` file.
 
 - **onlyLocalBurnerWallet**  
   Controls the networks where the Burner Wallet feature is available. This feature provides a lightweight wallet for users.

--- a/packages/hardhat/.env.example
+++ b/packages/hardhat/.env.example
@@ -1,7 +1,10 @@
-# This is a template for the environment variables
-# To use this template, copy this file, rename it .env, and fill in the values
+# Template for Hardhat environment variables.
 
-# Default values are stored in `packages/hardhat/hardhat.config.ts`, so developers can start hacking and prototyping without worrying about their API Keys, but we recommend getting your own API Keys for Production-Grade Apps
+# To use this template, copy this file, rename it .env, and fill in the values.
+
+# If not set, we provide default values (check `hardhat.config.ts`) so developers can start prototyping out of the box,
+# but we recommend getting your own API Keys for Production Apps.
+
 # To access the values stored in this .env file you can use: process.env.VARIABLENAME
 ALCHEMY_API_KEY=
 DEPLOYER_PRIVATE_KEY=

--- a/packages/hardhat/.env.example
+++ b/packages/hardhat/.env.example
@@ -1,5 +1,8 @@
 # This is a template for the environment variables
 # To use this template, copy this file, rename it .env, and fill in the values
+
+# Default values are stored in `packages/hardhat/hardhat.config.ts`, so developers can start hacking and prototyping without worrying about their API Keys, but we recommend getting your own API Keys for Production-Grade Apps
+# To access the values stored in this .env file you can use: process.env.VARIABLENAME
 ALCHEMY_API_KEY=
 DEPLOYER_PRIVATE_KEY=
 ETHERSCAN_API_KEY=

--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -1,0 +1,8 @@
+# This is a template for the nextjs environment variables
+# To use this template, copy this file, rename it .env.local, and fill in the values
+# It's recommended to store env's for nextjs in Vercel/system env config for live apps and use .env.local for local testing.
+
+# Default values are stored in `packages/nextjs/scaffold.config.ts`, so developers can start hacking and prototyping without worrying about their API Keys, but we recommend getting your own API Keys for Production-Grade Apps
+# To access the values stored in this .env file you can use: process.env.VARIABLENAME
+NEXT_PUBLIC_ALCHEMY_API_KEY=
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=

--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -1,8 +1,13 @@
-# This is a template for the nextjs environment variables
-# To use this template, copy this file, rename it .env.local, and fill in the values
-# It's recommended to store env's for nextjs in Vercel/system env config for live apps and use .env.local for local testing.
+# Template for NextJS environment variables.
 
-# Default values are stored in `packages/nextjs/scaffold.config.ts`, so developers can start hacking and prototyping without worrying about their API Keys, but we recommend getting your own API Keys for Production-Grade Apps
-# To access the values stored in this .env file you can use: process.env.VARIABLENAME
+# For local development, copy this file, rename it to .env.local, and fill in the values.
+# When deploying live, you'll need to store the vars in Vercel/System config.
+
+# If not set, we provide default values (check `scaffold.config.ts`) so developers can start prototyping out of the box,
+# but we recommend getting your own API Keys for Production Apps.
+
+# To access the values stored in this env file you can use: process.env.VARIABLENAME
+# You'll need to prefix the variables names with NEXT_PUBLIC_ if you want to access them on the client side.
+# More info: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
 NEXT_PUBLIC_ALCHEMY_API_KEY=
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=


### PR DESCRIPTION
## Description

This PR adds .env.example file for nextjs environment variables, like we already have for hardhat.

Also adds some extra information on how we are managing API Keys in config/env files in both hardhat and nextjs .env.example files, so users can have a better understanding.

## Additional Information

- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: pabl0cks.eth