### PR TITLE
Implemented Select Network to enable switching between different deployed Networks 

### DIFF
--- a/.vercel/README.txt
+++ b/.vercel/README.txt
@@ -1,0 +1,11 @@
+> Why do I have a folder named ".vercel" in my project?
+The ".vercel" folder is created when you link a directory to a Vercel project.
+
+> What does the "project.json" file contain?
+The "project.json" file contains:
+- The ID of the Vercel project that you linked ("projectId")
+- The ID of the user or team your Vercel project is owned by ("orgId")
+
+> Should I commit the ".vercel" folder?
+No, you should not share the ".vercel" folder with anyone.
+Upon creation, it will be automatically added to your ".gitignore" file.

--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,1 @@
+{"projectId":"prj_uQ3Pa7pMRPYV6CWRtTF6poAwxP4k","orgId":"WtaBDuiA8hwwGyAYnxWTnK1y"}

--- a/packages/nextjs/components/scaffold-eth/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/AddressInfoDropdown.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import CopyToClipboard from "react-copy-to-clipboard";
+import { useDisconnect } from "wagmi";
+import {
+  ArrowLeftOnRectangleIcon,
+  ArrowTopRightOnSquareIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  DocumentDuplicateIcon,
+  QrCodeIcon,
+} from "@heroicons/react/24/outline";
+import { BlockieAvatar } from "~~/components/scaffold-eth";
+
+interface IAddressInfoDropdown {
+  address: string;
+  blockExplorerAddressLink: string | undefined;
+  displayName: string;
+  ensAvatar?: string | undefined;
+}
+
+export const AddressInfoDropdown: React.FC<IAddressInfoDropdown> = ({
+  address,
+  ensAvatar,
+  displayName,
+  blockExplorerAddressLink,
+}) => {
+  const [addressCopied, setAddressCopied] = useState(false);
+  const { disconnect } = useDisconnect();
+
+  return (
+    <>
+      <div className="dropdown dropdown-end leading-3">
+        <label tabIndex={0} className="btn btn-secondary btn-sm pl-0 pr-2 shadow-md dropdown-toggle gap-0 !h-auto">
+          <BlockieAvatar address={address} size={30} ensImage={ensAvatar} />
+          <span className="ml-2 mr-1">{displayName}</span>
+          <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
+        </label>
+        <ul
+          tabIndex={0}
+          className="dropdown-content menu z-[2] p-2 mt-2 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
+        >
+          <li>
+            {addressCopied ? (
+              <div className="btn-sm !rounded-xl flex gap-3 py-3">
+                <CheckCircleIcon
+                  className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
+                  aria-hidden="true"
+                />
+                <span className=" whitespace-nowrap">Copy address</span>
+              </div>
+            ) : (
+              <CopyToClipboard
+                text={address}
+                onCopy={() => {
+                  setAddressCopied(true);
+                  setTimeout(() => {
+                    setAddressCopied(false);
+                  }, 800);
+                }}
+              >
+                <div className="btn-sm !rounded-xl flex gap-3 py-3">
+                  <DocumentDuplicateIcon
+                    className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
+                    aria-hidden="true"
+                  />
+                  <span className=" whitespace-nowrap">Copy address</span>
+                </div>
+              </CopyToClipboard>
+            )}
+          </li>
+          <li>
+            <label htmlFor="qrcode-modal" className="btn-sm !rounded-xl flex gap-3 py-3">
+              <QrCodeIcon className="h-6 w-4 ml-2 sm:ml-0" />
+              <span className="whitespace-nowrap">View QR Code</span>
+            </label>
+          </li>
+          <li>
+            <button className="menu-item btn-sm !rounded-xl flex gap-3 py-3" type="button">
+              <ArrowTopRightOnSquareIcon className="h-6 w-4 ml-2 sm:ml-0" />
+              <a
+                target="_blank"
+                href={blockExplorerAddressLink}
+                rel="noopener noreferrer"
+                className="whitespace-nowrap"
+              >
+                View on Block Explorer
+              </a>
+            </button>
+          </li>
+          <li>
+            <button
+              className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"
+              type="button"
+              onClick={() => disconnect()}
+            >
+              <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+};

--- a/packages/nextjs/components/scaffold-eth/AddressQRCodeModal.tsx
+++ b/packages/nextjs/components/scaffold-eth/AddressQRCodeModal.tsx
@@ -6,9 +6,6 @@ interface IAddressQRCodeModal {
   modalId: string;
 }
 
-/**
- * Custom Wagmi Connect Button (watch balance + custom design)
- */
 export const AddressQRCodeModal: React.FC<IAddressQRCodeModal> = ({ address, modalId }) => {
   return (
     <>

--- a/packages/nextjs/components/scaffold-eth/AddressQRCodeModal.tsx
+++ b/packages/nextjs/components/scaffold-eth/AddressQRCodeModal.tsx
@@ -1,0 +1,35 @@
+import { QRCodeSVG } from "qrcode.react";
+import { Address } from "~~/components/scaffold-eth";
+
+interface IAddressQRCodeModal {
+  address: string;
+  modalId: string;
+}
+
+/**
+ * Custom Wagmi Connect Button (watch balance + custom design)
+ */
+export const AddressQRCodeModal: React.FC<IAddressQRCodeModal> = ({ address, modalId }) => {
+  return (
+    <>
+      <div>
+        <input type="checkbox" id={`${modalId}`} className="modal-toggle" />
+        <label htmlFor={`${modalId}`} className="modal cursor-pointer">
+          <label className="modal-box relative">
+            {/* dummy input to capture event onclick on modal box */}
+            <input className="h-0 w-0 absolute top-0 left-0" />
+            <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3">
+              ✕
+            </label>
+            <div className="space-y-3 py-6">
+              <div className="flex space-x-4 flex-col items-center gap-6">
+                <QRCodeSVG value={address} size={256} />
+                <Address address={address} format="long" disableAddressLink />
+              </div>
+            </div>
+          </label>
+        </label>
+      </div>
+    </>
+  );
+};

--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -1,5 +1,5 @@
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { useAccountBalance } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 type TBalanceProps = {
   address?: string;
@@ -10,7 +10,7 @@ type TBalanceProps = {
  * Display (ETH & USD) balance of an ETH address.
  */
 export const Balance = ({ address, className = "" }: TBalanceProps) => {
-  const configuredNetwork = getTargetNetwork();
+  const { configuredNetwork } = useScaffoldConfig();
   const { balance, price, isError, isLoading, onToggleBalance, isEthBalance } = useAccountBalance(address);
 
   if (!address || isLoading || balance === null) {

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -4,8 +4,8 @@ import { ContractVariables } from "./ContractVariables";
 import { ContractWriteMethods } from "./ContractWriteMethods";
 import { Spinner } from "~~/components/assets/Spinner";
 import { Address, Balance } from "~~/components/scaffold-eth";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { useDeployedContractInfo, useNetworkColor } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
 import { ContractName } from "~~/utils/scaffold-eth/contract";
 
 type ContractUIProps = {
@@ -18,8 +18,7 @@ type ContractUIProps = {
  **/
 export const ContractUI = ({ contractName, className = "" }: ContractUIProps) => {
   const [refreshDisplayVariables, triggerRefreshDisplayVariables] = useReducer(value => !value, false);
-  const configuredNetwork = getTargetNetwork();
-
+  const { configuredNetwork } = useScaffoldConfig();
   const { data: deployedContractData, isLoading: deployedContractLoading } = useDeployedContractInfo(contractName);
   const networkColor = useNetworkColor();
 

--- a/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
@@ -12,8 +12,9 @@ import {
   getParsedContractFunctionArgs,
   getParsedError,
 } from "~~/components/scaffold-eth";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { useTransactor } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
+import { notification } from "~~/utils/scaffold-eth";
 
 type WriteOnlyFunctionFormProps = {
   abiFunction: AbiFunction;
@@ -32,7 +33,8 @@ export const WriteOnlyFunctionForm = ({
   const [txValue, setTxValue] = useState<string | bigint>("");
   const { chain } = useNetwork();
   const writeTxn = useTransactor();
-  const writeDisabled = !chain || chain?.id !== getTargetNetwork().id;
+  const { configuredNetwork } = useScaffoldConfig();
+  const writeDisabled = !chain || chain?.id !== configuredNetwork.id;
 
   const {
     data: result,

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -1,4 +1,5 @@
 import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { useAccount } from "wagmi";
 import { AddressInfoDropdown, AddressQRCodeModal, Balance, SelectNetwork } from "~~/components/scaffold-eth";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
 import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
@@ -9,6 +10,8 @@ import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold
 export const RainbowKitCustomConnectButton = () => {
   useAutoConnect();
   const networkColor = useNetworkColor();
+  const { connector: activeAccount } = useAccount();
+  const isBurnerWalletActive = activeAccount && activeAccount.id === "burner-wallet";
 
   return (
     <ConnectButton.Custom>
@@ -31,19 +34,32 @@ export const RainbowKitCustomConnectButton = () => {
 
               return (
                 <div className="px-2 flex justify-end items-center">
-                  <div className="flex items-center mr-1">
-                    <span className="text-xs" style={{ color: networkColor }}>
+                  {isBurnerWalletActive ? (
+                    <div className="flex flex-col items-center mr-1">
                       <Balance address={account.address} className="min-h-0 h-auto" />
-                    </span>
-                    <SelectNetwork chain={chain} />
-                  </div>
-                  <AddressInfoDropdown
-                    address={account.address}
-                    displayName={account.displayName}
-                    ensAvatar={account.ensAvatar}
-                    blockExplorerAddressLink={blockExplorerAddressLink}
-                  />
-                  <AddressQRCodeModal address={account.address} modalId="qrcode-modal" />
+                      <span className="text-xs" style={{ color: networkColor }}>
+                        {chain.name}
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center mr-1">
+                      <span className="text-xs" style={{ color: networkColor }}>
+                        <Balance address={account.address} className="min-h-0 h-auto" />
+                      </span>
+                      <SelectNetwork chain={chain} />
+                    </div>
+                  )}
+                  {!chain.unsupported && (
+                    <>
+                      <AddressInfoDropdown
+                        address={account.address}
+                        displayName={account.displayName}
+                        ensAvatar={account.ensAvatar}
+                        blockExplorerAddressLink={blockExplorerAddressLink}
+                      />
+                      <AddressQRCodeModal address={account.address} modalId="qrcode-modal" />
+                    </>
+                  )}
                 </div>
               );
             })()}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -1,19 +1,9 @@
-import { useState } from "react";
+import { AddressInfoDropdown } from "./AddressInfoDropdown";
 import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-// import { QRCodeSVG } from "qrcode.react";
-import CopyToClipboard from "react-copy-to-clipboard";
 import { useDisconnect, useSwitchNetwork } from "wagmi";
-import {
-  ArrowLeftOnRectangleIcon,
-  ArrowTopRightOnSquareIcon,
-  ArrowsRightLeftIcon,
-  CheckCircleIcon,
-  ChevronDownIcon,
-  DocumentDuplicateIcon,
-  QrCodeIcon,
-} from "@heroicons/react/24/outline";
-import { Balance, BlockieAvatar } from "~~/components/scaffold-eth";
+import { ArrowLeftOnRectangleIcon, ArrowsRightLeftIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
+import { Balance } from "~~/components/scaffold-eth";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
 import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
 
@@ -26,7 +16,6 @@ export const RainbowKitCustomConnectButton = () => {
   const configuredNetwork = getTargetNetwork();
   const { disconnect } = useDisconnect();
   const { switchNetwork } = useSwitchNetwork();
-  const [addressCopied, setAddressCopied] = useState(false);
 
   return (
     <ConnectButton.Custom>
@@ -92,78 +81,12 @@ export const RainbowKitCustomConnectButton = () => {
                       {chain.name}
                     </span>
                   </div>
-                  <div className="dropdown dropdown-end leading-3">
-                    <label
-                      tabIndex={0}
-                      className="btn btn-secondary btn-sm pl-0 pr-2 shadow-md dropdown-toggle gap-0 !h-auto"
-                    >
-                      <BlockieAvatar address={account.address} size={30} ensImage={account.ensAvatar} />
-                      <span className="ml-2 mr-1">{account.displayName}</span>
-                      <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
-                    </label>
-                    <ul
-                      tabIndex={0}
-                      className="dropdown-content menu z-[2] p-2 mt-2 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
-                    >
-                      <li>
-                        {addressCopied ? (
-                          <div className="btn-sm !rounded-xl flex gap-3 py-3">
-                            <CheckCircleIcon
-                              className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
-                              aria-hidden="true"
-                            />
-                            <span className=" whitespace-nowrap">Copy address</span>
-                          </div>
-                        ) : (
-                          <CopyToClipboard
-                            text={account.address}
-                            onCopy={() => {
-                              setAddressCopied(true);
-                              setTimeout(() => {
-                                setAddressCopied(false);
-                              }, 800);
-                            }}
-                          >
-                            <div className="btn-sm !rounded-xl flex gap-3 py-3">
-                              <DocumentDuplicateIcon
-                                className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
-                                aria-hidden="true"
-                              />
-                              <span className=" whitespace-nowrap">Copy address</span>
-                            </div>
-                          </CopyToClipboard>
-                        )}
-                      </li>
-                      <li>
-                        <label htmlFor="qrcode-modal" className="btn-sm !rounded-xl flex gap-3 py-3">
-                          <QrCodeIcon className="h-6 w-4 ml-2 sm:ml-0" />
-                          <span className="whitespace-nowrap">View QR Code</span>
-                        </label>
-                      </li>
-                      <li>
-                        <button className="menu-item btn-sm !rounded-xl flex gap-3 py-3" type="button">
-                          <ArrowTopRightOnSquareIcon className="h-6 w-4 ml-2 sm:ml-0" />
-                          <a
-                            target="_blank"
-                            href={blockExplorerAddressLink}
-                            rel="noopener noreferrer"
-                            className="whitespace-nowrap"
-                          >
-                            View on Block Explorer
-                          </a>
-                        </button>
-                      </li>
-                      <li>
-                        <button
-                          className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"
-                          type="button"
-                          onClick={() => disconnect()}
-                        >
-                          <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
-                        </button>
-                      </li>
-                    </ul>
-                  </div>
+                  <AddressInfoDropdown
+                    address={account.address}
+                    displayName={account.displayName}
+                    ensAvatar={account.ensAvatar}
+                    blockExplorerAddressLink={blockExplorerAddressLink}
+                  />
                   <AddressQRCodeModal address={account.address} modalId="qrcode-modal" />
                 </div>
               );

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -1,9 +1,5 @@
-import { AddressInfoDropdown } from "./AddressInfoDropdown";
-import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { useDisconnect, useSwitchNetwork } from "wagmi";
-import { ArrowLeftOnRectangleIcon, ArrowsRightLeftIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
-import { Balance } from "~~/components/scaffold-eth";
+import { AddressInfoDropdown, AddressQRCodeModal, Balance, SelectNetwork } from "~~/components/scaffold-eth";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
 import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
 
@@ -13,9 +9,6 @@ import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold
 export const RainbowKitCustomConnectButton = () => {
   useAutoConnect();
   const networkColor = useNetworkColor();
-  const configuredNetwork = getTargetNetwork();
-  const { disconnect } = useDisconnect();
-  const { switchNetwork } = useSwitchNetwork();
 
   return (
     <ConnectButton.Custom>
@@ -36,50 +29,13 @@ export const RainbowKitCustomConnectButton = () => {
                 );
               }
 
-              if (chain.unsupported || chain.id !== configuredNetwork.id) {
-                return (
-                  <div className="dropdown dropdown-end">
-                    <label tabIndex={0} className="btn btn-error btn-sm dropdown-toggle gap-1">
-                      <span>Wrong network</span>
-                      <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
-                    </label>
-                    <ul
-                      tabIndex={0}
-                      className="dropdown-content menu p-2 mt-1 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
-                    >
-                      <li>
-                        <button
-                          className="btn-sm !rounded-xl flex py-3 gap-3"
-                          type="button"
-                          onClick={() => switchNetwork?.(configuredNetwork.id)}
-                        >
-                          <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
-                          <span className="whitespace-nowrap">
-                            Switch to <span style={{ color: networkColor }}>{configuredNetwork.name}</span>
-                          </span>
-                        </button>
-                      </li>
-                      <li>
-                        <button
-                          className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"
-                          type="button"
-                          onClick={() => disconnect()}
-                        >
-                          <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
-                        </button>
-                      </li>
-                    </ul>
-                  </div>
-                );
-              }
-
               return (
                 <div className="px-2 flex justify-end items-center">
-                  <div className="flex flex-col items-center mr-1">
-                    <Balance address={account.address} className="min-h-0 h-auto" />
+                  <div className="flex items-center mr-1">
                     <span className="text-xs" style={{ color: networkColor }}>
-                      {chain.name}
+                      <Balance address={account.address} className="min-h-0 h-auto" />
                     </span>
+                    <SelectNetwork chain={chain} />
                   </div>
                   <AddressInfoDropdown
                     address={account.address}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
+import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { QRCodeSVG } from "qrcode.react";
+// import { QRCodeSVG } from "qrcode.react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { useDisconnect, useSwitchNetwork } from "wagmi";
 import {
@@ -12,7 +13,7 @@ import {
   DocumentDuplicateIcon,
   QrCodeIcon,
 } from "@heroicons/react/24/outline";
-import { Address, Balance, BlockieAvatar } from "~~/components/scaffold-eth";
+import { Balance, BlockieAvatar } from "~~/components/scaffold-eth";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
 import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
 
@@ -163,27 +164,7 @@ export const RainbowKitCustomConnectButton = () => {
                       </li>
                     </ul>
                   </div>
-                  <div>
-                    <input type="checkbox" id="qrcode-modal" className="modal-toggle" />
-                    <label htmlFor="qrcode-modal" className="modal cursor-pointer">
-                      <label className="modal-box relative">
-                        {/* dummy input to capture event onclick on modal box */}
-                        <input className="h-0 w-0 absolute top-0 left-0" />
-                        <label
-                          htmlFor="qrcode-modal"
-                          className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3"
-                        >
-                          ✕
-                        </label>
-                        <div className="space-y-3 py-6">
-                          <div className="flex space-x-4 flex-col items-center gap-6">
-                            <QRCodeSVG value={account.address} size={256} />
-                            <Address address={account.address} format="long" disableAddressLink />
-                          </div>
-                        </div>
-                      </label>
-                    </label>
-                  </div>
+                  <AddressQRCodeModal address={account.address} modalId="qrcode-modal" />
                 </div>
               );
             })()}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -1,8 +1,15 @@
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { useAccount } from "wagmi";
-import { AddressInfoDropdown, AddressQRCodeModal, Balance, SelectNetwork } from "~~/components/scaffold-eth";
+import {
+  AddressInfoDropdown,
+  AddressQRCodeModal,
+  Balance,
+  SelectNetwork,
+  SwitchNetwork,
+} from "~~/components/scaffold-eth";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
-import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
+import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
 
 /**
  * Custom Wagmi Connect Button (watch balance + custom design)
@@ -12,13 +19,14 @@ export const RainbowKitCustomConnectButton = () => {
   const networkColor = useNetworkColor();
   const { connector: activeAccount } = useAccount();
   const isBurnerWalletActive = activeAccount && activeAccount.id === "burner-wallet";
+  const { configuredNetwork } = useScaffoldConfig();
 
   return (
     <ConnectButton.Custom>
       {({ account, chain, openConnectModal, mounted }) => {
         const connected = mounted && account && chain;
         const blockExplorerAddressLink = account
-          ? getBlockExplorerAddressLink(getTargetNetwork(), account.address)
+          ? getBlockExplorerAddressLink(configuredNetwork, account.address)
           : undefined;
 
         return (
@@ -30,6 +38,13 @@ export const RainbowKitCustomConnectButton = () => {
                     Connect Wallet
                   </button>
                 );
+              }
+
+              if (
+                (isBurnerWalletActive && chain.unsupported) ||
+                (isBurnerWalletActive && chain.id !== configuredNetwork.id)
+              ) {
+                return <SwitchNetwork />;
               }
 
               return (

--- a/packages/nextjs/components/scaffold-eth/SelectNetwork.tsx
+++ b/packages/nextjs/components/scaffold-eth/SelectNetwork.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import { useDisconnect, useSwitchNetwork } from "wagmi";
+import { ArrowLeftOnRectangleIcon, ArrowsRightLeftIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
+import { useNetworkColor } from "~~/hooks/scaffold-eth";
+import { enabledChains } from "~~/services/web3/wagmiConnectors";
+
+type IChain = {
+  hasIcon: boolean;
+  iconUrl?: string;
+  iconBackground?: string;
+  id: number;
+  name?: string;
+  unsupported?: boolean;
+};
+
+interface ISelectNetwork {
+  chain: IChain;
+}
+
+/**
+ * Custom Wagmi Connect Button (watch balance + custom design)
+ */
+export const SelectNetwork: React.FC<ISelectNetwork> = ({ chain }) => {
+  const networkColor = useNetworkColor();
+  const { disconnect } = useDisconnect();
+  const { switchNetwork } = useSwitchNetwork();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const { configuredNetwork, setNetwork } = useScaffoldConfig();
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && event.target instanceof Node && !dropdownRef.current.contains(event.target)) {
+        setIsDropdownOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <>
+      <div className="dropdown dropdown-end mr-2" ref={dropdownRef}>
+        <label
+          tabIndex={0}
+          className={`btn btn-sm dropdown-toggle ${chain.unsupported ? "btn-error" : "btn-warning"}`}
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+        >
+          <span className="select-network-text">
+            {chain.unsupported ? "Wrong network" : chain.id !== configuredNetwork.id ? "Switch network" : chain.name}
+          </span>
+          <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
+        </label>
+        {isDropdownOpen && (
+          <ul tabIndex={0} className="dropdown-content menu p-2 mt-1 shadow-lg bg-base-100 rounded-box">
+            {enabledChains.map(chain => (
+              <li key={chain.id}>
+                <button
+                  className="menu-item"
+                  type="button"
+                  onClick={() => {
+                    switchNetwork?.(chain.id);
+                    setNetwork(chain);
+                    setIsDropdownOpen(false);
+                  }}
+                >
+                  <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
+                  <span className="whitespace-nowrap">
+                    Switch to <span style={{ color: networkColor }}>{chain.name}</span>
+                  </span>
+                </button>
+              </li>
+            ))}
+            <li>
+              <button className="menu-item text-error" type="button" onClick={() => disconnect()}>
+                <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
+              </button>
+            </li>
+          </ul>
+        )}
+      </div>
+    </>
+  );
+};

--- a/packages/nextjs/components/scaffold-eth/SwitchNetwork.tsx
+++ b/packages/nextjs/components/scaffold-eth/SwitchNetwork.tsx
@@ -1,0 +1,52 @@
+import { useDisconnect, useSwitchNetwork } from "wagmi";
+import { ArrowLeftOnRectangleIcon, ArrowsRightLeftIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
+import { useNetworkColor } from "~~/hooks/scaffold-eth";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
+
+export const SwitchNetwork = () => {
+  const networkColor = useNetworkColor();
+  const { disconnect } = useDisconnect();
+  const { switchNetwork } = useSwitchNetwork();
+  const { setNetwork } = useScaffoldConfig();
+
+  return (
+    <>
+      <div className="dropdown dropdown-end mr-2">
+        <label tabIndex={0} className="btn btn-error btn-sm dropdown-toggle gap-1">
+          <span>Wrong network</span>
+          <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
+        </label>
+        <ul
+          tabIndex={0}
+          className="dropdown-content menu p-2 mt-1 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
+        >
+          <li>
+            <button
+              className="btn-sm !rounded-xl flex py-3 gap-3"
+              type="button"
+              onClick={() => {
+                switchNetwork?.(getTargetNetwork().id);
+                setNetwork(getTargetNetwork());
+              }}
+            >
+              <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
+              <span className="whitespace-nowrap">
+                Switch to <span style={{ color: networkColor }}>{getTargetNetwork().name}</span>
+              </span>
+            </button>
+          </li>
+          <li>
+            <button
+              className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"
+              type="button"
+              onClick={() => disconnect()}
+            >
+              <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+};

--- a/packages/nextjs/components/scaffold-eth/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/index.tsx
@@ -9,3 +9,4 @@ export * from "./RainbowKitCustomConnectButton";
 export * from "./AddressInfoDropdown";
 export * from "./AddressQRCodeModal";
 export * from "./SelectNetwork";
+export * from "./SwitchNetwork";

--- a/packages/nextjs/components/scaffold-eth/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/index.tsx
@@ -6,3 +6,6 @@ export * from "./Faucet";
 export * from "./FaucetButton";
 export * from "./Input";
 export * from "./RainbowKitCustomConnectButton";
+export * from "./AddressInfoDropdown";
+export * from "./AddressQRCodeModal";
+export * from "./SelectNetwork";

--- a/packages/nextjs/context/ScaffoldConfigContext.tsx
+++ b/packages/nextjs/context/ScaffoldConfigContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useState } from "react";
+import * as chains from "wagmi/chains";
+import { ScaffoldConfig } from "~~/scaffold.config";
+import scaffoldConfig from "~~/scaffold.config";
+import { TChainAttributes } from "~~/utils/scaffold-eth";
+import { NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
+
+type IScaffoldConfig = ScaffoldConfig & Partial<TChainAttributes>;
+
+interface IScaffoldConfigContext {
+  config: IScaffoldConfig;
+  setNetwork: (network: chains.Chain) => void;
+  configuredNetwork: chains.Chain;
+}
+
+const ScaffoldConfigContext = createContext<IScaffoldConfigContext | undefined>(undefined);
+
+export const ScaffoldConfigProvider = ({ children }: { children: React.ReactNode }) => {
+  const [targetNetwork, setTargetNetwork] = useState<chains.Chain>(scaffoldConfig.targetNetwork); // Default network
+
+  const config: IScaffoldConfig = {
+    ...scaffoldConfig,
+    targetNetwork,
+    ...NETWORKS_EXTRA_DATA[targetNetwork.id],
+  };
+
+  return (
+    <ScaffoldConfigContext.Provider
+      value={{ config, setNetwork: setTargetNetwork, configuredNetwork: config.targetNetwork }}
+    >
+      {children}
+    </ScaffoldConfigContext.Provider>
+  );
+};
+
+export const useScaffoldConfig = () => {
+  const context = useContext(ScaffoldConfigContext);
+  if (!context) {
+    throw new Error("useScaffoldConfig must be used within a ScaffoldConfigProvider");
+  }
+  return context;
+};

--- a/packages/nextjs/generated/hardhat_contracts.ts
+++ b/packages/nextjs/generated/hardhat_contracts.ts
@@ -1,0 +1,152 @@
+export default {
+  31337: [
+    {
+      name: "localhost",
+      chainId: "31337",
+      contracts: {
+        YourContract: {
+          address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+          abi: [
+            {
+              inputs: [
+                {
+                  internalType: "address",
+                  name: "_owner",
+                  type: "address",
+                },
+              ],
+              stateMutability: "nonpayable",
+              type: "constructor",
+            },
+            {
+              anonymous: false,
+              inputs: [
+                {
+                  indexed: false,
+                  internalType: "address",
+                  name: "greetingSetter",
+                  type: "address",
+                },
+                {
+                  indexed: false,
+                  internalType: "string",
+                  name: "newGreeting",
+                  type: "string",
+                },
+                {
+                  indexed: false,
+                  internalType: "bool",
+                  name: "premium",
+                  type: "bool",
+                },
+                {
+                  indexed: false,
+                  internalType: "uint256",
+                  name: "value",
+                  type: "uint256",
+                },
+              ],
+              name: "GreetingChange",
+              type: "event",
+            },
+            {
+              inputs: [],
+              name: "greeting",
+              outputs: [
+                {
+                  internalType: "string",
+                  name: "",
+                  type: "string",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [],
+              name: "owner",
+              outputs: [
+                {
+                  internalType: "address",
+                  name: "",
+                  type: "address",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [],
+              name: "premium",
+              outputs: [
+                {
+                  internalType: "bool",
+                  name: "",
+                  type: "bool",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [
+                {
+                  internalType: "string",
+                  name: "_newGreeting",
+                  type: "string",
+                },
+              ],
+              name: "setGreeting",
+              outputs: [],
+              stateMutability: "payable",
+              type: "function",
+            },
+            {
+              inputs: [],
+              name: "totalCounter",
+              outputs: [
+                {
+                  internalType: "uint256",
+                  name: "",
+                  type: "uint256",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [
+                {
+                  internalType: "address",
+                  name: "",
+                  type: "address",
+                },
+              ],
+              name: "userGreetingCounter",
+              outputs: [
+                {
+                  internalType: "uint256",
+                  name: "",
+                  type: "uint256",
+                },
+              ],
+              stateMutability: "view",
+              type: "function",
+            },
+            {
+              inputs: [],
+              name: "withdraw",
+              outputs: [],
+              stateMutability: "nonpayable",
+              type: "function",
+            },
+            {
+              stateMutability: "payable",
+              type: "receive",
+            },
+          ],
+        },
+      },
+    },
+  ],
+} as const;

--- a/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
@@ -1,12 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
 import { useBalance } from "wagmi";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { useGlobalState } from "~~/services/store/store";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+
+// import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 export function useAccountBalance(address?: string) {
   const [isEthBalance, setIsEthBalance] = useState(true);
   const [balance, setBalance] = useState<number | null>(null);
   const price = useGlobalState(state => state.nativeCurrencyPrice);
+  const { configuredNetwork } = useScaffoldConfig();
 
   const {
     data: fetchedBalanceData,
@@ -15,7 +18,7 @@ export function useAccountBalance(address?: string) {
   } = useBalance({
     address,
     watch: true,
-    chainId: getTargetNetwork().id,
+    chainId: configuredNetwork.id,
   });
 
   const onToggleBalance = useCallback(() => {
@@ -28,7 +31,7 @@ export function useAccountBalance(address?: string) {
     if (fetchedBalanceData?.formatted) {
       setBalance(Number(fetchedBalanceData.formatted));
     }
-  }, [fetchedBalanceData]);
+  }, [fetchedBalanceData, configuredNetwork]);
 
   return { balance, price, isError, isLoading, onToggleBalance, isEthBalance };
 }

--- a/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useIsMounted } from "usehooks-ts";
 import { usePublicClient } from "wagmi";
-import scaffoldConfig from "~~/scaffold.config";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { Contract, ContractCodeStatus, ContractName, contracts } from "~~/utils/scaffold-eth/contract";
 
 /**
@@ -10,11 +10,10 @@ import { Contract, ContractCodeStatus, ContractName, contracts } from "~~/utils/
  */
 export const useDeployedContractInfo = <TContractName extends ContractName>(contractName: TContractName) => {
   const isMounted = useIsMounted();
-  const deployedContract = contracts?.[scaffoldConfig.targetNetwork.id]?.[
-    contractName as ContractName
-  ] as Contract<TContractName>;
+  const { configuredNetwork } = useScaffoldConfig();
+  const deployedContract = contracts?.[configuredNetwork.id]?.[contractName as ContractName] as Contract<TContractName>;
   const [status, setStatus] = useState<ContractCodeStatus>(ContractCodeStatus.LOADING);
-  const publicClient = usePublicClient({ chainId: scaffoldConfig.targetNetwork.id });
+  const publicClient = usePublicClient({ chainId: configuredNetwork.id });
 
   useEffect(() => {
     const checkContractDeployment = async () => {
@@ -38,7 +37,7 @@ export const useDeployedContractInfo = <TContractName extends ContractName>(cont
     };
 
     checkContractDeployment();
-  }, [isMounted, contractName, deployedContract, publicClient]);
+  }, [isMounted, contractName, deployedContract, publicClient, configuredNetwork]);
 
   return {
     data: status === ContractCodeStatus.DEPLOYED ? deployedContract : undefined,

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,5 +1,5 @@
 import { useDarkMode } from "usehooks-ts";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 
 const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
 
@@ -8,7 +8,8 @@ const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
  */
 export const useNetworkColor = () => {
   const { isDarkMode } = useDarkMode();
-  const colorConfig = getTargetNetwork().color ?? DEFAULT_NETWORK_COLOR;
+  const { config } = useScaffoldConfig();
+  const colorConfig = config.color ?? DEFAULT_NETWORK_COLOR;
 
   return Array.isArray(colorConfig) ? (isDarkMode ? colorConfig[1] : colorConfig[0]) : colorConfig;
 };

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
@@ -1,7 +1,7 @@
 import type { ExtractAbiFunctionNames } from "abitype";
 import { useContractRead } from "wagmi";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
 import {
   AbiFunctionReturnType,
   ContractAbi,
@@ -26,9 +26,10 @@ export const useScaffoldContractRead = <
   ...readConfig
 }: UseScaffoldReadConfig<TContractName, TFunctionName>) => {
   const { data: deployedContract } = useDeployedContractInfo(contractName);
+  const { configuredNetwork } = useScaffoldConfig();
 
   return useContractRead({
-    chainId: getTargetNetwork().id,
+    chainId: configuredNetwork.id,
     functionName,
     address: deployedContract?.address,
     abi: deployedContract?.abi,

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -2,8 +2,9 @@ import { useState } from "react";
 import { Abi, ExtractAbiFunctionNames } from "abitype";
 import { useContractWrite, useNetwork } from "wagmi";
 import { getParsedError } from "~~/components/scaffold-eth";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { useDeployedContractInfo, useTransactor } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
+import { notification } from "~~/utils/scaffold-eth";
 import { ContractAbi, ContractName, UseScaffoldWriteConfig } from "~~/utils/scaffold-eth/contract";
 
 type UpdatedArgs = Parameters<ReturnType<typeof useContractWrite<Abi, string, undefined>>["writeAsync"]>[0];
@@ -32,9 +33,10 @@ export const useScaffoldContractWrite = <
   const { chain } = useNetwork();
   const writeTx = useTransactor();
   const [isMining, setIsMining] = useState(false);
-  const configuredNetwork = getTargetNetwork();
+  const { configuredNetwork } = useScaffoldConfig();
 
   const wagmiContractWrite = useContractWrite({
+    chainId: configuredNetwork.id,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,
     functionName: functionName as any,

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
@@ -1,8 +1,8 @@
 import { Abi, ExtractAbiEventNames } from "abitype";
 import { Log } from "viem";
 import { useContractEvent } from "wagmi";
+import { useScaffoldConfig } from "~~/context/ScaffoldConfigContext";
 import { addIndexedArgsToEvent, useDeployedContractInfo } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
 import { ContractAbi, ContractName, UseScaffoldEventConfig } from "~~/utils/scaffold-eth/contract";
 
 /**
@@ -21,6 +21,7 @@ export const useScaffoldEventSubscriber = <
   listener,
 }: UseScaffoldEventConfig<TContractName, TEventName>) => {
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
+  const { configuredNetwork } = useScaffoldConfig();
 
   const addInexedArgsToLogs = (logs: Log[]) => logs.map(addIndexedArgsToEvent);
   const listenerWithIndexedArgs = (logs: Log[]) =>
@@ -29,7 +30,7 @@ export const useScaffoldEventSubscriber = <
   return useContractEvent({
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,
-    chainId: getTargetNetwork().id,
+    chainId: configuredNetwork.id,
     listener: listenerWithIndexedArgs,
     eventName,
   });

--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -9,6 +9,7 @@ import { WagmiConfig } from "wagmi";
 import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
+import { ScaffoldConfigProvider } from "~~/context/ScaffoldConfigContext";
 import { useNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
 import { useGlobalState } from "~~/services/store/store";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
@@ -40,14 +41,16 @@ const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
         avatar={BlockieAvatar}
         theme={isDarkTheme ? darkTheme() : lightTheme()}
       >
-        <div className="flex flex-col min-h-screen">
-          <Header />
-          <main className="relative flex flex-col flex-1">
-            <Component {...pageProps} />
-          </main>
-          <Footer />
-        </div>
-        <Toaster />
+        <ScaffoldConfigProvider>
+          <div className="flex flex-col min-h-screen">
+            <Header />
+            <main className="relative flex flex-col flex-1">
+              <Component {...pageProps} />
+            </main>
+            <Footer />
+          </div>
+          <Toaster />
+        </ScaffoldConfigProvider>
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -20,7 +20,7 @@ const configuredNetwork = getTargetNetwork();
 const { onlyLocalBurnerWallet } = scaffoldConfig;
 
 // We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-const enabledChains = configuredNetwork.id === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
+export const enabledChains = configuredNetwork.id === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
 
 /**
  * Chains for the app

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -30,3 +30,7 @@ p {
 .btn.btn-ghost {
   @apply shadow-none;
 }
+
+.select-network-text {
+  font-size: 11px;
+}


### PR DESCRIPTION
## Description

Implemented the ability to select different networks a Dapp is deployed to, so users can easily switch between different networks

<img width="941" alt="sc-select-network" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/45943555/f1a5e89d-d995-400c-8898-eabb88d988ed">

Specify the networks the Dapp is deployed to in ```~~/services/web3/wagmiConnectors.tsx```

<img width="941" alt="sc-deployed-networks" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/45943555/ad9348b1-785e-4e06-8c42-ba9de13c733c">

When burner wallet is the wallet in use, select network component is hidden

<img width="941" alt="sc-burner-wallet-active" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/45943555/c7ef1e02-9449-46e9-b12f-15adf5a59376">

## Additional Information

- Created scaffoldConfigContext and provider 
- Refactored/created the following files to use hook from context: - 

1. Created SelectNetwork.tsx
2. Created SwitchNetwork.tsx
3. Created AddressQRCodeModal.tsx
4. Created AddressInfoDropdown.tsx
5. Refactored RainbowKitCustomConnectButton.tsx
6. Refactored WriteOnlyFunctionForm.tsx to use ```configuredNetwork``` instead of ```getTargetNetwork()```
7. Refactored useDeployedContractInfo.ts to use ```configuredNetwork``` instead of ```getTargetNetwork()```
8. Refactored useScaffoldEventSubscriber.ts to use ```configuredNetwork``` instead of ```getTargetNetwork()```
9. Refactored useScaffoldContractRead.ts to use ```configuredNetwork``` instead of ```getTargetNetwork()```
10. Refactored useScaffoldContractWrite.ts to use ```configuredNetwork``` instead of ```getTargetNetwork()```
11. Refactored useAccountBalance.ts to use ```configuredNetwork``` instead of ```getTargetNetwork()```
12. Refactored Balance.tsx to use ```configuredNetwork``` instead of ```getTargetNetwork()```
13. Refactored ContractUI.tsx to use ```configuredNetwork``` instead of ```getTargetNetwork()```
14. Added ScaffoldConfigProvider to _app.tsx
15. Refactored wagmiConnectors.tsx to use ```configuredNetwork``` instead of ```getTargetNetwork()```
16. Refactored useNetworkColor.ts to use ```configuredNetwork``` instead of ```getTargetNetwork()```

@carletex, could you please review this pull request? 

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #599_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: dannithomx.eth
