### PR TITLE
fix ETH price on sepolia network showing 0

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
+++ b/packages/nextjs/utils/scaffold-eth/fetchPriceFromUniswap.ts
@@ -18,7 +18,11 @@ const ABI = parseAbi([
 
 export const fetchPriceFromUniswap = async (): Promise<number> => {
   const configuredNetwork = getTargetNetwork();
-  if (configuredNetwork.nativeCurrency.symbol !== "ETH" && !configuredNetwork.nativeCurrencyTokenAddress) {
+  if (
+    configuredNetwork.nativeCurrency.symbol !== "ETH" &&
+    configuredNetwork.nativeCurrency.symbol !== "SEP" &&
+    !configuredNetwork.nativeCurrencyTokenAddress
+  ) {
     return 0;
   }
   try {


### PR DESCRIPTION
## Description

It seems wagmi chain `sepolia` has `nativeCurrencySymbol` as "SEP" instead of "ETH" and we had this guard condition in `fetchPriceUniswap` :
```ts
if (configuredNetwork.nativeCurrency.symbol !== "ETH" && !configuredNetwork.nativeCurrencyTokenAddress) {
    return 0;
  }
```

Which was returning the price as 0 for Sepolia chain originally encountered here -> https://github.com/scaffold-eth/se-2-challenges/pull/84#issuecomment-1716159180