### PR TITLE
New shadow-center utility class for dropdown/notifications

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -37,10 +37,13 @@ export const RainbowKitCustomConnectButton = () => {
                       <span>Wrong network</span>
                       <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
                     </label>
-                    <ul tabIndex={0} className="dropdown-content menu p-2 mt-1 shadow-lg bg-base-100 rounded-box">
+                    <ul
+                      tabIndex={0}
+                      className="dropdown-content menu p-2 mt-1 shadow-center shadow-accent bg-base-100 rounded-box gap-1"
+                    >
                       <li>
                         <button
-                          className="menu-item"
+                          className="menu-item btn-sm !rounded-xl"
                           type="button"
                           onClick={() => switchNetwork?.(configuredNetwork.id)}
                         >
@@ -51,7 +54,11 @@ export const RainbowKitCustomConnectButton = () => {
                         </button>
                       </li>
                       <li>
-                        <button className="menu-item text-error" type="button" onClick={() => disconnect()}>
+                        <button
+                          className="menu-item text-error btn-sm !rounded-xl"
+                          type="button"
+                          onClick={() => disconnect()}
+                        >
                           <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
                         </button>
                       </li>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -39,7 +39,7 @@ export const RainbowKitCustomConnectButton = () => {
                     </label>
                     <ul
                       tabIndex={0}
-                      className="dropdown-content menu p-2 mt-1 shadow-center shadow-accent bg-base-100 rounded-box gap-1"
+                      className="dropdown-content menu p-2 mt-1 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
                     >
                       <li>
                         <button

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -93,6 +93,9 @@ module.exports = {
       fontFamily: {
         "bai-jamjuree": ["Bai Jamjuree", "sans-serif"],
       },
+      boxShadow: {
+        center: "0 0 12px -2px rgb(0 0 0 / 0.05)",
+      },
       keyframes: {
         grow: {
           "0%": {

--- a/packages/nextjs/utils/scaffold-eth/notification.tsx
+++ b/packages/nextjs/utils/scaffold-eth/notification.tsx
@@ -49,7 +49,7 @@ const Notification = ({
   return toast.custom(
     t => (
       <div
-        className={`flex flex-row items-start justify-between max-w-sm rounded-md shadow-2xl hover:shadow-none bg-base-200 p-4 transform-gpu relative transition-all duration-500 ease-in-out space-x-2
+        className={`flex flex-row items-start justify-between max-w-sm rounded-xl shadow-center shadow-accent bg-base-200 p-4 transform-gpu relative transition-all duration-500 ease-in-out space-x-2
         ${
           position.substring(0, 3) == "top"
             ? `hover:translate-y-1 ${t.visible ? "top-0" : "-top-96"}`


### PR DESCRIPTION
Fixes #441 

I discussed several options with Andrea, to make the dropdown / notifications look better (they were mixing with the background).

We ended up adding a new shadow utility class `shadow-center` that combined with a `shadow-accent` (or `shadow-{primary|secondary|etc..}) gives a nice effect.

Notifications:
![Screenshot from 2023-07-27 12-23-25](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/910e3011-3cd8-45a7-a11d-3be758aada3e)

Dropdown menu: (Also made the dropdown menu items smaller and adjust the border radius (we can also apply this to #446))

![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/a87d4373-7cd3-45a2-8fc6-47e6d52c8165)

What do you all think?
