### PR TITLE
feat: enable support to mode network testnet to networks

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -130,6 +130,11 @@ const config: HardhatUserConfig = {
       url: "https://sepolia.publicgoods.network",
       accounts: [deployerPrivateKey],
     },
+    mode: {
+      url: "https://sepolia.mode.network",
+      chainId: 919,
+      accounts: [deployerPrivateKey],
+    },
   },
   verify: {
     etherscan: {


### PR DESCRIPTION
## Description

I have been reviewing the benefits of using the current project on different networks, and I have conducted tests to validate compatibility with Mode Network (https://www.mode.network/); therefore, to facilitate the adoption of the tool for Mode Network developers, I would like to add their chain."

Contract deployed:
https://sepolia.explorer.mode.network/address/0xE81673a40B621A2d900Ba5cEC5d5eF3eB514D404?tab=txs

Personal project deployed successfully to validate that everything is running as expected.
<img width="1263" alt="image" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/791301/5ba5eed0-1869-4288-ac8b-4767b483fb81">

Mode Network documentation
https://docs.mode.network/build-on-mode/tutorials/deploying-a-smart-contract/using-hardhat


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

