### PR TITLE
make use of tailwind `link`-class with some extensions

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -33,12 +33,7 @@ export const Footer = () => {
         <ul className="menu menu-horizontal w-full">
           <div className="flex justify-center items-center gap-2 text-sm w-full">
             <div className="text-center">
-              <a
-                href="https://github.com/scaffold-eth/se-2"
-                target="_blank"
-                rel="noreferrer"
-                className="underline underline-offset-2"
-              >
+              <a href="https://github.com/scaffold-eth/se-2" target="_blank" rel="noreferrer" className="link">
                 Fork me
               </a>
             </div>
@@ -54,17 +49,12 @@ export const Footer = () => {
                 rel="noreferrer"
               >
                 <BuidlGuidlLogo className="w-3 h-5 pb-1" />
-                <span className="underline underline-offset-2">BuidlGuidl</span>
+                <span className="link">BuidlGuidl</span>
               </a>
             </div>
             <span>·</span>
             <div className="text-center">
-              <a
-                href="https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA"
-                target="_blank"
-                rel="noreferrer"
-                className="underline underline-offset-2"
-              >
+              <a href="https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA" target="_blank" rel="noreferrer" className="link">
                 Support
               </a>
             </div>

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -31,10 +31,10 @@ module.exports = {
             "--tooltip-tail": "6px",
           },
           ".link": {
-            "textUnderlineOffset": "2px"
+            textUnderlineOffset: "2px",
           },
           ".link:hover": {
-            "opacity": "80%",
+            opacity: "80%",
           },
         },
       },
@@ -64,10 +64,10 @@ module.exports = {
             "--tooltip-color": "hsl(var(--p))",
           },
           ".link": {
-            "textUnderlineOffset": "2px"
+            textUnderlineOffset: "2px",
           },
           ".link:hover": {
-            "opacity": "80%",
+            opacity: "80%",
           },
         },
       },

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -30,6 +30,12 @@ module.exports = {
           ".tooltip": {
             "--tooltip-tail": "6px",
           },
+          ".link": {
+            "textUnderlineOffset": "2px"
+          },
+          ".link:hover": {
+            "opacity": "80%",
+          },
         },
       },
       {
@@ -56,6 +62,12 @@ module.exports = {
           ".tooltip": {
             "--tooltip-tail": "6px",
             "--tooltip-color": "hsl(var(--p))",
+          },
+          ".link": {
+            "textUnderlineOffset": "2px"
+          },
+          ".link:hover": {
+            "opacity": "80%",
           },
         },
       },


### PR DESCRIPTION
## Description

Changes so that the Footer uses `link` from tailwind. Also adding some customization to it.

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Implements the feedback from @carletex here: https://github.com/scaffold-eth/scaffold-eth-2/pull/551

Your ENS/address: harmont.eth
