### PR TITLE
Fix/useAccount & some other hooks hydration issue 

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useIsMounted } from "usehooks-ts";
 import { Address as AddressType, createWalletClient, http, parseEther } from "viem";
 import { useNetwork } from "wagmi";
 import { hardhat } from "wagmi/chains";
@@ -26,7 +25,6 @@ export const Faucet = () => {
   const [sendValue, setSendValue] = useState("");
 
   const { chain: ConnectedChain } = useNetwork();
-  const isMounted = useIsMounted();
 
   const faucetTxn = useTransactor(localWalletClient);
 
@@ -78,7 +76,7 @@ export const Faucet = () => {
   };
 
   // Render only on local chain
-  if (ConnectedChain?.id !== hardhat.id || !isMounted()) {
+  if (ConnectedChain?.id !== hardhat.id) {
     return null;
   }
 

--- a/packages/nextjs/components/scaffold-eth/FaucetButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/FaucetButton.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useIsMounted } from "usehooks-ts";
 import { createWalletClient, http, parseEther } from "viem";
 import { useAccount, useNetwork } from "wagmi";
 import { hardhat } from "wagmi/chains";
@@ -23,7 +22,6 @@ export const FaucetButton = () => {
   const { balance } = useAccountBalance(address);
 
   const { chain: ConnectedChain } = useNetwork();
-  const isMounted = useIsMounted();
 
   const [loading, setLoading] = useState(false);
 
@@ -46,7 +44,7 @@ export const FaucetButton = () => {
   };
 
   // Render only on local chain
-  if (ConnectedChain?.id !== hardhat.id || !isMounted()) {
+  if (ConnectedChain?.id !== hardhat.id) {
     return null;
   }
 

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -13,13 +13,14 @@ import {
   QrCodeIcon,
 } from "@heroicons/react/24/outline";
 import { Address, Balance, BlockieAvatar } from "~~/components/scaffold-eth";
-import { useNetworkColor } from "~~/hooks/scaffold-eth";
+import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
 import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
 
 /**
  * Custom Wagmi Connect Button (watch balance + custom design)
  */
 export const RainbowKitCustomConnectButton = () => {
+  useAutoConnect();
   const networkColor = useNetworkColor();
   const configuredNetwork = getTargetNetwork();
   const { disconnect } = useDisconnect();

--- a/packages/nextjs/hooks/scaffold-eth/index.ts
+++ b/packages/nextjs/hooks/scaffold-eth/index.ts
@@ -13,3 +13,4 @@ export * from "./useScaffoldEventHistory";
 export * from "./useTransactor";
 export * from "./useFetchBlocks";
 export * from "./useContractLogs";
+export * from "./useAutoConnect";

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -6,7 +6,7 @@ import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletId, defaultBurnerChainId } from "~~/services/web3/wagmi-burner/BurnerConnector";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
-const walletIdStorageKey = "scaffoldEth2.wallet";
+const SCAFFOLD_WALLET_STROAGE_KEY = "scaffoldEth2.wallet";
 const WAGMI_WALLET_STORAGE_KEY = "wagmi.wallet";
 
 /**
@@ -49,7 +49,7 @@ const getInitialConnector = (
  */
 export const useAutoConnect = (): void => {
   const wagmiWalletValue = useReadLocalStorage<string>(WAGMI_WALLET_STORAGE_KEY);
-  const [walletId, setWalletId] = useLocalStorage<string>(walletIdStorageKey, wagmiWalletValue ?? "");
+  const [walletId, setWalletId] = useLocalStorage<string>(SCAFFOLD_WALLET_STROAGE_KEY, wagmiWalletValue ?? "");
   const connectState = useConnect();
   const accountState = useAccount();
 
@@ -59,7 +59,7 @@ export const useAutoConnect = (): void => {
       setWalletId(accountState.connector?.id ?? "");
     } else {
       // user has disconnected, reset walletName
-      window.localStorage.setItem(WAGMI_WALLET_STORAGE_KEY, "");
+      window.localStorage.setItem(WAGMI_WALLET_STORAGE_KEY, JSON.stringify(""));
       setWalletId("");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+import { useEffectOnce, useLocalStorage, useReadLocalStorage } from "usehooks-ts";
+import { Connector, useAccount, useConnect } from "wagmi";
+import { hardhat } from "wagmi/chains";
+import scaffoldConfig from "~~/scaffold.config";
+import { burnerWalletId, defaultBurnerChainId } from "~~/services/web3/wagmi-burner/BurnerConnector";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
+
+const walletIdStorageKey = "scaffoldEth2.wallet";
+const WAGMI_WALLET_STORAGE_KEY = "wagmi.wallet";
+
+/**
+ * This function will get the initial wallet connector (if any), the app will connect to
+ * @param previousWalletId
+ * @param connectors
+ * @returns
+ */
+const getInitialConnector = (
+  previousWalletId: string,
+  connectors: Connector[],
+): { connector: Connector | undefined; chainId?: number } | undefined => {
+  const targetNetwork = getTargetNetwork();
+
+  const allowBurner = scaffoldConfig.onlyLocalBurnerWallet ? targetNetwork.id === hardhat.id : true;
+
+  if (!previousWalletId) {
+    // The user was not connected to a wallet
+    if (allowBurner && scaffoldConfig.walletAutoConnect) {
+      const connector = connectors.find(f => f.id === burnerWalletId);
+      return { connector, chainId: defaultBurnerChainId };
+    }
+  } else {
+    // the user was connected to wallet
+    if (scaffoldConfig.walletAutoConnect) {
+      if (previousWalletId === burnerWalletId && !allowBurner) {
+        return;
+      }
+
+      const connector = connectors.find(f => f.id === previousWalletId);
+      return { connector };
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Automatically connect to a wallet/connector based on config and prior wallet
+ */
+export const useAutoConnect = (): void => {
+  const wagmiWalletValue = useReadLocalStorage<string>(WAGMI_WALLET_STORAGE_KEY);
+  const [walletId, setWalletId] = useLocalStorage<string>(walletIdStorageKey, wagmiWalletValue ?? "");
+  const connectState = useConnect();
+  const accountState = useAccount();
+
+  useEffect(() => {
+    if (accountState.isConnected) {
+      // user is connected, set walletName
+      setWalletId(accountState.connector?.id ?? "");
+    } else {
+      // user has disconnected, reset walletName
+      window.localStorage.setItem(WAGMI_WALLET_STORAGE_KEY, "");
+      setWalletId("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountState.isConnected, accountState.connector?.name]);
+
+  useEffectOnce(() => {
+    const initialConnector = getInitialConnector(walletId, connectState.connectors);
+
+    if (initialConnector?.connector) {
+      connectState.connect({ connector: initialConnector.connector, chainId: initialConnector.chainId });
+    }
+  });
+};

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -1,9 +1,8 @@
 import { createConfig } from "wagmi";
-import scaffoldConfig from "~~/scaffold.config";
 import { appChains, wagmiConnectors } from "~~/services/web3/wagmiConnectors";
 
 export const wagmiConfig = createConfig({
-  autoConnect: scaffoldConfig.walletAutoConnect,
+  autoConnect: false,
   connectors: wagmiConnectors,
   publicClient: appChains.publicClient,
 });


### PR DESCRIPTION
###  Description
Proposing a hacky but minimal and working solution after many tries 😅

###  Solution : 

It seems that Wagmi maintains a localStorage too for the last connected wallet in the key `"wagmi.wallet"` I just latched on it as intial value for our localStorage key `"scaffoldEth2.wallet"` . 

I have also put back `useAutoConnect` because it seems to solve hydration errors while using other hooks too like `useNetwork` (that's why there was a need of adding `useIsMounted` in Faucet and faucetButton in #412)


## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Fixes #453 

Your ENS/address: shivbhonde.eth
