### PR TITLE
Contract Deploy - Check for exact path segment when extracting contract path in artifacts

### DIFF
--- a/packages/hardhat/deploy/99_generateTsAbis.ts
+++ b/packages/hardhat/deploy/99_generateTsAbis.ts
@@ -60,7 +60,7 @@ function getInheritedFunctions(sources: Record<string, any>, contractName: strin
   const inheritedFunctions = {} as Record<string, any>;
 
   for (const sourceContractName of actualSources) {
-    const sourcePath = Object.keys(sources).find(key => key.includes(sourceContractName));
+    const sourcePath = Object.keys(sources).find(key => key.includes(`/${sourceContractName}`));
     if (sourcePath) {
       const sourceName = sourcePath?.split("/").pop()?.split(".sol")[0];
       const { abi } = JSON.parse(fs.readFileSync(`${ARTIFACTS_DIR}/${sourcePath}/${sourceName}.json`).toString());


### PR DESCRIPTION
## Description

### Error

I ran into some problems when importing the open-zepline  ERC721 contract.
Trying to import this:
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/13890618/f86eb50c-d9fa-4410-ad08-17644a78cd08)

Having this error when deploying at the moment it runs the 99_generateTsAbis.ts script:
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/13890618/c069844e-7291-4029-9419-7a994cd82535)

### Explication:
In these lines, it tried to look for ERC721 in available entries (sources), however, it found IERC721 before the actual ERC721.
So he resolved with the path of IERC721 instead.

### Fix
Looking for the exact path segment using '/' as prefix for includes argument did the job:
E.g. Looking for `/ERC721` in 
[
"@openzeppelin/contracts/interfaces/IERC721.sol",
"@openzeppelin/contracts/token/ERC721.sol"
]

Only the second entry matched this time (expected one).

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: Gossman.eth
