### PR TITLE
Add address log for generated wallet & gnosis, chiado in hardhat config

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -90,6 +90,14 @@ const config: HardhatUserConfig = {
       accounts: [deployerPrivateKey],
       verifyURL: "https://zksync2-mainnet-explorer.zksync.io/contract_verification",
     },
+    gnosis: {
+      url: "https://rpc.gnosischain.com",
+      accounts: [deployerPrivateKey],
+    },
+    chiado: {
+      url: "https://rpc.chiadochain.net",
+      accounts: [deployerPrivateKey],
+    },
   },
   verify: {
     etherscan: {

--- a/packages/hardhat/scripts/generateAccount.ts
+++ b/packages/hardhat/scripts/generateAccount.ts
@@ -20,6 +20,7 @@ const setNewEnvConfig = (existingEnvConfig = {}) => {
   // Store in .env
   fs.writeFileSync(envFilePath, stringify(newEnvConfig));
   console.log("📄 Private Key saved to packages/hardhat/.env file");
+  console.log("🪄 Generated wallet address:", randomWallet.address);
 };
 
 async function main() {


### PR DESCRIPTION
## Description

1. Show generated address when you run `yarn generate`
![Screenshot 2023-08-12 at 4 31 02 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/13369344-3680-4c86-8ee9-8d6195615592)

2. Add gnosis and Chiado, we recently added them in foundry at #469, also was mentioned in #481 

NOTE: It does not solve #481 completely
## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


Your ENS/address: shivbhonde.eth
