### PR TITLE
Subgraph package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "clean-node": "yarn workspace @se-2/subgraph clean-node",
     "run-node": "yarn workspace @se-2/subgraph run-node",
     "local-create": "yarn workspace @se-2/subgraph local-create",
-    "local-ship": "yarn workspace @se-2/subgraph local-ship"
+    "local-ship": "yarn workspace @se-2/subgraph local-ship",
+    "abi-copy": "yarn workspace @se-2/subgraph abi-copy",
+    "codegen": "yarn workspace @se-2/subgraph codegen"
   },
   "packageManager": "yarn@3.2.3",
   "devDependencies": {

--- a/packages/subgraph/graph-node/docker-compose.yml
+++ b/packages/subgraph/graph-node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:latest
+    image: graphprotocol/graph-node:v0.32.0
     ports:
       - "8000:8000"
       - "8001:8001"

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -15,8 +15,8 @@
     "clean-node": "rm -rf graph-node/data/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.46.1",
-    "@graphprotocol/graph-ts": "^0.29.3",
+    "@graphprotocol/graph-cli": "^0.55.0",
+    "@graphprotocol/graph-ts": "^0.31.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   }


### PR DESCRIPTION
## Description

I updated the package.json as well as the docker-compose configuration to hard code graph-node version. We experienced some users having issues with a cached version and broke graph cli functionality

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes N/A

Your ENS/address: Shutterblock.eth
