### PR TITLE
Fix RainbowKitCustomConnectButton dropdown styles

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -91,15 +91,18 @@ export const RainbowKitCustomConnectButton = () => {
                       {chain.name}
                     </span>
                   </div>
-                  <div className="dropdown dropdown-end">
-                    <label tabIndex={0} className="btn btn-secondary btn-sm pl-0 pr-2 shadow-md dropdown-toggle gap-0">
+                  <div className="dropdown dropdown-end leading-3">
+                    <label
+                      tabIndex={0}
+                      className="btn btn-secondary btn-sm pl-0 pr-2 shadow-md dropdown-toggle gap-0 !h-auto"
+                    >
                       <BlockieAvatar address={account.address} size={24} ensImage={account.ensAvatar} />
                       <span className="ml-2 mr-1">{account.displayName}</span>
                       <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
                     </label>
                     <ul
                       tabIndex={0}
-                      className="dropdown-content menu p-2 mt-1 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
+                      className="dropdown-content menu p-2 mt-2 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
                     >
                       <li>
                         {addressCopied ? (

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -102,7 +102,7 @@ export const RainbowKitCustomConnectButton = () => {
                     </label>
                     <ul
                       tabIndex={0}
-                      className="dropdown-content menu p-2 mt-2 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
+                      className="dropdown-content menu z-[2] p-2 mt-2 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
                     >
                       <li>
                         {addressCopied ? (

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -108,7 +108,7 @@ export const RainbowKitCustomConnectButton = () => {
                         {addressCopied ? (
                           <div className="btn-sm !rounded-xl flex gap-3 py-3">
                             <CheckCircleIcon
-                              className=" text-xl font-normal h-6 w-4 cursor-pointer"
+                              className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
                               aria-hidden="true"
                             />
                             <span className=" whitespace-nowrap">Copy address</span>
@@ -125,7 +125,7 @@ export const RainbowKitCustomConnectButton = () => {
                           >
                             <div className="btn-sm !rounded-xl flex gap-3 py-3">
                               <DocumentDuplicateIcon
-                                className=" text-xl font-normal h-6 w-4 cursor-pointer"
+                                className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
                                 aria-hidden="true"
                               />
                               <span className=" whitespace-nowrap">Copy address</span>


### PR DESCRIPTION
## Description

Fixes RainbowKitCustomConnectButton dropdown styles

before:
wrong alignment
Copy address line is overlapped by grab faucet message
<img width="373" alt="Снимок экрана 2023-08-23 в 14 30 16" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/25638585/86e95438-a2d7-4f6f-a914-f0e0303330b9">


after:
<img width="410" alt="Снимок экрана 2023-08-23 в 14 30 44" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/25638585/6f181aa7-64e0-4912-9912-493d4519ce03">


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address:
0xrinat
