### PR TITLE
add moonbeam networks to hardhat config

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -130,6 +130,22 @@ const config: HardhatUserConfig = {
       url: "https://sepolia.publicgoods.network",
       accounts: [deployerPrivateKey],
     },
+    moonbeam: {
+      url: "https://rpc.api.moonbeam.network",
+      accounts: [deployerPrivateKey],
+    },
+    moonriver: {
+      url: "https://rpc.api.moonriver.moonbeam.network",
+      accounts: [deployerPrivateKey],
+    },
+    moonbaseAlpha: {
+      url: "https://rpc.api.moonbase.moonbeam.network",
+      accounts: [deployerPrivateKey],
+    },
+    moonbeamDevNode: {
+      url: "http://127.0.0.1:9944",
+      accounts: [deployerPrivateKey],
+    },
   },
   verify: {
     etherscan: {


### PR DESCRIPTION
## Description

This PR adds the network configurations for all [Moonbeam-based networks](https://docs.moonbeam.network/builders/get-started/networks/) to the `hardhat.config.js` file.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
