### PR TITLE
update the abi type for getContract in useScaffoldContract

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContract.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContract.ts
@@ -1,8 +1,8 @@
-import { Abi } from "abitype";
 import { getContract } from "viem";
+import { usePublicClient } from "wagmi";
 import { GetWalletClientResult } from "wagmi/actions";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
-import { ContractName } from "~~/utils/scaffold-eth/contract";
+import { Contract, ContractName } from "~~/utils/scaffold-eth/contract";
 
 /**
  * Gets a deployed contract by contract name and returns a contract instance
@@ -18,16 +18,15 @@ export const useScaffoldContract = <TContractName extends ContractName>({
   walletClient?: GetWalletClientResult;
 }) => {
   const { data: deployedContractData, isLoading: deployedContractLoading } = useDeployedContractInfo(contractName);
-
-  // type GetWalletClientResult = WalletClient | null, hence narrowing it to undefined so that it can be passed to getContract
-  const walletClientInstance = walletClient != null ? walletClient : undefined;
+  const publicClient = usePublicClient();
 
   let contract = undefined;
   if (deployedContractData) {
     contract = getContract({
       address: deployedContractData.address,
-      abi: deployedContractData.abi as Abi,
-      walletClient: walletClientInstance,
+      abi: deployedContractData.abi as Contract<TContractName>["abi"],
+      walletClient: walletClient ? walletClient : undefined,
+      publicClient,
     });
   }
 


### PR DESCRIPTION
### Description

This PR tries to add to autocompletion when using `useScaffoldContract` : 

https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/a73e916e-891b-457b-a769-bf2959f11e19


### Small Catch : 
As you can see in the above video we haven't passed `walletClient` to `useScaffoldContract` but we are still able to access `yourContract?.write` and its all method. 

The reason I am telling this is because if you look at viem's [`getContract`](https://viem.sh/docs/contract/getContract.html#usage) it say's that: 
1.  if you pass only `publicClient` you see only  `youractContract.read.{all read methods}` is available 
2.  if you pass  only `walletClient` you see only `yourContract.write.{all write methods}` 
3.  if you pass both `publicClient` & `walletClient` you see both `youractContract.read.{all read methods}` &  `yourContract.write.{all write methods}` 

I wonder how would we achieve this ?   

### Ideal Situation : 

```typescript
 const { data: yourContract } = useScaffoldContract({ contractName: "YourContract" });
 console.log("yourContract: ", yourContract?.write.withdraw());
//                                             ^ Typescript should give error no "write" 
// property found because `walletClient` was not passed

/** Also if you try above code it will break frontend saying "`withdraw` does not exist on undefined"
this is also one reason we should this because it will give user false hope at compile time **/
```
`yourContract?.read.{all read methods}` this should always be available since internally in `useScffafoldContract` we are always passing `publicClient`

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Closes #459 

Your ENS/address: shivbhonde.eth
