### PR TITLE
chore: footer missalignment on mobile screens

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -31,7 +31,7 @@ export const Footer = () => {
       <div className="w-full">
         <ul className="menu menu-horizontal w-full">
           <div className="flex justify-center items-center gap-2 text-sm w-full">
-            <div>
+            <div className="text-center">
               <a
                 href="https://github.com/scaffold-eth/se-2"
                 target="_blank"
@@ -43,18 +43,20 @@ export const Footer = () => {
             </div>
             <span>·</span>
             <div>
-              Built with <HeartIcon className="inline-block h-4 w-4" /> at 🏰{" "}
-              <a
-                href="https://buidlguidl.com/"
-                target="_blank"
-                rel="noreferrer"
-                className="underline underline-offset-2"
-              >
-                BuidlGuidl
-              </a>
+              <p className="m-0 text-center">
+                Built with <HeartIcon className="inline-block h-4 w-4" /> at 🏰{" "}
+                <a
+                  href="https://buidlguidl.com/"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2"
+                >
+                  BuidlGuidl
+                </a>
+              </p>
             </div>
             <span>·</span>
-            <div>
+            <div className="text-center">
               <a
                 href="https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA"
                 target="_blank"

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -13,7 +13,7 @@ export const Footer = () => {
   const nativeCurrencyPrice = useGlobalState(state => state.nativeCurrencyPrice);
 
   return (
-    <div className="min-h-0 p-5 mb-11 lg:mb-0">
+    <div className="min-h-0 py-5 px-1 mb-11 lg:mb-0">
       <div>
         <div className="fixed flex justify-between items-center w-full z-10 p-4 bottom-0 left-0 pointer-events-none">
           <div className="flex space-x-2 pointer-events-auto">
@@ -42,7 +42,7 @@ export const Footer = () => {
               </a>
             </div>
             <span>·</span>
-            <div className="flex items-center">
+            <div>
               Built with <HeartIcon className="inline-block h-4 w-4" /> at 🏰{" "}
               <a
                 href="https://buidlguidl.com/"

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -42,7 +42,7 @@ export const Footer = () => {
               </a>
             </div>
             <span>·</span>
-            <div>
+            <div className="flex items-center">
               Built with <HeartIcon className="inline-block h-4 w-4" /> at 🏰{" "}
               <a
                 href="https://buidlguidl.com/"

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -15,11 +15,19 @@ const Home: NextPage = () => {
           </h1>
           <p className="text-center text-lg">
             Get started by editing{" "}
-            <code className="italic bg-base-300 text-base font-bold">packages/nextjs/pages/index.tsx</code>
+            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
+              packages/nextjs/pages/index.tsx
+            </code>
           </p>
           <p className="text-center text-lg">
-            Edit your smart contract <code className="italic bg-base-300 text-base font-bold">YourContract.sol</code> in{" "}
-            <code className="italic bg-base-300 text-base font-bold">packages/hardhat/contracts</code>
+            Edit your smart contract{" "}
+            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
+              YourContract.sol
+            </code>{" "}
+            in{" "}
+            <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">
+              packages/hardhat/contracts
+            </code>
           </p>
         </div>
 


### PR DESCRIPTION
## Description

Removed the padding-x so as to have greater space on mobile screens (updated version #501 ) : 

![Screenshot 2023-08-23 at 11 44 25 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/98d2518d-2f77-45d8-b1fa-753ce3fb448f)

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

fixes #497 

Your ENS/address: shivbhonde.eth
