### PR TITLE
Add: Error pages and _document page. Improve: test/YourContract.ts and MetaHeader

### DIFF
--- a/packages/hardhat/deploy/00_deploy_your_contract.ts
+++ b/packages/hardhat/deploy/00_deploy_your_contract.ts
@@ -39,4 +39,4 @@ export default deployYourContract;
 
 // Tags are useful if you have multiple deploy files and only want to run one of them.
 // e.g. yarn deploy --tags YourContract
-deployYourContract.tags = ["YourContract"];
+deployYourContract.tags = ["all", "YourContract"];

--- a/packages/hardhat/test/YouContract.ts
+++ b/packages/hardhat/test/YouContract.ts
@@ -1,16 +1,17 @@
 import { expect } from "chai";
-import { ethers } from "hardhat";
+import { ethers, deployments } from "hardhat";
 import { YourContract } from "../typechain-types";
+import { Deployment } from "hardhat-deploy/types";
 
 describe("YourContract", function () {
   // We define a fixture to reuse the same setup in every test.
 
   let yourContract: YourContract;
   before(async () => {
-    const [owner] = await ethers.getSigners();
-    const yourContractFactory = await ethers.getContractFactory("YourContract");
-    yourContract = (await yourContractFactory.deploy(owner.address)) as YourContract;
-    await yourContract.deployed();
+    // Since we already have deployment scripts available, there's no need to write them again
+    await deployments.fixture(["all"]);
+    const deployment: Deployment = await deployments.get("YourContract");
+    yourContract = await ethers.getContractAt(deployment.abi, deployment.address);
   });
 
   describe("Deployment", function () {

--- a/packages/nextjs/components/Error.tsx
+++ b/packages/nextjs/components/Error.tsx
@@ -1,0 +1,27 @@
+import Head from "next/head";
+import Image from "next/image";
+import Link from "next/link";
+
+function Error({ statusCode, message }: ErrorProps) {
+  return (
+    <div>
+      <Head>
+        <title>{`Error - ${statusCode} ${message}`}</title>
+      </Head>
+
+      <div className="flex flex-col justify-center items-center h-screen mx-10">
+        <Image src="/logo.svg" width={300} height={300} alt="Scaffold Logo" />
+        <p className="font-bold text-3xl text-error">{`${statusCode} - ${message}`}</p>
+        <p className="font-bold text-3xl">
+          {`Go to Scaffold-ETH's `}
+          <Link href="/" className="underline hover:text-info">
+            Home
+          </Link>
+          {` Page`}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default Error;

--- a/packages/nextjs/components/MetaHeader.tsx
+++ b/packages/nextjs/components/MetaHeader.tsx
@@ -6,6 +6,9 @@ type MetaHeaderProps = {
   description?: string;
   image?: string;
   twitterCard?: string;
+  timestamp?: string;
+  url?: string;
+  noIndex?: boolean;
   children?: React.ReactNode;
 };
 
@@ -18,6 +21,9 @@ export const MetaHeader = ({
   description = "Built with 🏗 Scaffold-ETH 2",
   image = "thumbnail.jpg",
   twitterCard = "summary_large_image",
+  timestamp,
+  url,
+  noIndex = false,
   children,
 }: MetaHeaderProps) => {
   const imageUrl = baseUrl + image;
@@ -42,10 +48,30 @@ export const MetaHeader = ({
         <>
           <meta property="og:image" content={imageUrl} />
           <meta name="twitter:image" content={imageUrl} />
+          <meta name="twitter:image:alt" content={`Scaffold-ETH Image`} key="twitteralt" />
         </>
       )}
       {twitterCard && <meta name="twitter:card" content={twitterCard} />}
       <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
+
+      {url && (
+        <>
+          <link rel="canonical" href={url} />
+          <meta property="og:url" content={url} />
+        </>
+      )}
+      {timestamp && <meta name="revised" content={timestamp} key="timestamp" />}
+      {!noIndex ? <meta name="robots" content="index, follow" /> : <meta name="robots" content="noindex, nofollow" />}
+
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="Scaffold-ETH 2 App" />
+      <meta name="twitter:site" content="@harendrashakya_" key="twittersite" />
+
+      <meta name="keywords" key="keywords" content="Ethereum, DeFi, Blockchain, smart contracts" />
+      <meta name="apple-mobile-web-app-title" content={`Scaffold-ETH 2 App`} />
+      <meta name="apple-mobile-web-app-capable" content="yes" />
+      <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+
       {children}
     </Head>
   );

--- a/packages/nextjs/components/MetaHeader.tsx
+++ b/packages/nextjs/components/MetaHeader.tsx
@@ -65,7 +65,6 @@ export const MetaHeader = ({
 
       <meta property="og:type" content="website" />
       <meta property="og:site_name" content="Scaffold-ETH 2 App" />
-      <meta name="twitter:site" content="@harendrashakya_" key="twittersite" />
 
       <meta name="keywords" key="keywords" content="Ethereum, DeFi, Blockchain, smart contracts" />
       <meta name="apple-mobile-web-app-title" content={`Scaffold-ETH 2 App`} />

--- a/packages/nextjs/pages/404.tsx
+++ b/packages/nextjs/pages/404.tsx
@@ -1,0 +1,7 @@
+import Error from "~~/components/Error";
+
+function ErrorPage() {
+  return <Error statusCode="404" message="Page not found" />;
+}
+
+export default ErrorPage;

--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { AppProps } from "next/app";
+import Head from "next/head";
 import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 import NextNProgress from "nextjs-progressbar";
@@ -34,6 +35,9 @@ const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
 
   return (
     <WagmiConfig config={wagmiConfig}>
+      <Head>
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
+      </Head>
       <NextNProgress />
       <RainbowKitProvider
         chains={appChains.chains}

--- a/packages/nextjs/pages/_document.tsx
+++ b/packages/nextjs/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Head, Html, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/packages/nextjs/pages/_error.tsx
+++ b/packages/nextjs/pages/_error.tsx
@@ -1,0 +1,17 @@
+import type { NextPageContext } from "next";
+import Error from "~~/components/Error";
+
+function ErrorPage({ statusCode, message }: ErrorProps) {
+  return <Error statusCode={statusCode} message={message} />;
+}
+
+ErrorPage.getInitialProps = (ctx: NextPageContext) => {
+  const { res, err } = ctx;
+  // Inspect the status code and show the given template based off of it
+  // Default to 404 page
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  const message = err ? err.message : "An error occurred";
+  return { statusCode, message };
+};
+
+export default ErrorPage;

--- a/packages/nextjs/types.d.ts
+++ b/packages/nextjs/types.d.ts
@@ -1,0 +1,4 @@
+type ErrorProps = {
+  statusCode: number | string;
+  message?: string;
+};


### PR DESCRIPTION
## Description

There are 3 changes I've made

1. I've added Error pages  in `packages/nextjs/pages`. The addition of `404.tsx` and `_error.tsx` aims to handle errors like "page not found" and "API errors" gracefully.

These pages are leveraging the `Error.tsx` component to ensure consistent error handling throughout the application.

```
function Error({ statusCode, message }: ErrorProps) {
  return (
    <div>
      <Head>
        <title>{`Error - ${statusCode} ${message}`}</title>
      </Head>

      <div className="flex flex-col justify-center items-center h-screen mx-10">
        <Image src="/logo.svg" width={300} height={300} alt="Scaffold Logo" />
        <p className="font-bold text-3xl text-error">{`${statusCode} - ${message}`}</p>
        <p className="font-bold text-3xl">
          {`Go to Scaffold-ETH's `}
          <Link href="/" className="underline hover:text-info">
            Home
          </Link>
          {` Page`}
        </p>
      </div>
    </div>
  );
}

```

2. I have made improvements to the process of obtaining YourContract  in `packages/hardhat/test/YourContract.ts`. This new approach offers significant advantages, as developers no longer need to update tests every time the deployment process is modified, making it much more convenient and efficient.


```
    // Since we already have deployment scripts available, there's no need to write them again
    await deployments.fixture(["all"]);
    const deployment: Deployment = await deployments.get("YourContract");
    yourContract = await ethers.getContractAt(deployment.abi, deployment.address);

```

3. I've added `_document.tsx` to the project in `packages/nextjs/pages`. It holds crucial significance for SEO and ensures proper communication with search engines regarding the website's language.

```
import { Head, Html, Main, NextScript } from "next/document";

export default function Document() {
  return (
    <Html lang="en">
      <Head />
      <body>
        <Main />
        <NextScript />
      </body>
    </Html>
  );
}

```

4. I've improved MetaHeader in `packages/nextjs/components` and added these 

```
    {url && (
        <>
          <link rel="canonical" href={url} />
          <meta property="og:url" content={url} />
        </>
      )}
      {timestamp && <meta name="revised" content={timestamp} key="timestamp" />}
      {!noIndex ? <meta name="robots" content="index, follow" /> : <meta name="robots" content="noindex, nofollow" />}

      <meta property="og:type" content="website" />
      <meta property="og:site_name" content="Scaffold-ETH 2 App" />

      <meta name="keywords" key="keywords" content="Ethereum, DeFi, Blockchain, smart contracts" />
      <meta name="apple-mobile-web-app-title" content={`Scaffold-ETH 2 App`} />
      <meta name="apple-mobile-web-app-capable" content="yes" />
      <meta name="apple-mobile-web-app-status-bar-style" content="black" />
```


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Your ENS/address: 0xB8B14B7f0E4dF000f0654aF98498d52e567F2bfE
