### PR TITLE
Fix useScaffoldEventHistory hook new events order

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -95,7 +95,7 @@ export const useScaffoldEventHistory = <
           });
         }
         if (events && typeof fromBlock === "undefined") {
-          setEvents([...events, ...newEvents]);
+          setEvents([...newEvents, ...events]);
         } else {
           setEvents(newEvents);
         }


### PR DESCRIPTION
## Description

The events are sorted by new ones first, so the newEvents should be added in front of the old events.

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: damianmarti.eth
