### PR TITLE
patch scaffoldConfig type error

### DIFF
--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -7,7 +7,6 @@ export type ScaffoldConfig = {
   walletConnectProjectId: string;
   onlyLocalBurnerWallet: boolean;
   walletAutoConnect: boolean;
-  useStrictAddressType?: boolean;
 };
 
 const scaffoldConfig = {
@@ -39,12 +38,6 @@ const scaffoldConfig = {
    * 2. If user is not connected to any wallet:  On reload, connect to burner wallet if burnerWallet.enabled is true && burnerWallet.onlyLocal is false
    */
   walletAutoConnect: true,
-
-  /**
-   * Strict address types makes viem/wagmi use `0x${string}` instead of plain string for addresses
-   * Leave this undefined or set to the default value if you're new to TypeScript
-   */
-  useStrictAddressType: false,
 } as const satisfies ScaffoldConfig;
 
 export default scaffoldConfig;

--- a/packages/nextjs/types/abitype/abi.d.ts
+++ b/packages/nextjs/types/abitype/abi.d.ts
@@ -1,7 +1,6 @@
 import "abitype";
-import scaffoldConfig from "~~/scaffold.config";
 
-type AddressType = typeof scaffoldConfig extends { useStrictAddressType: true } ? `0x${string}` : string;
+type AddressType = string;
 
 declare module "viem/node_modules/abitype" {
   export interface Config {


### PR DESCRIPTION
## Description

Fixes #640 for now, this removes the ability for the users to configure `AddressType` from `scaffold.config.ts` until we properly find a way to handle it (without having type error) 

 Maybe we can merge this for now since #640 is kind of blocker for people deploying on other networks / using multi-chain 