### PR TITLE
fix: incorrect error when sending txn with insufficient funds 

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
@@ -32,7 +32,6 @@ export const WriteOnlyFunctionForm = ({ abiFunction, onChange, contractAddress }
     isLoading,
     writeAsync,
   } = useContractWrite({
-    chainId: getTargetNetwork().id,
     address: contractAddress,
     functionName: abiFunction.name,
     abi: [abiFunction] as Abi,

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -35,7 +35,6 @@ export const useScaffoldContractWrite = <
   const configuredNetwork = getTargetNetwork();
 
   const wagmiContractWrite = useContractWrite({
-    chainId: configuredNetwork.id,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,
     functionName: functionName as any,


### PR DESCRIPTION
## Description

In summary, we get this error : 

![Screenshot 2023-10-24 at 3 18 46 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/6220eb43-6f5e-48d6-9894-ecefbfe3e1aa)
 
 While sending `value` i.e greater than our wallet balance, Ideally it should have given us "Sender doesn't have enought fund...." error  

Check out https://github.com/wagmi-dev/wagmi/issues/3155 for full context

Removing `chainId` from `useContractWrite` solves this problem, We could also wait until https://github.com/wagmi-dev/wagmi/issues/3155 is fixed and close this 🙌
