### PR TITLE
Create an alias for hardhat:test

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "hardhat:lint": "yarn workspace @se-2/hardhat lint",
     "hardhat:lint-staged": "yarn workspace @se-2/hardhat lint-staged",
     "hardhat:test": "yarn workspace @se-2/hardhat test",
+    "test": "yarn hardhat:test",
     "start": "yarn workspace @se-2/nextjs dev",
     "next:lint": "yarn workspace @se-2/nextjs lint",
     "next:format": "yarn workspace @se-2/nextjs format",


### PR DESCRIPTION
This is one of the historical commands, and I think it should be there. Instead of calling the command on packages/hardhat, I'm calling `hardhat:test` so it becomes clear that it's an alias.

This could become `hardhat:test && nextjs:test` in the future... an alias to run both test suites (if we do some https://github.com/Synthetixio/synpress testing in the frontend at some point)

Also, I can't handle the pressure of @austintgriffith calling me at 3am for this (jk jk <3)

**Note:** If you all are ok with this, we should also do it in the cli branch (for hardhat / foundry)