### PR TITLE
Allow to use useTransactor hook with contract.write.method

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -67,7 +67,7 @@ export const useScaffoldContractWrite = <
     if (wagmiContractWrite.writeAsync) {
       try {
         setIsMining(true);
-        await writeTx(
+        const writeTxResult = await writeTx(
           () =>
             wagmiContractWrite.writeAsync({
               args: newArgs ?? args,
@@ -76,6 +76,8 @@ export const useScaffoldContractWrite = <
             }),
           { onBlockConfirmation, blockConfirmations },
         );
+
+        return writeTxResult;
       } catch (e: any) {
         const message = getParsedError(e);
         notification.error(message);

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -5,7 +5,7 @@ import { getParsedError } from "~~/components/scaffold-eth";
 import { getBlockExplorerTxLink, notification } from "~~/utils/scaffold-eth";
 
 type TransactionFunc = (
-  tx: (() => Promise<WriteContractResult>) | SendTransactionParameters,
+  tx: (() => Promise<WriteContractResult>) | (() => Promise<`0x${string}`>) | SendTransactionParameters,
   options?: {
     onBlockConfirmation?: (txnReceipt: TransactionReceipt) => void;
     blockConfirmations?: number;
@@ -57,7 +57,12 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
       notificationId = notification.loading(<TxnNotification message="Awaiting for user confirmation" />);
       if (typeof tx === "function") {
         // Tx is already prepared by the caller
-        transactionHash = (await tx()).hash;
+        const result = await tx();
+        if (typeof result === "string") {
+          transactionHash = result;
+        } else {
+          transactionHash = result.hash;
+        }
       } else if (tx != null) {
         transactionHash = await walletClient.sendTransaction(tx);
       } else {

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -5,7 +5,7 @@ import { getParsedError } from "~~/components/scaffold-eth";
 import { getBlockExplorerTxLink, notification } from "~~/utils/scaffold-eth";
 
 type TransactionFunc = (
-  tx: (() => Promise<WriteContractResult>) | (() => Promise<`0x${string}`>) | SendTransactionParameters,
+  tx: (() => Promise<WriteContractResult>) | (() => Promise<Hash>) | SendTransactionParameters,
   options?: {
     onBlockConfirmation?: (txnReceipt: TransactionReceipt) => void;
     blockConfirmations?: number;


### PR DESCRIPTION
## Description

This PR adds ```(() => Promise<`0x${string}`>)``` to tx types on useTransactor to allow them to be called using a contract.write.method. 

For example:

```
  const writeTx = useTransactor();

  const { data: walletClient } = useWalletClient();
  const { data: yourContract } = useScaffoldContract({
    contractName: "YourContract",
    walletClient,
  });

  const setGreeting = async () => {
    if (yourContract !== undefined) {
      const makeWrite = () => yourContract.write.setGreeting(greeting);

      await writeTx(makeWrite, {
        onBlockConfirmation: txnReceipt => {
          console.log("Transaction blockHash", txnReceipt.blockHash);
        },
      });
    }
}
```

Please, let me know if you think this is useful or is there a better way to do this.

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: damianmarti.eth
