### PR TITLE
Adds Flare network chain configurations

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -122,6 +122,52 @@ const config: HardhatUserConfig = {
       url: "https://rpc.scroll.io",
       accounts: [deployerPrivateKey],
     },
+    songbird: {
+      url: "https://songbird-api.flare.network/ext/bc/C/rpc",
+      accounts: [deployerPrivateKey],
+      chainId: 19,
+      verify: {
+        etherscan: {
+          // hardhat-verify or hardhat-etherscan want "/api" at the end, hardhat-deploy doesn't
+          apiUrl: "https://songbird-explorer.flare.network",
+        },
+      },
+    },
+    coston: {
+      // faucet: https://faucet.towolabs.com/
+      url: "https://coston-api.flare.network/ext/bc/C/rpc",
+      accounts: [deployerPrivateKey],
+      chainId: 16,
+      verify: {
+        etherscan: {
+          // hardhat-verify or hardhat-etherscan want "/api" at the end, hardhat-deploy doesn't
+          apiUrl: "https://coston-explorer.flare.network",
+        },
+      },
+    },
+    flare: {
+      url: "https://flare-api.flare.network/ext/C/rpc",
+      accounts: [deployerPrivateKey],
+      chainId: 14,
+      verify: {
+        etherscan: {
+          // hardhat-verify or hardhat-etherscan want "/api" at the end, hardhat-deploy doesn't
+          apiUrl: "https://flare-explorer.flare.network",
+        },
+      },
+    },
+    coston2: {
+      // faucet: https://coston2-faucet.towolabs.com/
+      url: "https://coston2-api.flare.network/ext/C/rpc",
+      accounts: [deployerPrivateKey],
+      chainId: 114,
+      verify: {
+        etherscan: {
+          // hardhat-verify or hardhat-etherscan want "/api" at the end, hardhat-deploy doesn't
+          apiUrl: "https://coston2-explorer.flare.network",
+        },
+      },
+    },
   },
   verify: {
     etherscan: {


### PR DESCRIPTION
## Description

Adds hardhat configuration for Flare and Songbird together with testnets.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: j00sko.eth
