### PR TITLE
Memo history events

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Abi, AbiEvent, ExtractAbiEventNames } from "abitype";
 import { Hash } from "viem";
 import { usePublicClient } from "wagmi";
@@ -108,14 +108,20 @@ export const useScaffoldEventHistory = <
     receiptData,
   ]);
 
+  const eventHistoryData = useMemo(
+    () =>
+      events?.map(addIndexedArgsToEvent) as UseScaffoldEventHistoryData<
+        TContractName,
+        TEventName,
+        TBlockData,
+        TTransactionData,
+        TReceiptData
+      >,
+    [events],
+  );
+
   return {
-    data: events?.map(addIndexedArgsToEvent) as UseScaffoldEventHistoryData<
-      TContractName,
-      TEventName,
-      TBlockData,
-      TTransactionData,
-      TReceiptData
-    >,
+    data: eventHistoryData,
     isLoading: isLoading,
     error: error,
   };


### PR DESCRIPTION
## Description

Return `data` from `useScaffoldEventHistory` is not memoized. So because of `.map` it returns new array on every render even when `events` doesn't change

This pr fixes it

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address:
0xrinat
