### PR TITLE
Add event logs to transaction page

### DIFF
--- a/packages/nextjs/pages/blockexplorer/transaction/[txHash].tsx
+++ b/packages/nextjs/pages/blockexplorer/transaction/[txHash].tsx
@@ -125,14 +125,13 @@ const TransactionPage: NextPage = () => {
                 <td>
                   <strong>Logs:</strong>
                 </td>
-                <td className="form-control">
+                <td>
                   <ul>
-                    {receipt?.logs &&
-                      receipt.logs.map((log, i) => (
-                        <li key={i}>
-                          <strong>Topics {i}:</strong> {JSON.stringify(log.topics, replacer, 2)}
-                        </li>
-                      ))}
+                    {receipt?.logs?.map((log, i) => (
+                      <li key={i}>
+                        <strong>Topics {i}:</strong> {JSON.stringify(log.topics, replacer, 2)}
+                      </li>
+                    ))}
                   </ul>
                 </td>
               </tr>

--- a/packages/nextjs/pages/blockexplorer/transaction/[txHash].tsx
+++ b/packages/nextjs/pages/blockexplorer/transaction/[txHash].tsx
@@ -6,6 +6,7 @@ import { hardhat } from "viem/chains";
 import { usePublicClient } from "wagmi";
 import { Address } from "~~/components/scaffold-eth";
 import { decodeTransactionData, getFunctionDetails, getTargetNetwork } from "~~/utils/scaffold-eth";
+import { replacer } from "~~/utils/scaffold-eth/common";
 
 const TransactionPage: NextPage = () => {
   const client = usePublicClient({ chainId: hardhat.id });
@@ -118,6 +119,21 @@ const TransactionPage: NextPage = () => {
                 </td>
                 <td className="form-control">
                   <textarea readOnly value={transaction.input} className="p-0 textarea-primary bg-inherit h-[150px]" />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Logs:</strong>
+                </td>
+                <td className="form-control">
+                  <ul>
+                    {receipt?.logs &&
+                      receipt.logs.map((log, i) => (
+                        <li key={i}>
+                          <strong>Topics {i}:</strong> {JSON.stringify(log.topics, replacer, 2)}
+                        </li>
+                      ))}
+                  </ul>
                 </td>
               </tr>
             </tbody>

--- a/packages/nextjs/pages/blockexplorer/transaction/[txHash].tsx
+++ b/packages/nextjs/pages/blockexplorer/transaction/[txHash].tsx
@@ -129,7 +129,7 @@ const TransactionPage: NextPage = () => {
                   <ul>
                     {receipt?.logs?.map((log, i) => (
                       <li key={i}>
-                        <strong>Topics {i}:</strong> {JSON.stringify(log.topics, replacer, 2)}
+                        <strong>Log {i} topics:</strong> {JSON.stringify(log.topics, replacer, 2)}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Description

Add event logs to the transaction page.

I added only the topics since I think all the important log information is already on the transaction data. Please let me know if you think I should add something more. 

![localhost_3002_blockexplorer_transaction_0x3320937f63d313fbd8c1efd012288bdff723aa11acdab76445877d634ccf0e9c](https://github.com/scaffold-eth/scaffold-eth-2/assets/466652/541dd509-b770-4c21-ad02-606782da0fb3)

We should try to show the topics information in a prettier way, adding the event name and the parameters names, and decoding the data. Here and in the contract logs page too, but this is for another issue ;-)

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: damianmarti.eth
