### PR TITLE
backmerge recent updates into CLI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ const { writeAsync, isLoading, isMining } = useScaffoldContractWrite({
 To send the transaction, you can call the `writeAsync` function returned by the hook. Here's an example usage:
 
 ```ts
-<button className="btn btn-primary" onClick={writeAsync}>
+<button className="btn btn-primary" onClick={() => writeAsync()}>
   Send TX
 </button>
 ```
@@ -305,7 +305,7 @@ const { data: yourContract } = useScaffoldContract({
   contractName: "YourContract",
 });
 // Returns the greeting and can be called in any function, unlike useScaffoldContractRead
-await yourContract?.greeting();
+await yourContract?.read.greeting();
 
 // Used to write to a contract and can be called in any function
 import { useWalletClient } from "wagmi";
@@ -317,7 +317,7 @@ const { data: yourContract } = useScaffoldContract({
 });
 const setGreeting = async () => {
   // Call the method in any function
-  await yourContract?.setGreeting("the greeting here");
+  await yourContract?.write.setGreeting(["the greeting here"]);
 };
 ```
 

--- a/src/tasks/create-first-git-commit.ts
+++ b/src/tasks/create-first-git-commit.ts
@@ -66,15 +66,6 @@ export async function createFirstGitCommit(
       await checkoutLatestTag(
         path.resolve(foundryWorkSpacePath, "lib", "openzeppelin-contracts")
       );
-
-      // Commit the submodule changes in openzepplin-contracts
-      await execa("git", ["commit", "-am", "update forge-std"], {
-        cwd: path.resolve(
-          foundryWorkSpacePath,
-          "lib",
-          "openzeppelin-contracts"
-        ),
-      });
     }
 
     await execa("git", ["add", "-A"], { cwd: targetDir });
@@ -83,6 +74,13 @@ export async function createFirstGitCommit(
       ["commit", "-m", "Initial commit with 🏗️ Scaffold-ETH 2", "--no-verify"],
       { cwd: targetDir }
     );
+
+    // Update the submodule, since we have checked out the latest tag in the previous step of foundry
+    if (options.extensions?.includes("foundry")) {
+      await execa("git", ["submodule", "update", "--init", "--recursive"], {
+        cwd: path.resolve(targetDir, "packages", "foundry"),
+      });
+    }
   } catch (e: any) {
     // cast error as ExecaError to get stderr
 

--- a/src/tasks/create-first-git-commit.ts
+++ b/src/tasks/create-first-git-commit.ts
@@ -2,6 +2,7 @@ import { execa } from "execa";
 import { Options } from "../types";
 import path from "path";
 
+// Checkout the latest release tag in a git submodule
 async function checkoutLatestTag(submodulePath: string): Promise<void> {
   try {
     const { stdout } = await execa("git", ["tag", "-l", "--sort=-v:refname"], {

--- a/templates/base/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/templates/base/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -51,12 +51,13 @@ export const ReadOnlyFunctionForm = ({ contractAddress, abiFunction }: TReadOnly
     <div className="flex flex-col gap-3 py-5 first:pt-0 last:pb-1">
       <p className="font-medium my-0 break-words">{abiFunction.name}</p>
       {inputElements}
-      <div className="flex justify-between gap-2">
-        <div className="flex-grow">
+      <div className="flex justify-between gap-2 flex-wrap">
+        <div className="flex-grow w-4/5">
           {result !== null && result !== undefined && (
-            <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
-              <strong>Result</strong>: {displayTxResult(result)}
-            </span>
+            <div className="bg-secondary rounded-3xl text-sm px-4 py-1.5 break-words">
+              <p className="font-bold m-0 mb-1">Result:</p>
+              <pre className="whitespace-pre-wrap break-words">{displayTxResult(result)}</pre>
+            </div>
           )}
         </div>
         <button

--- a/templates/base/packages/nextjs/hooks/scaffold-eth/useScaffoldContract.ts
+++ b/templates/base/packages/nextjs/hooks/scaffold-eth/useScaffoldContract.ts
@@ -1,8 +1,8 @@
-import { Abi } from "abitype";
-import { getContract } from "viem";
+import { Account, Address, Transport, getContract } from "viem";
+import { Chain, PublicClient, usePublicClient } from "wagmi";
 import { GetWalletClientResult } from "wagmi/actions";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
-import { ContractName } from "~~/utils/scaffold-eth/contract";
+import { Contract, ContractName } from "~~/utils/scaffold-eth/contract";
 
 /**
  * Gets a deployed contract by contract name and returns a contract instance
@@ -10,24 +10,34 @@ import { ContractName } from "~~/utils/scaffold-eth/contract";
  * @param config.contractName - Deployed contract name
  * @param config.walletClient - An viem wallet client instance (optional)
  */
-export const useScaffoldContract = <TContractName extends ContractName>({
+export const useScaffoldContract = <
+  TContractName extends ContractName,
+  TWalletClient extends Exclude<GetWalletClientResult, null> | undefined,
+>({
   contractName,
   walletClient,
 }: {
   contractName: TContractName;
-  walletClient?: GetWalletClientResult;
+  walletClient?: TWalletClient | null;
 }) => {
   const { data: deployedContractData, isLoading: deployedContractLoading } = useDeployedContractInfo(contractName);
-
-  // type GetWalletClientResult = WalletClient | null, hence narrowing it to undefined so that it can be passed to getContract
-  const walletClientInstance = walletClient != null ? walletClient : undefined;
+  const publicClient = usePublicClient();
 
   let contract = undefined;
   if (deployedContractData) {
-    contract = getContract({
+    contract = getContract<
+      Transport,
+      Address,
+      Contract<TContractName>["abi"],
+      Chain,
+      Account,
+      PublicClient,
+      TWalletClient
+    >({
       address: deployedContractData.address,
-      abi: deployedContractData.abi as Abi,
-      walletClient: walletClientInstance,
+      abi: deployedContractData.abi as Contract<TContractName>["abi"],
+      walletClient: walletClient ? walletClient : undefined,
+      publicClient,
     });
   }
 

--- a/templates/extensions/foundry/packages/foundry/package.json
+++ b/templates/extensions/foundry/packages/foundry/package.json
@@ -7,8 +7,8 @@
     "fork": "anvil --fork-url ${0:-mainnet} --config-out localhost.json",
     "compile": "forge compile",
     "generate": "node script/generateAccount.js",
-    "deploy": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${0:-default_network} --broadcast && node script/generateTsAbis.js",
-    "deploy:verify": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${0:-default_network} --broadcast --verify && node script/generateTsAbis.js",
+    "deploy": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${1:-default_network} --broadcast --legacy && node script/generateTsAbis.js",
+    "deploy:verify": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${1:-default_network} --broadcast --legacy --verify && node script/generateTsAbis.js",
     "lint": "forge fmt",
     "test": "forge test"
   },

--- a/templates/extensions/foundry/packages/foundry/remappings.txt
+++ b/templates/extensions/foundry/packages/foundry/remappings.txt
@@ -1,0 +1,1 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts

--- a/templates/extensions/foundry/packages/foundry/script/Deploy.s.sol
+++ b/templates/extensions/foundry/packages/foundry/script/Deploy.s.sol
@@ -5,9 +5,15 @@ import "../contracts/YourContract.sol";
 import "./DeployHelpers.s.sol";
 
 contract DeployScript is ScaffoldETHDeploy {
+    error InvalidPrivateKey(string);
+
     function run() external {
         uint256 deployerPrivateKey = setupLocalhostEnv();
-
+        if (deployerPrivateKey == 0) {
+            revert InvalidPrivateKey(
+                "You don't have a deployer account. Make sure you have set DEPLOYER_PRIVATE_KEY in .env or use `yarn generate` to generate a new random account"
+            );
+        }
         vm.startBroadcast(deployerPrivateKey);
         YourContract yourContract = new YourContract(
             vm.addr(deployerPrivateKey)
@@ -26,9 +32,6 @@ contract DeployScript is ScaffoldETHDeploy {
          * This function should be called last.
          */
         exportDeployments();
-
-        // If your chain is not present in foundry's stdChain, then you need to call function with chainName:
-        // exportDeployments("chiado")
     }
 
     function test() public {}

--- a/templates/extensions/foundry/packages/foundry/script/generateAccount.js
+++ b/templates/extensions/foundry/packages/foundry/script/generateAccount.js
@@ -20,6 +20,7 @@ const setNewEnvConfig = (existingEnvConfig = {}) => {
   // Store in .env
   fs.writeFileSync(envFilePath, stringify(newEnvConfig));
   console.log("📄 Private Key saved to packages/foundry/.env file");
+  console.log("🪄 Generated wallet address:", randomWallet.address);
 };
 
 async function main() {

--- a/templates/extensions/hardhat/packages/hardhat/hardhat.config.ts
+++ b/templates/extensions/hardhat/packages/hardhat/hardhat.config.ts
@@ -90,6 +90,14 @@ const config: HardhatUserConfig = {
       accounts: [deployerPrivateKey],
       verifyURL: "https://zksync2-mainnet-explorer.zksync.io/contract_verification",
     },
+    gnosis: {
+      url: "https://rpc.gnosischain.com",
+      accounts: [deployerPrivateKey],
+    },
+    chiado: {
+      url: "https://rpc.chiadochain.net",
+      accounts: [deployerPrivateKey],
+    },
   },
   verify: {
     etherscan: {

--- a/templates/extensions/hardhat/packages/hardhat/scripts/generateAccount.ts
+++ b/templates/extensions/hardhat/packages/hardhat/scripts/generateAccount.ts
@@ -20,6 +20,7 @@ const setNewEnvConfig = (existingEnvConfig = {}) => {
   // Store in .env
   fs.writeFileSync(envFilePath, stringify(newEnvConfig));
   console.log("📄 Private Key saved to packages/hardhat/.env file");
+  console.log("🪄 Generated wallet address:", randomWallet.address);
 };
 
 async function main() {


### PR DESCRIPTION
## Description

1. Foundry Updates(#475 ) : 
   a. We have put back `yarn deploy --network network_name` command similar to hardhat
   b. Adds openzepplin by default with installation 
   c. Updated deploy scripts to solve pt.5 of https://github.com/scaffold-eth/scaffold-eth-2/issues/470#issue-1832581912
   
2. Some changes from `main` branch : 
    a. Remove unused types (#465)
    b. autocompletion for useScaffoldContract (#460 )
    c. fix styles for read contract in debug page (#478 )

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: shivbhonde.eth
