### PR TITLE
use default values for safeConnector

### DIFF
--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -62,7 +62,7 @@ const wallets = [
         }),
       ]
     : []),
-  safeWallet({ ...walletsOptions, debug: false, allowedDomains: [/./s] }),
+  safeWallet({ ...walletsOptions }),
 ];
 
 /**

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -62,7 +62,7 @@ const wallets = [
         }),
       ]
     : []),
-  safeWallet({ ...walletsOptions, debug: false, allowedDomains: [/gnosis-safe.io$/, /app.safe.global$/] }),
+  safeWallet({ ...walletsOptions, debug: false, allowedDomains: [/./s] }),
 ];
 
 /**


### PR DESCRIPTION
This allows any app to iframe in SE-2 and connect. 

For example : [impersonator.vision](https://impersonator.vision/)

Also tested it nicely even with safe iframe and works great everywhere. This PR just removes extra options that we had and keeps it default.

Here is the option's documentation: https://github.com/safe-global/safe-apps-sdk/tree/main/packages/safe-apps-sdk#documentation

test app link: https://ifram-any.vercel.app


Thanks to @austintgriffith for suggestion 🙌