### PR TITLE
updated the UseScaffoldReadConfig and UseScaffoldWriteConfig to inclu…

### DIFF
--- a/packages/nextjs/generated/deployedContracts.ts
+++ b/packages/nextjs/generated/deployedContracts.ts
@@ -1,3 +1,154 @@
-const deployedContracts = null;
+const contracts = {
+  31337: [
+    {
+      chainId: "31337",
+      name: "localhost",
+      contracts: {
+        YourContract: {
+          address: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+          abi: [
+            {
+              inputs: [
+                {
+                  internalType: "address",
+                  name: "_owner",
+                  type: "address",
+                },
+              ],
+              stateMutability: "nonpayable",
+              type: "constructor",
+            },
+            {
+              anonymous: false,
+              inputs: [
+                {
+                  indexed: true,
+                  internalType: "address",
+                  name: "greetingSetter",
+                  type: "address",
+                },
+                {
+                  indexed: false,
+                  internalType: "string",
+                  name: "newGreeting",
+                  type: "string",
+                },
+                {
+                  indexed: false,
+                  internalType: "bool",
+                  name: "premium",
+                  type: "bool",
+                },
+                {
+                  indexed: false,
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+              ],
+              name: "GreetingChange",
+              type: "event",
+            },
+            {
+              inputs: [],
+              name: "greeting",
+              outputs: [
+                {
+                  internalType: "string",
+                  name: "",
+                  type: "string",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [],
+              name: "owner",
+              outputs: [
+                {
+                  internalType: "address",
+                  name: "",
+                  type: "address",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [],
+              name: "premium",
+              outputs: [
+                {
+                  internalType: "bool",
+                  name: "",
+                  type: "bool",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [
+                {
+                  internalType: "string",
+                  name: "_newGreeting",
+                  type: "string",
+                },
+              ],
+              name: "setGreeting",
+              outputs: [],
+              stateMutability: "payable",
+              type: "function",
+            },
+            {
+              inputs: [],
+              name: "totalCounter",
+              outputs: [
+                {
+                  internalType: "uint256",
+                  name: "",
+                  type: "uint256",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [
+                {
+                  internalType: "address",
+                  name: "",
+                  type: "address",
+                },
+              ],
+              name: "userGreetingCounter",
+              outputs: [
+                {
+                  internalType: "uint256",
+                  name: "",
+                  type: "uint256",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [],
+              name: "withdraw",
+              outputs: [],
+              stateMutability: "nonpayable",
+              type: "function",
+            },
+            {
+              stateMutability: "payable",
+              type: "receive",
+            },
+          ],
+        },
+      },
+    },
+  ],
+} as const;
 
-export default deployedContracts;
+export default contracts;

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
@@ -23,6 +23,7 @@ export const useScaffoldContractRead = <
   contractName,
   functionName,
   args,
+  address,
   ...readConfig
 }: UseScaffoldReadConfig<TContractName, TFunctionName>) => {
   const { data: deployedContract } = useDeployedContractInfo(contractName);
@@ -30,7 +31,7 @@ export const useScaffoldContractRead = <
   return useContractRead({
     chainId: getTargetNetwork().id,
     functionName,
-    address: deployedContract?.address,
+    address: address ? address : deployedContract?.address,
     abi: deployedContract?.abi,
     watch: true,
     args,

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -27,6 +27,7 @@ export const useScaffoldContractWrite = <
   value,
   onBlockConfirmation,
   blockConfirmations,
+  address,
   ...writeConfig
 }: UseScaffoldWriteConfig<TContractName, TFunctionName>) => {
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
@@ -37,7 +38,7 @@ export const useScaffoldContractWrite = <
 
   const wagmiContractWrite = useContractWrite({
     chainId: configuredNetwork.id,
-    address: deployedContractData?.address,
+    address: address ? address : deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,
     functionName: functionName as any,
     args: args as unknown[],

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -135,7 +135,9 @@ export type UseScaffoldReadConfig<
     functionName: TFunctionName;
   } & UseScaffoldArgsParam<TContractName, TFunctionName> &
     Omit<UseContractReadConfig, "chainId" | "abi" | "address" | "functionName" | "args">
->;
+> & {
+    address?: string;
+  };
 
 export type UseScaffoldWriteConfig<
   TContractName extends ContractName,
@@ -144,6 +146,7 @@ export type UseScaffoldWriteConfig<
   contractName: TContractName;
   onBlockConfirmation?: (txnReceipt: TransactionReceipt) => void;
   blockConfirmations?: number;
+  address?: string;
 } & IsContractDeclarationMissing<
   Partial<Omit<UseContractWriteConfig, "value"> & { value: `${number}` }>,
   (ExtractStateMutability<TContractName, TFunctionName> extends "payable"


### PR DESCRIPTION
added address as an optional string to UseScaffoldReadConfig and UseScaffoldWriteConfig tyoes so that any contract address can be used to read and write. Also updated their respective hooks: useScaffoldContractRead and useScaffoldContractWrite

## Description

The change would allow factory contracts and their instances to work since users can use the address of instances as a field to read and write to that specific contract

## Additional Information

- [ True] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [True ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: shubhpatni.eth
