### PR TITLE
Remove 'use client' from EtherInput, IntegerInput, and AddressInput to Resolve Serialization Lint Warning

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useCallback, useEffect, useState } from "react";
 import { blo } from "blo";
 import { useDebounce } from "usehooks-ts";

--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useEffect, useMemo, useState } from "react";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
 import { CommonInputProps, InputBase, SIGNED_NUMBER_REGEX } from "~~/components/scaffold-eth";

--- a/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useCallback, useEffect, useState } from "react";
 import { CommonInputProps, InputBase, IntegerVariant, isValidInteger } from "~~/components/scaffold-eth";
 


### PR DESCRIPTION
## Description
Removed "use client" from EtherInput IntergerInput and AddessInput due to lint-warning: Props must be serializable for components
There is no need for a child component to have "use client" when the parent contains "use client" already https://github.com/vercel/next.js/discussions/46795
_Concise description of proposed changes, We recommend using screenshots and videos for better description_

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
