### PR TITLE
Package.json repo url + README link to CLI branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> ⚠️ This branch is under active development.  
+> ⚠️ The [CLI branch](https://github.com/scaffold-eth/scaffold-eth-2/tree/cli) is under active development.  
 > If you find any bug, please report as [issue](https://github.com/scaffold-eth/scaffold-eth-2/issues) or send a message in [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)
 
 # 🏗 Scaffold-ETH 2

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "create-eth",
   "version": "0.0.21",
   "description": "Create a Scaffold-ETH-2 app",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scaffold-eth/scaffold-eth-2.git"
+  },
   "main": "dist/cli.js",
   "type": "module",
   "bin": "bin/create-dapp-se2.js",


### PR DESCRIPTION
Added the `repository` prop to `package.json` so it shows the link on the npmjs package sidebar.

![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/aa3ecaee-a159-445c-8364-6d815e3edd91)

---

Also updated the README to have a link to the CLI branch.
