### PR TITLE
Update and typescript version

### DIFF
--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -43,7 +43,7 @@
     "solidity-coverage": "^0.8.2",
     "ts-node": "^10.9.1",
     "typechain": "^8.1.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.1.6"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.8.1",

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -9,6 +9,10 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: process.env.NEXT_PUBLIC_IGNORE_BUILD_ERROR === "true",
   },
+  webpack: config => {
+    config.resolve.fallback = { fs: false, net: false, tls: false };
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -31,7 +31,7 @@
     "react-hot-toast": "^2.4.0",
     "use-debounce": "^8.0.4",
     "usehooks-ts": "^2.7.2",
-    "viem": "1.2.1",
+    "viem": "^1.6.7",
     "wagmi": "1.3.10",
     "zustand": "^4.1.2"
   },
@@ -50,7 +50,7 @@
     "postcss": "^8.4.16",
     "prettier": "^2.8.4",
     "tailwindcss": "^3.3.3",
-    "typescript": "^4.9.5",
+    "typescript": "^5.1.6",
     "vercel": "^28.15.1"
   }
 }

--- a/packages/nextjs/types/abitype/abi.d.ts
+++ b/packages/nextjs/types/abitype/abi.d.ts
@@ -1,5 +1,11 @@
 import "abitype";
 
