### PR TITLE
Add requiredFilters param to useScaffoldEventHistory hook

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -26,6 +26,7 @@ import {
  * @param config.transactionData - if set to true it will return the transaction data for each event (default: false)
  * @param config.receiptData - if set to true it will return the receipt data for each event (default: false)
  * @param config.watch - if set to true, the events will be updated every pollingInterval milliseconds set at scaffoldConfig (default: false)
+ * @param config.requiredFilters - if a required filter is not set, no events are returned and the error is set (default: empty)
  */
 export const useScaffoldEventHistory = <
   TContractName extends ContractName,
@@ -42,6 +43,7 @@ export const useScaffoldEventHistory = <
   transactionData,
   receiptData,
   watch,
+  requiredFilters,
 }: UseScaffoldEventHistoryConfig<TContractName, TEventName, TBlockData, TTransactionData, TReceiptData>) => {
   const [events, setEvents] = useState<any[]>();
   const [isLoading, setIsLoading] = useState(false);
@@ -62,6 +64,13 @@ export const useScaffoldEventHistory = <
       const event = (deployedContractData.abi as Abi).find(
         part => part.type === "event" && part.name === eventName,
       ) as AbiEvent;
+
+      if (requiredFilters && requiredFilters.length > 0) {
+        const missingFields = requiredFilters.filter(field => !filters || !filters[field]);
+        if (missingFields.length > 0) {
+          throw new Error(`Missing required fields: ${missingFields.join(", ")}`);
+        }
+      }
 
       const blockNumber = await publicClient.getBlockNumber({ cacheTime: 0 });
 

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -43,7 +43,7 @@ export const useScaffoldEventHistory = <
   transactionData,
   receiptData,
   watch,
-  requiredFilters,
+  enabled = true,
 }: UseScaffoldEventHistoryConfig<TContractName, TEventName, TBlockData, TTransactionData, TReceiptData>) => {
   const [events, setEvents] = useState<any[]>();
   const [isLoading, setIsLoading] = useState(false);
@@ -61,16 +61,13 @@ export const useScaffoldEventHistory = <
         throw new Error("Contract not found");
       }
 
+      if (!enabled) {
+        throw new Error("Hook disabled");
+      }
+
       const event = (deployedContractData.abi as Abi).find(
         part => part.type === "event" && part.name === eventName,
       ) as AbiEvent;
-
-      if (requiredFilters && requiredFilters.length > 0) {
-        const missingFields = requiredFilters.filter(field => !filters || !filters[field]);
-        if (missingFields.length > 0) {
-          throw new Error(`Missing required fields: ${missingFields.join(", ")}`);
-        }
-      }
 
       const blockNumber = await publicClient.getBlockNumber({ cacheTime: 0 });
 
@@ -122,7 +119,7 @@ export const useScaffoldEventHistory = <
   useEffect(() => {
     readEvents(fromBlock);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fromBlock]);
+  }, [fromBlock, enabled]);
 
   useEffect(() => {
     if (!deployedContractLoading) {

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -26,7 +26,7 @@ import {
  * @param config.transactionData - if set to true it will return the transaction data for each event (default: false)
  * @param config.receiptData - if set to true it will return the receipt data for each event (default: false)
  * @param config.watch - if set to true, the events will be updated every pollingInterval milliseconds set at scaffoldConfig (default: false)
- * @param config.requiredFilters - if a required filter is not set, no events are returned and the error is set (default: empty)
+ * @param config.enabled - set this to false to disable the hook from running (default: true)
  */
 export const useScaffoldEventHistory = <
   TContractName extends ContractName,

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -240,7 +240,7 @@ export type UseScaffoldEventHistoryConfig<
   transactionData?: TTransactionData;
   receiptData?: TReceiptData;
   watch?: boolean;
-  requiredFilters?: IndexedEventInputs<TContractName, TEventName>["name"][];
+  enabled?: boolean;
 };
 
 export type UseScaffoldEventHistoryData<

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -240,6 +240,7 @@ export type UseScaffoldEventHistoryConfig<
   transactionData?: TTransactionData;
   receiptData?: TReceiptData;
   watch?: boolean;
+  requiredFilters?: IndexedEventInputs<TContractName, TEventName>["name"][];
 };
 
 export type UseScaffoldEventHistoryData<


### PR DESCRIPTION
## Description

Add requiredFilters param to useScaffoldEventHistory hook to avoid getting wrong events when setting a filter that is not yet populated with the right value.

If one of the requiredFilters is not set, the hook returns an error.

For example, if I get the filter value from the router query, the first value is undefined, and the hook will return all the events, without this filter applied.

To fix it, I can use a useEffect hook, something like this:

```
const { roomHash } = router.query as { roomHash: 0x${string} };

const [roomHashFilter, setRoomHashFilter] = useState<string>("aa");

  useEffect(() => {
    if (roomHash) {
      setRoomHashFilter(roomHash);
    }
  }, [roomHash]);

  const {
    data: roomJoinEvents,
    isLoading: isLoadingRoomCreateEvents,
    error: errorReadingRoomCreateEvents,
  } = useScaffoldEventHistory({
    contractName: "BettingRoom",
    eventName: "RoomJoin",
    fromBlock: 1n,
    filters: { roomHash: roomHashFilter },
    watch: true,
  });
```

But if I use the requieredFilters params I only need the useScaffoldEventHistory hook:

```
const { roomHash } = router.query as { roomHash: 0x${string} };

  const {
    data: roomJoinEvents,
    isLoading: isLoadingRoomCreateEvents,
    error: errorReadingRoomCreateEvents,
  } = useScaffoldEventHistory({
    contractName: "BettingRoom",
    eventName: "RoomJoin",
    fromBlock: 1n,
    filters: { roomHash: roomHash },
    watch: true,
    requiredFilters: ["roomHash"],
  });
```

Or maybe there is another better option that I'm missing :-)

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: damianmarti.eth
