### PR TITLE
fix empty debug page  when mismatch in localStorage and contractName

### DIFF
--- a/packages/nextjs/pages/debug.tsx
+++ b/packages/nextjs/pages/debug.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import type { NextPage } from "next";
 import { useLocalStorage } from "usehooks-ts";
 import { MetaHeader } from "~~/components/MetaHeader";
@@ -6,13 +7,19 @@ import { ContractName } from "~~/utils/scaffold-eth/contract";
 import { getContractNames } from "~~/utils/scaffold-eth/contractNames";
 
 const selectedContractStorageKey = "scaffoldEth2.selectedContract";
+const contractNames = getContractNames();
 
 const Debug: NextPage = () => {
-  const contractNames = getContractNames();
   const [selectedContract, setSelectedContract] = useLocalStorage<ContractName>(
     selectedContractStorageKey,
     contractNames[0],
   );
+
+  useEffect(() => {
+    if (!contractNames.includes(selectedContract)) {
+      setSelectedContract(contractNames[0]);
+    }
+  }, [selectedContract, setSelectedContract]);
 
   return (
     <>


### PR DESCRIPTION
## Description

![Screenshot 2023-07-26 at 2 15 22 AM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/ac21c9eb-ad23-42f2-aab6-c0bf48c16ad4)

We get a blank debug page, this happens when there is a value in localStorage that does not match any of newly deployed contractNames 

### Solution : 
Added a `useEffect` which checks if the current localStorage value is present in `contractNames`array and returns 0th contractName if it doesn't find any match