+declare module "viem/node_modules/abitype" {
+  export interface Config {
+    AddressType: string;
+  }
+}
+
 declare module "abitype" {
   export interface Config {
     AddressType: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@noble/curves@npm:1.1.0"
+  dependencies:
+    "@noble/hashes": 1.3.1
+  checksum: 2658cdd3f84f71079b4e3516c47559d22cf4b55c23ac8ee9d2b1f8e5b72916d9689e59820e0f9d9cb4a46a8423af5b56dc6bb7782405c88be06a015180508db5
+  languageName: node
+  linkType: hard
+
 "@noble/ed25519@npm:^1.7.0":
   version: 1.7.1
   resolution: "@noble/ed25519@npm:1.7.1"
@@ -1189,6 +1198,13 @@ __metadata:
   version: 1.3.0
   resolution: "@noble/hashes@npm:1.3.0"
   checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@noble/hashes@npm:1.3.1"
+  checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
   languageName: node
   linkType: hard
 
@@ -1795,7 +1811,7 @@ __metadata:
     solidity-coverage: ^0.8.2
     ts-node: ^10.9.1
     typechain: ^8.1.0
-    typescript: ^4.9.5
+    typescript: ^5.1.6
   languageName: unknown
   linkType: soft
 
@@ -1832,11 +1848,11 @@ __metadata:
     react-fast-marquee: ^1.3.5
     react-hot-toast: ^2.4.0
     tailwindcss: ^3.3.3
-    typescript: ^4.9.5
+    typescript: ^5.1.6
     use-debounce: ^8.0.4
     usehooks-ts: ^2.7.2
     vercel: ^28.15.1
-    viem: 1.2.1
+    viem: ^1.6.7
     wagmi: 1.3.10
     zustand: ^4.1.2
   languageName: unknown
@@ -2599,6 +2615,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: b4c9b8ad209620c9b21e78314ce4ff07515c0cadab9af101c1651e7bfb992d7fd933bd8b9c99d110738fd6db523ed15f82f29f50b45510288da72e964dedb1a3
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.4":
+  version: 8.5.5
+  resolution: "@types/ws@npm:8.5.5"
+  dependencies:
+    "@types/node": "*"
+  checksum: d00bf8070e6938e3ccf933010921c6ce78ac3606696ce37a393b27a9a603f7bd93ea64f3c5fa295a2f743575ba9c9a9fdb904af0f5fe2229bf2adf0630386e4a
   languageName: node
   linkType: hard
 
@@ -3745,6 +3770,21 @@ __metadata:
     zod:
       optional: true
   checksum: 4351466808969bcc73e5c535c3d96bb687ee2be0bccd48eba024c47e6cc248f0c8bd368f9e42dab35d39923e63b1349ade470f72812de27127968caf1a1426c9
+  languageName: node
+  linkType: hard
+
+"abitype@npm:0.9.3":
+  version: 0.9.3
+  resolution: "abitype@npm:0.9.3"
+  peerDependencies:
+    typescript: ">=5.0.4"
+    zod: ^3 >=3.19.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+    zod:
+      optional: true
+  checksum: f97c5a118180563b9ed8b97da492a82d3ce53dcd7d96c87764e90dbe84c04ae72dd5703d1ed5a54601033ab1772b8a235a1b5aadaf7aad6c4b5fdad7fd3a69a7
   languageName: node
   linkType: hard
 
@@ -13308,13 +13348,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:^5.1.6":
+  version: 5.1.6
+  resolution: "typescript@npm:5.1.6"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
   languageName: node
   linkType: hard
 
@@ -13328,13 +13368,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=a1c5e5"
+"typescript@patch:typescript@^5.1.6#~builtin<compat/typescript>":
+  version: 5.1.6
+  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
+  checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
   languageName: node
   linkType: hard
 
@@ -13637,7 +13677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:1.2.1, viem@npm:^1.0.0":
+"viem@npm:^1.0.0":
   version: 1.2.1
   resolution: "viem@npm:1.2.1"
   dependencies:
@@ -13653,6 +13693,29 @@ __metadata:
   peerDependencies:
     typescript: ">=5.0.4"
   checksum: f3b0a682a801bcaa89164e587916d5a8c17793ad8bfb639cb43ce0083261bba5ae5a28a6e2815e5267009f91e566d6b6ff83c7130fda0c248bd735bef2548cdb
+  languageName: node
+  linkType: hard
+
+"viem@npm:^1.6.7":
+  version: 1.6.7
+  resolution: "viem@npm:1.6.7"
+  dependencies:
+    "@adraffy/ens-normalize": 1.9.0
+    "@noble/curves": 1.1.0
+    "@noble/hashes": 1.3.0
+    "@scure/bip32": 1.3.0
+    "@scure/bip39": 1.2.0
+    "@types/ws": ^8.5.4
+    "@wagmi/chains": 1.7.0
+    abitype: 0.9.3
+    isomorphic-ws: 5.0.0
+    ws: 8.12.0
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: d923f46c2e0e66ef542162d68a5faed5719c12fd30de22c4a4701cbd81093346166ff18b5d4fe6dabef08e20393c3f507f9fbc18af5798f4125888b21bbfc6e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

So after a lot of digging, I landed on [how to two versions of same npm package](https://stackoverflow.com/questions/43770328/two-versions-of-same-npm-package-in-node-application) and for some reason, I am not able to find that particular link but people were trying to have kind of same typescript version. Which led to me thinking that the reason  `yarn next:check-types` might be checking `node_modules` as discussed in #492 is because `viem` is using typescript version `5+` 

So the steps I followed to fix #492  : 

1. Updated `viem` version to latest using `yarn workspace @se-2/nextjs up viem`

2. I did `yarn next:check-types` here I got `678 errors` mostly from `node_modules/viem`

3. `yarn workspace @se-2/nextjs up typescript` (For some reason this also updated hardhat typescript version which is ok I think nd kind of makes sense)

4. Again `yarn next:check-types` it now gave me only errors from Se-2 repo regarding `AddressType` 

5. Updated `abi.d.ts`, to also handle `viem/node_modules/abitype` and have `AddressType : string`

6. Again `yarn next:check-types` and lol no types error at all!!

---

Started with manual testing and found that nextjs app broke with "Cannot find `fs` module error", after some digging found this on [Rainbowkit installation Page](https://www.rainbowkit.com/docs/installation#additional-build-tooling-setup)  : 

![Screenshot 2023-08-23 at 2 27 42 AM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/1a5afaf3-3e55-481d-8b59-a69f8f725891)

So I added nextjs config which they linked on their [installation Page](https://www.rainbowkit.com/docs/installation#additional-build-tooling-setup) and everything started working. I don't why we didn't have to do it before. 

My wild guess is something heavily changed inside `viem` which kind of removed exposing `ethers` to outter world and we got that error because `viem` is internally using `ethers` [somewhere,  check its dependencies here](https://github.com/wagmi-dev/viem/blob/6a5688684a39e1ce24c8366debc65d9e1bd30132/package.json#L165). 

----

Lol I didn't particularly know what was actual cause, so explained all the steps if someone can infer something from it 🙌. 

I need to do some testing nicely, will do it tomorrow and would appreciate it if others could test as well 🙌

Also please feel free to share your thoughts !!


## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

#492 

Your ENS/address: shivbhonde.eth
