### PR TITLE
chore: better align footer items.

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -42,7 +42,7 @@ export const Footer = () => {
               </a>
             </div>
             <span>·</span>
-            <div>
+            <div className="flex items-center">
               Built with <HeartIcon className="inline-block h-4 w-4" /> at 🏰{" "}
               <a
                 href="https://buidlguidl.com/"


### PR DESCRIPTION
## Description

When deploying a fresh Scaffold-ETH 2 build, I've noticed that the footer on mobile devices appears misaligned and is positioned to the left. This behaviour seems unintended and could potentially be considered a bug.

It's a small change but will ensure builders have fewer UI issues to fix when shipping.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{497}_


Your ENS/address: chijoke.eth
