### PR TITLE
Add address qrcode to rainbowkit custom connect button

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -86,7 +86,11 @@ export const RainbowKitCustomConnectButton = () => {
                     </label>
                     <ul tabIndex={0} className="dropdown-content menu p-2 mt-1 shadow-lg bg-base-100 rounded-box">
                       <li className="items-center">
-                        <QRCodeSVG value={account.address} size={180} className="p-1 !rounded-none cursor-default" />
+                        <QRCodeSVG
+                          value={account.address}
+                          size={180}
+                          className="p-1 !rounded-none cursor-default bg-inherit"
+                        />
                       </li>
                       <li>
                         {addressCopied ? (

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -23,9 +23,6 @@ export const RainbowKitCustomConnectButton = () => {
   const { disconnect } = useDisconnect();
   const { switchNetwork } = useSwitchNetwork();
   const [addressCopied, setAddressCopied] = useState(false);
-  const [qrSize, setQrSize] = useState(100); // Add this state
-
-  const toggleQrSize = () => setQrSize(qrSize === 100 ? 150 : 100);
 
   return (
     <ConnectButton.Custom>
@@ -91,14 +88,13 @@ export const RainbowKitCustomConnectButton = () => {
                       <li className="items-center">
                         <QRCodeSVG
                           value={account.address}
-                          size={qrSize}
+                          size={100}
                           bgColor={"#ffffff"}
                           fgColor={"#000000"}
                           level={"L"}
                           includeMargin={false}
                           style={{ borderRadius: "0px" }} // forcefully remove border radius
                           className="p-1"
-                          onClick={toggleQrSize}
                         />
                       </li>
                       <li>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -86,16 +86,7 @@ export const RainbowKitCustomConnectButton = () => {
                     </label>
                     <ul tabIndex={0} className="dropdown-content menu p-2 mt-1 shadow-lg bg-base-100 rounded-box">
                       <li className="items-center">
-                        <QRCodeSVG
-                          value={account.address}
-                          size={180}
-                          bgColor={"#ffffff"}
-                          fgColor={"#000000"}
-                          level={"L"}
-                          includeMargin={false}
-                          style={{ borderRadius: "0px" }} // forcefully remove border radius
-                          className="p-1"
-                        />
+                        <QRCodeSVG value={account.address} size={180} className="p-1 !rounded-none cursor-default" />
                       </li>
                       <li>
                         {addressCopied ? (

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -88,7 +88,7 @@ export const RainbowKitCustomConnectButton = () => {
                       <li className="items-center">
                         <QRCodeSVG
                           value={account.address}
-                          size={100}
+                          size={180}
                           bgColor={"#ffffff"}
                           fgColor={"#000000"}
                           level={"L"}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -1,6 +1,14 @@
+import { useState } from "react";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { QRCodeSVG } from "qrcode.react";
+import CopyToClipboard from "react-copy-to-clipboard";
 import { useDisconnect, useSwitchNetwork } from "wagmi";
-import { ArrowLeftOnRectangleIcon, ArrowsRightLeftIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+import {
+  ArrowLeftOnRectangleIcon,
+  ArrowsRightLeftIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+} from "@heroicons/react/24/solid";
 import { Balance, BlockieAvatar } from "~~/components/scaffold-eth";
 import { useNetworkColor } from "~~/hooks/scaffold-eth";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
@@ -13,10 +21,11 @@ export const RainbowKitCustomConnectButton = () => {
   const configuredNetwork = getTargetNetwork();
   const { disconnect } = useDisconnect();
   const { switchNetwork } = useSwitchNetwork();
+  const [addressCopied, setAddressCopied] = useState(false);
 
   return (
     <ConnectButton.Custom>
-      {({ account, chain, openAccountModal, openConnectModal, mounted }) => {
+      {({ account, chain, openConnectModal, mounted }) => {
         const connected = mounted && account && chain;
 
         return (
@@ -62,24 +71,58 @@ export const RainbowKitCustomConnectButton = () => {
 
               return (
                 <div className="px-2 flex justify-end items-center">
-                  <div className="flex justify-center items-center border-1 rounded-lg">
-                    <div className="flex flex-col items-center mr-1">
-                      <Balance address={account.address} className="min-h-0 h-auto" />
-                      <span className="text-xs" style={{ color: networkColor }}>
-                        {chain.name}
-                      </span>
-                    </div>
-                    <button
-                      onClick={openAccountModal}
-                      type="button"
-                      className="btn btn-secondary btn-sm pl-0 pr-2 shadow-md"
-                    >
+                  <div className="flex flex-col items-center mr-1">
+                    <Balance address={account.address} className="min-h-0 h-auto" />
+                    <span className="text-xs" style={{ color: networkColor }}>
+                      {chain.name}
+                    </span>
+                  </div>
+                  <div className="dropdown dropdown-end">
+                    <label tabIndex={0} className="btn btn-secondary btn-sm pl-0 pr-2 shadow-md dropdown-toggle">
                       <BlockieAvatar address={account.address} size={24} ensImage={account.ensAvatar} />
                       <span className="ml-2 mr-1">{account.displayName}</span>
-                      <span>
-                        <ChevronDownIcon className="h-6 w-4" />
-                      </span>
-                    </button>
+                      <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
+                    </label>
+                    <ul tabIndex={0} className="dropdown-content menu p-2 mt-1 shadow-lg bg-base-100 rounded-box">
+                      <li>
+                        <CopyToClipboard
+                          text={account.address}
+                          onCopy={() => {
+                            setAddressCopied(true);
+                            setTimeout(() => {
+                              setAddressCopied(false);
+                            }, 800);
+                          }}
+                        >
+                          <span>
+                            Copy Address
+                            {addressCopied && (
+                              <CheckCircleIcon
+                                className="ml-1.5 text-xl absolute right-1 font-normal text-sky-600 h-5 w-5 cursor-pointer"
+                                aria-hidden="true"
+                              />
+                            )}
+                          </span>
+                        </CopyToClipboard>
+                      </li>
+                      <li className="items-center">
+                        <QRCodeSVG
+                          value={account.address}
+                          size={100}
+                          bgColor={"#ffffff"}
+                          fgColor={"#000000"}
+                          level={"L"}
+                          includeMargin={false}
+                          style={{ borderRadius: "0px" }} // forcefully remove border radius
+                          className="p-1"
+                        />
+                      </li>
+                      <li>
+                        <button className="menu-item text-error" type="button" onClick={() => disconnect()}>
+                          <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
+                        </button>
+                      </li>
+                    </ul>
                   </div>
                 </div>
               );

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -8,6 +8,7 @@ import {
   ArrowsRightLeftIcon,
   CheckCircleIcon,
   ChevronDownIcon,
+  DocumentDuplicateIcon,
 } from "@heroicons/react/24/solid";
 import { Balance, BlockieAvatar } from "~~/components/scaffold-eth";
 import { useNetworkColor } from "~~/hooks/scaffold-eth";
@@ -84,27 +85,6 @@ export const RainbowKitCustomConnectButton = () => {
                       <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
                     </label>
                     <ul tabIndex={0} className="dropdown-content menu p-2 mt-1 shadow-lg bg-base-100 rounded-box">
-                      <li>
-                        <CopyToClipboard
-                          text={account.address}
-                          onCopy={() => {
-                            setAddressCopied(true);
-                            setTimeout(() => {
-                              setAddressCopied(false);
-                            }, 800);
-                          }}
-                        >
-                          <span>
-                            Copy Address
-                            {addressCopied && (
-                              <CheckCircleIcon
-                                className="ml-1.5 text-xl absolute right-1 font-normal text-sky-600 h-5 w-5 cursor-pointer"
-                                aria-hidden="true"
-                              />
-                            )}
-                          </span>
-                        </CopyToClipboard>
-                      </li>
                       <li className="items-center">
                         <QRCodeSVG
                           value={account.address}
@@ -116,6 +96,35 @@ export const RainbowKitCustomConnectButton = () => {
                           style={{ borderRadius: "0px" }} // forcefully remove border radius
                           className="p-1"
                         />
+                      </li>
+                      <li>
+                        {addressCopied ? (
+                          <div>
+                            <CheckCircleIcon
+                              className=" text-xl font-normal text-sky-600 h-6 w-4 cursor-pointer"
+                              aria-hidden="true"
+                            />
+                            <span className=" whitespace-nowrap">Copy address</span>
+                          </div>
+                        ) : (
+                          <CopyToClipboard
+                            text={account.address}
+                            onCopy={() => {
+                              setAddressCopied(true);
+                              setTimeout(() => {
+                                setAddressCopied(false);
+                              }, 800);
+                            }}
+                          >
+                            <div>
+                              <DocumentDuplicateIcon
+                                className=" text-xl font-normal text-sky-600 h-6 w-4 cursor-pointer"
+                                aria-hidden="true"
+                              />
+                              <span className=" whitespace-nowrap">Copy address</span>
+                            </div>
+                          </CopyToClipboard>
+                        )}
                       </li>
                       <li>
                         <button className="menu-item text-error" type="button" onClick={() => disconnect()}>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -23,6 +23,9 @@ export const RainbowKitCustomConnectButton = () => {
   const { disconnect } = useDisconnect();
   const { switchNetwork } = useSwitchNetwork();
   const [addressCopied, setAddressCopied] = useState(false);
+  const [qrSize, setQrSize] = useState(100); // Add this state
+
+  const toggleQrSize = () => setQrSize(qrSize === 100 ? 150 : 100);
 
   return (
     <ConnectButton.Custom>
@@ -88,13 +91,14 @@ export const RainbowKitCustomConnectButton = () => {
                       <li className="items-center">
                         <QRCodeSVG
                           value={account.address}
-                          size={100}
+                          size={qrSize}
                           bgColor={"#ffffff"}
                           fgColor={"#000000"}
                           level={"L"}
                           includeMargin={false}
                           style={{ borderRadius: "0px" }} // forcefully remove border radius
                           className="p-1"
+                          onClick={toggleQrSize}
                         />
                       </li>
                       <li>

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -22,6 +22,7 @@
     "daisyui": "^2.31.0",
     "next": "^13.1.6",
     "nextjs-progressbar": "^0.0.16",
+    "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
     "react-blockies": "^1.4.1",
     "react-copy-to-clipboard": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,6 +1817,7 @@ __metadata:
     nextjs-progressbar: ^0.0.16
     postcss: ^8.4.16
     prettier: ^2.8.4
+    qrcode.react: ^3.1.0
     react: ^18.2.0
     react-blockies: ^1.4.1
     react-copy-to-clipboard: ^5.1.0
@@ -10890,6 +10891,15 @@ __metadata:
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
   checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8
+  languageName: node
+  linkType: hard
+
+"qrcode.react@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "qrcode.react@npm:3.1.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 94a2942ecf83f461d869adb20305ae663c6d1abe93ef2c72442b07d756ce70cf6deb6fd588dc5b382b48c6991cfde1dfd5ac9b814c1461e71d5edb2d945e67fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR removes the popup when clicking the rainbowkit custom connect button and adds a dropdown instead.

Before:

https://github.com/scaffold-eth/scaffold-eth-2/assets/108868128/fa9feafd-9511-46db-9a34-461f67c89b0b



After: 

https://github.com/scaffold-eth/scaffold-eth-2/assets/108868128/fa2c0247-f3d5-432a-9a06-e9d648bcf4b9


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #237 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
