### PR TITLE
Add copy to clipboard to TxReceipt

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/TxReceipt.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/TxReceipt.tsx
@@ -10,12 +10,8 @@ export const TxReceipt = (
   const [txResultCopied, setTxResultCopied] = useState(false);
 
   return (
-    <div className="flex-wrap collapse collapse-arrow mb-2">
-      <input type="checkbox" className="min-h-0 peer" />
-      <div className="collapse-title text-sm rounded-3xl peer-checked:rounded-b-none min-h-0 bg-secondary py-1.5">
-        <strong>Transaction Receipt</strong>
-      </div>
-      <div className="collapse-content overflow-auto bg-secondary rounded-t-none rounded-3xl">
+    <div className="flex text-sm rounded-3xl peer-checked:rounded-b-none min-h-0 bg-secondary py-0">
+      <div className="mt-1 pl-2">
         {txResultCopied ? (
           <CheckCircleIcon
             className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
@@ -37,7 +33,15 @@ export const TxReceipt = (
             />
           </CopyToClipboard>
         )}
-        <pre className="text-xs pt-4">{displayTxResult(txResult)}</pre>
+      </div>
+      <div className="flex-wrap collapse collapse-arrow">
+        <input type="checkbox" className="min-h-0 peer" />
+        <div className="collapse-title text-sm min-h-0 py-1.5 pl-1">
+          <strong>Transaction Receipt</strong>
+        </div>
+        <div className="collapse-content overflow-auto bg-secondary rounded-t-none rounded-3xl">
+          <pre className="text-xs pt-4">{displayTxResult(txResult)}</pre>
+        </div>
       </div>
     </div>
   );

--- a/packages/nextjs/components/scaffold-eth/Contract/TxReceipt.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/TxReceipt.tsx
@@ -1,9 +1,14 @@
+import { useState } from "react";
+import { CopyToClipboard } from "react-copy-to-clipboard";
 import { TransactionReceipt } from "viem";
+import { CheckCircleIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outline";
 import { displayTxResult } from "~~/components/scaffold-eth";
 
 export const TxReceipt = (
   txResult: string | number | bigint | Record<string, any> | TransactionReceipt | undefined,
 ) => {
+  const [txResultCopied, setTxResultCopied] = useState(false);
+
   return (
     <div className="flex-wrap collapse collapse-arrow mb-2">
       <input type="checkbox" className="min-h-0 peer" />
@@ -11,6 +16,27 @@ export const TxReceipt = (
         <strong>Transaction Receipt</strong>
       </div>
       <div className="collapse-content overflow-auto bg-secondary rounded-t-none rounded-3xl">
+        {txResultCopied ? (
+          <CheckCircleIcon
+            className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+            aria-hidden="true"
+          />
+        ) : (
+          <CopyToClipboard
+            text={displayTxResult(txResult) as string}
+            onCopy={() => {
+              setTxResultCopied(true);
+              setTimeout(() => {
+                setTxResultCopied(false);
+              }, 800);
+            }}
+          >
+            <DocumentDuplicateIcon
+              className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+              aria-hidden="true"
+            />
+          </CopyToClipboard>
+        )}
         <pre className="text-xs pt-4">{displayTxResult(txResult)}</pre>
       </div>
     </div>


### PR DESCRIPTION
## Description

Add copy to clipboard to transaction receipt to allow to copy the transaction data easily.

![localhost_3002_debug](https://github.com/scaffold-eth/scaffold-eth-2/assets/466652/b67fc4c8-d1b3-4817-bd97-62f221d5be86)

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: damianmarti.eth
