### PR TITLE
fix overflow for read functions and add pre tag to show formated struct

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -51,12 +51,13 @@ export const ReadOnlyFunctionForm = ({ contractAddress, abiFunction }: TReadOnly
     <div className="flex flex-col gap-3 py-5 first:pt-0 last:pb-1">
       <p className="font-medium my-0 break-words">{abiFunction.name}</p>
       {inputElements}
-      <div className="flex justify-between gap-2">
-        <div className="flex-grow">
+      <div className="flex justify-between gap-2 flex-wrap">
+        <div className="flex-grow w-4/5">
           {result !== null && result !== undefined && (
-            <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
-              <strong>Result</strong>: {displayTxResult(result)}
-            </span>
+            <div className="bg-secondary rounded-3xl text-sm px-4 py-1.5 break-words">
+              <p className="font-bold m-0 mb-1">Result:</p>
+              <pre className="whitespace-pre-wrap break-words">{displayTxResult(result)}</pre>
+            </div>
           )}
         </div>
         <button


### PR DESCRIPTION
## Description

Tries to solve #477 , 

Also, it now shows formatted `struct` : 

| Before | After | 
| -------| ------ | 
| ![Screenshot 2023-08-04 at 2 32 50 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/6260c42e-ce95-483a-983e-d55b91735457) |  ![Screenshot 2023-08-04 at 2 33 12 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/3505160c-0c72-4adf-9665-85f706ce376f) | 


## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Closes #477 

Your ENS/address: shivbhonde.eth
