### PR TITLE
Add an explanation and example usage when using `useScaffoldContractWrite` with state

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,22 @@ To send the transaction, you can call the `writeAsync` function returned by the 
 
 This example sends a transaction to the `YourContract` smart contract to call the `setGreeting` function with the arguments passed in `args`. The `writeAsync` function sends the transaction to the smart contract, and the `isLoading` and `isMining` properties indicate whether the transaction is currently being processed by the network.
 
+If you have any state, you can just pass it into the `args`, and it will automatically update when you call `writeAsync()`. Example:
+
+```ts
+const [address, setAddress] = useState("");
+
+const { writeAsync } = useScaffoldContractWrite({
+  contractName: "YourContract",
+  functionName: "calculateStuffWithAddress",
+  args: [address],
+});
+
+<input onChange={e => setAddress(e.target.value)} />
+
+<button onClick={writeAsync}> {/* This will submit with the current value of `address`! */}
+```
+
 ### useScaffoldEventSubscriber:
 
 Use this hook to subscribe to events emitted by your smart contract, and receive real-time updates when these events are emitted.


### PR DESCRIPTION
## Description

I got a bit stuck when trying to write to a contract with state. I don't use React that much, so I didn't know how hooks worked. This PR adds some documentation about the fact that the state changes after you initialize the hook.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: `0x598cb95773D9b66a27a5780DB5EED2d018685879`
