### PR TITLE
patch: add check before accessing `cause.data` in getParsedError

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -25,9 +25,9 @@ const getParsedError = (e: any): string => {
       message = e.details;
     } else if (e.shortMessage) {
       message = e.shortMessage;
-      const cause = e.cause as { data?: DecodeErrorResultReturnType };
+      const cause = e.cause as { data?: DecodeErrorResultReturnType } | undefined;
       // if its not generic error, append custom error name and its args to message
-      if (cause.data && cause.data?.abiItem?.name !== "Error") {
+      if (cause?.data && cause.data?.abiItem?.name !== "Error") {
         const customErrorArgs = cause.data.args?.toString() ?? "";
         message = `${message.replace(/reverted\.$/, "reverted with following reason:")}\n${
           cause.data.errorName


### PR DESCRIPTION
## Description


https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/7bb60bf3-ddb8-4b16-a527-d0988ee62ef7

Noticed while testing #648 and was introduced in #638 my bad 🤦‍♂️ 

I will also raise an issue on VIem so that in the future we don't need to assert typing manually and get proper typing from it directly when narrowed through `ContractFunctionExecutionError`




