### PR TITLE
Add multiplyBy1e18Enabled flat to IntegerInput component

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
@@ -3,6 +3,7 @@ import { CommonInputProps, InputBase, IntegerVariant, isValidInteger } from "~~/
 
 type IntegerInputProps = CommonInputProps<string | bigint> & {
   variant?: IntegerVariant;
+  multiplyBy1e18Enabled?: boolean;
 };
 
 export const IntegerInput = ({
@@ -12,6 +13,7 @@ export const IntegerInput = ({
   placeholder,
   disabled,
   variant = IntegerVariant.UINT256,
+  multiplyBy1e18Enabled = true,
 }: IntegerInputProps) => {
   const [inputError, setInputError] = useState(false);
   const multiplyBy1e18 = useCallback(() => {
@@ -41,7 +43,8 @@ export const IntegerInput = ({
       onChange={onChange}
       disabled={disabled}
       suffix={
-        !inputError && (
+        !inputError &&
+        multiplyBy1e18Enabled && (
           <div
             className="space-x-4 flex tooltip tooltip-top tooltip-secondary before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
             data-tip="Multiply by 10^18 (wei)"

--- a/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
@@ -3,7 +3,7 @@ import { CommonInputProps, InputBase, IntegerVariant, isValidInteger } from "~~/
 
 type IntegerInputProps = CommonInputProps<string | bigint> & {
   variant?: IntegerVariant;
-  multiplyBy1e18Enabled?: boolean;
+  disableMultiplyBy1e18?: boolean;
 };
 
 export const IntegerInput = ({
@@ -13,7 +13,7 @@ export const IntegerInput = ({
   placeholder,
   disabled,
   variant = IntegerVariant.UINT256,
-  multiplyBy1e18Enabled = true,
+  disableMultiplyBy1e18 = false,
 }: IntegerInputProps) => {
   const [inputError, setInputError] = useState(false);
   const multiplyBy1e18 = useCallback(() => {
@@ -44,7 +44,7 @@ export const IntegerInput = ({
       disabled={disabled}
       suffix={
         !inputError &&
-        multiplyBy1e18Enabled && (
+        !disableMultiplyBy1e18 && (
           <div
             className="space-x-4 flex tooltip tooltip-top tooltip-secondary before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
             data-tip="Multiply by 10^18 (wei)"


### PR DESCRIPTION
## Description

Add multiplyBy1e18Enabled flat to IntegerInput component. 

When this flag is set to false, the button to multiply the number by 1e18 is not shown. This is to be used when doesn't make sense to multiply the user input by that amount, like when it's used to enter a regular number.

The default value is true, so the default behavior is not changed.

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: damianmarti.eth
