### PR TITLE
remove `parseEther` from useScaffoldContractWrite

### DIFF
--- a/packages/nextjs/components/example-ui/ContractInteraction.tsx
+++ b/packages/nextjs/components/example-ui/ContractInteraction.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { CopyIcon } from "./assets/CopyIcon";
 import { DiamondIcon } from "./assets/DiamondIcon";
 import { HareIcon } from "./assets/HareIcon";
+import { parseEther } from "viem";
 import { ArrowSmallRightIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
 
@@ -13,7 +14,7 @@ export const ContractInteraction = () => {
     contractName: "YourContract",
     functionName: "setGreeting",
     args: [newGreeting],
-    value: "0.01",
+    value: parseEther("0.01"),
     onBlockConfirmation: txnReceipt => {
       console.log("📦 Transaction blockHash", txnReceipt.blockHash);
     },

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Abi, ExtractAbiFunctionNames } from "abitype";
-import { parseEther } from "viem";
 import { useContractWrite, useNetwork } from "wagmi";
 import { getParsedError } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useTransactor } from "~~/hooks/scaffold-eth";
@@ -41,7 +40,7 @@ export const useScaffoldContractWrite = <
     abi: deployedContractData?.abi as Abi,
     functionName: functionName as any,
     args: args as unknown[],
-    value: value ? parseEther(value) : undefined,
+    value: value,
     ...writeConfig,
   });
 
@@ -73,7 +72,7 @@ export const useScaffoldContractWrite = <
           () =>
             wagmiContractWrite.writeAsync({
               args: newArgs ?? args,
-              value: newValue ? parseEther(newValue) : value && parseEther(value),
+              value: newValue ? newValue : value && value,
               ...otherConfig,
             }),
           { onBlockConfirmation, blockConfirmations },

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -72,7 +72,7 @@ export const useScaffoldContractWrite = <
           () =>
             wagmiContractWrite.writeAsync({
               args: newArgs ?? args,
-              value: newValue ? newValue : value && value,
+              value: newValue ?? value,
               ...otherConfig,
             }),
           { onBlockConfirmation, blockConfirmations },

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -122,17 +122,6 @@ type UseScaffoldArgsParam<
       args?: never;
     };
 
-type ExtractStateMutability<
-  TContractName extends ContractName,
-  TFunctionName extends ExtractAbiFunctionNames<ContractAbi<TContractName>, WriteAbiStateMutability>,
-> = Extract<
-  ContractAbi<TContractName>[number],
-  {
-    name: TFunctionName;
-    stateMutability: string;
-  }
->["stateMutability"];
-
 export type UseScaffoldReadConfig<
   TContractName extends ContractName,
   TFunctionName extends ExtractAbiFunctionNames<ContractAbi<TContractName>, ReadAbiStateMutability>,
@@ -154,13 +143,11 @@ export type UseScaffoldWriteConfig<
   onBlockConfirmation?: (txnReceipt: TransactionReceipt) => void;
   blockConfirmations?: number;
 } & IsContractDeclarationMissing<
-  Partial<Omit<UseContractWriteConfig, "value"> & { value: `${number}` }>,
-  (ExtractStateMutability<TContractName, TFunctionName> extends "payable"
-    ? { value: `${number}` }
-    : { value?: never }) & {
+  Partial<UseContractWriteConfig>,
+  {
     functionName: TFunctionName;
   } & UseScaffoldArgsParam<TContractName, TFunctionName> &
-    Omit<UseContractWriteConfig, "chainId" | "abi" | "address" | "functionName" | "args" | "value" | "mode">
+    Omit<UseContractWriteConfig, "chainId" | "abi" | "address" | "functionName" | "args" | "mode">
 >;
 
 export type UseScaffoldEventConfig<


### PR DESCRIPTION
## Description

As discussed in https://github.com/scaffold-eth/scaffold-eth-2/discussions/516, I agree with the discussion and also makes sense now 🙌

also btw the type of `value` that we had was a bit too harsh as it was typed as `${number}` lol which was a PITA to get it right until you write your own validate function helper or assert it with `as` or just pass in literal value like "0.1".

Here is an example that might frustrate users: 
![Screenshot 2023-09-29 at 3 46 33 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/d991cd0c-13a6-40a3-bf1c-248634ab18c0)

Nevertheless, this PR removes `parseEther` from `useScaffoldContractWrite` so we leave it to users, which solves all the issue 🙌
