### PR TITLE
fix vercel deployments version mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next:check-types": "yarn workspace @se-2/nextjs check-types",
     "postinstall": "husky install",
     "precommit": "lint-staged",
+    "vercel-cli": "yarn workspace @se-2/nextjs vercel-cli",
     "vercel": "yarn workspace @se-2/nextjs vercel",
     "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo",
     "vercel:preview": "yarn workspace @se-2/nextjs vercel:preview"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "postinstall": "husky install",
     "precommit": "lint-staged",
     "vercel": "yarn workspace @se-2/nextjs vercel",
-    "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo"
+    "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo",
+    "vercel:preview": "yarn workspace @se-2/nextjs vercel:preview"
   },
   "packageManager": "yarn@3.2.3",
   "devDependencies": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint",
     "format": "prettier --write . '!(node_modules|.next|contracts)/**/*'",
     "check-types": "tsc --noEmit --incremental",
+    "vercel-cli": "vercel",
     "vercel:preview": "vercel build && vercel deploy --prebuilt",
     "vercel": "vercel build --prod && vercel deploy --prebuilt --prod",
     "vercel:yolo": "NEXT_PUBLIC_IGNORE_BUILD_ERROR=true vercel build --prod && vercel deploy --prebuilt --prod"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -10,8 +10,9 @@
     "lint": "next lint",
     "format": "prettier --write . '!(node_modules|.next|contracts)/**/*'",
     "check-types": "tsc --noEmit --incremental",
-    "vercel": "vercel",
-    "vercel:yolo": "vercel --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true"
+    "vercel:preview": "vercel build && vercel deploy --prebuilt",
+    "vercel": "vercel build --prod && vercel deploy --prebuilt --prod",
+    "vercel:yolo": "NEXT_PUBLIC_IGNORE_BUILD_ERROR=true vercel build --prod && vercel deploy --prebuilt --prod"
   },
   "dependencies": {
     "@ethersproject/providers": "^5.7.2",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,9 +11,9 @@
     "format": "prettier --write . '!(node_modules|.next|contracts)/**/*'",
     "check-types": "tsc --noEmit --incremental",
     "vercel-cli": "vercel",
-    "vercel:preview": "vercel build && vercel deploy --prebuilt",
-    "vercel": "vercel build --prod && vercel deploy --prebuilt --prod",
-    "vercel:yolo": "NEXT_PUBLIC_IGNORE_BUILD_ERROR=true vercel build --prod && vercel deploy --prebuilt --prod"
+    "vercel:preview": "vercel pull && vercel build && vercel deploy --prebuilt",
+    "vercel": "vercel pull && vercel build --prod && vercel deploy --prebuilt --prod",
+    "vercel:yolo": "vercel pull && NEXT_PUBLIC_IGNORE_BUILD_ERROR=true vercel build --prod && vercel deploy --prebuilt --prod"
   },
   "dependencies": {
     "@ethersproject/providers": "^5.7.2",


### PR DESCRIPTION
# Description

## Changes to flow :  

### 1 . Very First time deployment : 

The only change is you need to hit extra enter because of the extra first question "No Project Settings found locally....." :  

https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/e5df8811-3689-4096-bd02-473abe2b0d99

### 2 . Deployment to prod or getting preview llink : 

1. Instead of running "yarn vercel --prod"  now "yarn vercel" by default deploys to prod 
2. For preview deployments we need to run `yarn vercel:preview`

### 3 . vercel:yolo : 

No changes to this 


## Other options explored : 

I was actually trying to get https://github.com/scaffold-eth/scaffold-eth-2/pull/231#issuecomment-1471632149 work by people without needing to specify "packages/nextjs" and tried with different option configuring in [`vercel.json`](https://vercel.com/docs/projects/project-configuration) but nothing worked :( 

Also tried reaching out on Next discord checkout [our discusstion thread](https://discord.com/channels/752553802359505017/1155930156435767336), summary : 
- we didn't find any config option to configure "code location" in `vercel.json` 
- Different approach : Using [Vercel REST API](https://vercel.com/docs/rest-api/endpoints#update-an-existing-project) for uploading and deployments (lol not feasible at all) 

## Drawback and Advantages of current approach : 

### Advantages : 

1. Its really superfast as compared to uploaidng and then building on vercel server 
2. Its solves our problem where local versions != deployed versions 

### Drawback(which I could think of ) : 

1. To run plain vercel commands now you need to run `yarn vercel-cli` 
2. Maybe on the very first deployment, first question "No Project Settings found locally.....Run `vercel pull`.."  might confuse the user about what they need to 
3. When doing `yarn vercel:preview` vercel logs this at the end :  
"📝  To deploy to production (test-test-test-test-pi.vercel.app), run `vercel --prod`"
this might give the wrong notion to users to use `vercel --prod` where instead they need to do just  `yarn vercel` for prod deployments


Also in case if we go with this please feel free to suggest the script names, I overrided "vercel" since people are habitat for running `yarn vercel` to deploy app directly 

we could also do "vercel:ship" etch please feel free to suggest 🙌