### PR TITLE
use targetNetwork instead of hardcoding dir name in template root

### DIFF
--- a/templates/base/packages/nextjs/pages/blockexplorer/address/[address].tsx
+++ b/templates/base/packages/nextjs/pages/blockexplorer/address/[address].tsx
@@ -15,6 +15,7 @@ import {
 import { Address, Balance } from "~~/components/scaffold-eth";
 import deployedContracts from "~~/generated/deployedContracts";
 import { useFetchBlocks } from "~~/hooks/scaffold-eth";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 
 type AddressCodeTabProps = {
@@ -154,6 +155,7 @@ async function fetchByteCodeAndAssembly(buildInfoDirectory: string, contractPath
 }
 
 export const getServerSideProps: GetServerSideProps = async context => {
+  const configuredNetwork = getTargetNetwork();
   const address = (context.params?.address as string).toLowerCase();
   const contracts = deployedContracts as GenericContractsDeclaration | null;
   const chainId = hardhat.id;
@@ -167,8 +169,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
     "..",
     "..",
     "..",
-    "hardhat",
-    "artifacts",
+    `${configuredNetwork.network}`,
+    `${configuredNetwork.network === "hardhat" ? "artifacts" : "out"}`,
     "build-info",
   );
 


### PR DESCRIPTION
## Description

The UI breaks for `blockexplorer/[address]` in `foundry` extension since we have hardcoded `hardhat` in `[address].tsx` 

![Screenshot 2023-07-26 at 5 44 15 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/e0b5d178-c73c-442d-9031-a94186051f2a)


Should we add this to `main` and `foundry` branch too 🤔? 
