### PR TITLE
fix eth_accounts calls on localNetwork

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useIsMounted } from "usehooks-ts";
 import { Address as AddressType, createWalletClient, http, parseEther } from "viem";
 import { useNetwork } from "wagmi";
@@ -23,10 +23,15 @@ export const Faucet = () => {
   const { chain: ConnectedChain } = useNetwork();
   const isMounted = useIsMounted();
 
-  const localWalletClient = createWalletClient({
-    chain: hardhat,
-    transport: http(),
-  });
+  const localWalletClient = useMemo(
+    () =>
+      createWalletClient({
+        chain: hardhat,
+        transport: http(),
+      }),
+    [],
+  );
+
   const faucetTxn = useTransactor(localWalletClient);
 
   useEffect(() => {

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useIsMounted } from "usehooks-ts";
 import { Address as AddressType, createWalletClient, http, parseEther } from "viem";
 import { useNetwork } from "wagmi";
@@ -11,6 +11,11 @@ import { notification } from "~~/utils/scaffold-eth";
 // Account index to use from generated hardhat accounts.
 const FAUCET_ACCOUNT_INDEX = 0;
 
+const localWalletClient = createWalletClient({
+  chain: hardhat,
+  transport: http(),
+});
+
 /**
  * Faucet modal which lets you send ETH to any address.
  */
@@ -22,15 +27,6 @@ export const Faucet = () => {
 
   const { chain: ConnectedChain } = useNetwork();
   const isMounted = useIsMounted();
-
-  const localWalletClient = useMemo(
-    () =>
-      createWalletClient({
-        chain: hardhat,
-        transport: http(),
-      }),
-    [],
-  );
 
   const faucetTxn = useTransactor(localWalletClient);
 
@@ -56,7 +52,7 @@ export const Faucet = () => {
       }
     };
     getFaucetAddress();
-  }, [localWalletClient]);
+  }, []);
 
   const sendETH = async () => {
     if (!faucetAddress) {

--- a/packages/nextjs/components/scaffold-eth/FaucetButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/FaucetButton.tsx
@@ -10,6 +10,11 @@ import { useAccountBalance, useTransactor } from "~~/hooks/scaffold-eth";
 const NUM_OF_ETH = "1";
 const FAUCET_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
+const localWalletClient = createWalletClient({
+  chain: hardhat,
+  transport: http(),
+});
+
 /**
  * FaucetButton button which lets you grab eth.
  */
@@ -21,10 +26,7 @@ export const FaucetButton = () => {
   const isMounted = useIsMounted();
 
   const [loading, setLoading] = useState(false);
-  const localWalletClient = createWalletClient({
-    chain: hardhat,
-    transport: http(),
-  });
+
   const faucetTxn = useTransactor(localWalletClient);
 
   const sendETH = async () => {


### PR DESCRIPTION
## Description

Since we have `localWalletClient` as use effect dependency we get lot of `eth_accounts` because of this line : https://github.com/scaffold-eth/scaffold-eth-2/blob/6370b4c49440f4aab7eff6896b43d814d6d01650/packages/nextjs/components/scaffold-eth/Faucet.tsx#L35


You can easily notice lot of `eth_accounts` while using SE-2 through CLI but for some reason on `main` it sometimes doesn't happens directly and if you add `console.log("This is localWalletClient", localWalletClient)` below the above `permalink` it will start making `eth_accounts` (😅 even I am confused about this behavior on `main` but I noticed on it on main)


Nevertheless, I think it makes  sense not to pass objects as dependency to `useEffect` 

### Solution : 
Move `localWalletClient` outside of the component this we don't need to pass it as a dependency. 



JSON.stringify doesn't work because `uid` is changing in  `localWalletClient`

```
{"chain" :  ........... "uid":"0f45556b091"}
```



