### PR TITLE
fix: don't throw error just log if artificats are not present

### DIFF
--- a/packages/nextjs/pages/blockexplorer/address/[address].tsx
+++ b/packages/nextjs/pages/blockexplorer/address/[address].tsx
@@ -173,7 +173,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
   );
 
   if (!fs.existsSync(buildInfoDirectory)) {
-    throw new Error(`Directory ${buildInfoDirectory} not found.`);
+    console.error(`Directory ${buildInfoDirectory} not found.`);
+    return { props: { address, contractData: null } };
   }
 
   const deployedContractsOnChain = contracts ? contracts[chainId] : {};


### PR DESCRIPTION
## Description

If you don't have `artifacts` folder in `pacakges/hardhat` when running `yarn start` you get this error log in your next dev server terminal : 

![Screenshot 2023-11-02 at 6 34 34 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/0579a66b-b9e2-4e02-8f83-8155c7f31cc3)

This is not that above obvious when clonning SE-2, but when you do `npx create-eth@latest` and switch scaffold.config `targetNetwork` to other network eg `sepolia` it you get constant error log there because of this logic we have in CLI 


https://github.com/scaffold-eth/scaffold-eth-2/blob/f9d27d128b519af1d224d30b598475de83eae9f8/templates/base/packages/nextjs/pages/blockexplorer/address/%5Baddress%5D.tsx#L173

noticed this while testing #593 