### PR TITLE
Move Block Explorer to footer

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -19,12 +19,12 @@ export const Footer = () => {
   return (
     <div className="min-h-0 py-5 px-1 mb-11 lg:mb-0">
       <div>
-        <div className="fixed flex justify-between items-center w-full z-10 p-4 bottom-0 left-0 pointer-events-none ">
+        <div className="fixed flex justify-between items-center w-full z-10 p-4 bottom-0 left-0 pointer-events-none">
           <div className="flex flex-col md:flex-row gap-2 pointer-events-auto">
             {nativeCurrencyPrice > 0 && (
               <div>
-                <div className="btn btn-primary btn-sm font-normal cursor-auto gap-0">
-                  <CurrencyDollarIcon className="h-4 w-4 mr-0.5" />
+                <div className="btn btn-primary btn-sm font-normal normal-case gap-1 cursor-auto">
+                  <CurrencyDollarIcon className="h-4 w-4" />
                   <span>{nativeCurrencyPrice}</span>
                 </div>
               </div>
@@ -32,8 +32,8 @@ export const Footer = () => {
             {isLocalNetwork && (
               <>
                 <Faucet />
-                <Link href="/blockexplorer" passHref className="btn btn-primary btn-sm font-normal gap-0 normal-case">
-                  <MagnifyingGlassIcon className="h-4 w-4 mr-0.5" />
+                <Link href="/blockexplorer" passHref className="btn btn-primary btn-sm font-normal normal-case gap-1">
+                  <MagnifyingGlassIcon className="h-4 w-4" />
                   <span>Block Explorer</span>
                 </Link>
               </>

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -1,5 +1,7 @@
+import React from "react";
+import Link from "next/link";
 import { hardhat } from "wagmi/chains";
-import { CurrencyDollarIcon } from "@heroicons/react/24/outline";
+import { CurrencyDollarIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { HeartIcon } from "@heroicons/react/24/outline";
 import { SwitchTheme } from "~~/components/SwitchTheme";
 import { BuidlGuidlLogo } from "~~/components/assets/BuidlGuidlLogo";
@@ -12,21 +14,32 @@ import { getTargetNetwork } from "~~/utils/scaffold-eth";
  */
 export const Footer = () => {
   const nativeCurrencyPrice = useGlobalState(state => state.nativeCurrencyPrice);
+  const isLocalNetwork = getTargetNetwork().id === hardhat.id;
 
   return (
     <div className="min-h-0 py-5 px-1 mb-11 lg:mb-0">
       <div>
-        <div className="fixed flex justify-between items-center w-full z-10 p-4 bottom-0 left-0 pointer-events-none">
-          <div className="flex space-x-2 pointer-events-auto">
+        <div className="fixed flex justify-between items-center w-full z-10 p-4 bottom-0 left-0 pointer-events-none ">
+          <div className="flex flex-col md:flex-row gap-2 pointer-events-auto">
             {nativeCurrencyPrice > 0 && (
-              <div className="btn btn-primary btn-sm font-normal cursor-auto gap-0">
-                <CurrencyDollarIcon className="h-4 w-4 mr-0.5" />
-                <span>{nativeCurrencyPrice}</span>
+              <div>
+                <div className="btn btn-primary btn-sm font-normal cursor-auto gap-0">
+                  <CurrencyDollarIcon className="h-4 w-4 mr-0.5" />
+                  <span>{nativeCurrencyPrice}</span>
+                </div>
               </div>
             )}
-            {getTargetNetwork().id === hardhat.id && <Faucet />}
+            {isLocalNetwork && (
+              <>
+                <Faucet />
+                <Link href="/blockexplorer" passHref className="btn btn-primary btn-sm font-normal gap-0 normal-case">
+                  <MagnifyingGlassIcon className="h-4 w-4 mr-0.5" />
+                  <span>Block Explorer</span>
+                </Link>
+              </>
+            )}
           </div>
-          <SwitchTheme className="pointer-events-auto" />
+          <SwitchTheme className={`pointer-events-auto ${isLocalNetwork ? "self-end md:self-auto" : ""}`} />
         </div>
       </div>
       <div className="w-full">

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Bars3Icon, BugAntIcon, MagnifyingGlassIcon, SparklesIcon } from "@heroicons/react/24/outline";
+import { Bars3Icon, BugAntIcon, SparklesIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
 
@@ -26,11 +26,6 @@ export const menuLinks: HeaderMenuLink[] = [
     label: "Example UI",
     href: "/example-ui",
     icon: <SparklesIcon className="h-4 w-4" />,
-  },
-  {
-    label: "Block Explorer",
-    href: "/blockexplorer",
-    icon: <MagnifyingGlassIcon className="h-4 w-4" />,
   },
 ];
 

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -82,7 +82,7 @@ export const Faucet = () => {
 
   return (
     <div>
-      <label htmlFor="faucet-modal" className="btn btn-primary btn-sm px-2 rounded-full font-normal normal-case">
+      <label htmlFor="faucet-modal" className="btn btn-primary btn-sm font-normal normal-case gap-1">
         <BanknotesIcon className="h-4 w-4" />
         <span>Faucet</span>
       </label>


### PR DESCRIPTION
For the sake of cleaning up the UI a bit (Example UI might be next :D Will create an issue soon), I'm testing moving the Block Explorer from the main menu to the footer. You still have access in any page (+ in the TX notifications) but in a less intrusive way. It will only show on dev env (local network), like the Faucet.

![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/7fcad03c-91cc-4cb6-a442-5bfab7cd438b)
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/fcac12d6-8282-435c-baca-5fd770621a04)

---

Anyway, just tinkering. Let me know what you think!


