### PR TITLE
use `Addreth` for displaying addresses

### DIFF
--- a/packages/nextjs/app/blockexplorer/_components/AddressComponent.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/AddressComponent.tsx
@@ -1,6 +1,8 @@
 import { BackButton } from "./BackButton";
 import { ContractTabs } from "./ContractTabs";
-import { Address, Balance } from "~~/components/scaffold-eth";
+import { Address } from "addreth";
+import { AddrethComp } from "~~/components/AddrethComp";
+import { Balance } from "~~/components/scaffold-eth";
 
 export const AddressComponent = ({
   address,
@@ -19,7 +21,7 @@ export const AddressComponent = ({
           <div className="bg-base-100 border-base-300 border shadow-md shadow-secondary rounded-3xl px-6 lg:px-8 mb-6 space-y-1 py-4 overflow-x-auto">
             <div className="flex">
               <div className="flex flex-col gap-1">
-                <Address address={address} format="long" />
+                <AddrethComp address={address as Address} shortenAddress={false} />
                 <div className="flex gap-1 items-center">
                   <span className="font-bold text-sm">Balance:</span>
                   <Balance address={address} className="text" />

--- a/packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx
@@ -1,6 +1,7 @@
 import { TransactionHash } from "./TransactionHash";
+import { Address } from "addreth";
 import { formatEther } from "viem";
-import { Address } from "~~/components/scaffold-eth";
+import { AddrethComp } from "~~/components/AddrethComp";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { TransactionWithFunction } from "~~/utils/scaffold-eth";
 import { TransactionsTableProps } from "~~/utils/scaffold-eth/";
@@ -44,14 +45,14 @@ export const TransactionsTable = ({ blocks, transactionReceipts }: TransactionsT
                     <td className="w-1/12 md:py-4">{block.number?.toString()}</td>
                     <td className="w-2/1 md:py-4">{timeMined}</td>
                     <td className="w-2/12 md:py-4">
-                      <Address address={tx.from} size="sm" />
+                      <AddrethComp address={tx.from as Address} size="sm" />
                     </td>
                     <td className="w-2/12 md:py-4">
                       {!receipt?.contractAddress ? (
-                        tx.to && <Address address={tx.to} size="sm" />
+                        tx.to && <AddrethComp address={tx.to as Address} size="sm" />
                       ) : (
                         <div className="relative">
-                          <Address address={receipt.contractAddress} size="sm" />
+                          <AddrethComp address={receipt.contractAddress as Address} size="sm" />
                           <small className="absolute top-4 left-4">(Contract Creation)</small>
                         </div>
                       )}

--- a/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Address } from "addreth";
 import type { NextPage } from "next";
 import { Hash, Transaction, TransactionReceipt, formatEther, formatUnits } from "viem";
 import { hardhat } from "viem/chains";
 import { usePublicClient } from "wagmi";
-import { Address } from "~~/components/scaffold-eth";
+import { AddrethComp } from "~~/components/AddrethComp";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { decodeTransactionData, getFunctionDetails } from "~~/utils/scaffold-eth";
 import { replacer } from "~~/utils/scaffold-eth/common";
@@ -69,7 +70,7 @@ const TransactionPage: NextPage<PageProps> = ({ params }: PageProps) => {
                   <strong>From:</strong>
                 </td>
                 <td>
-                  <Address address={transaction.from} format="long" />
+                  <AddrethComp address={transaction.from as Address} shortenAddress={false} />
                 </td>
               </tr>
               <tr>
@@ -78,11 +79,11 @@ const TransactionPage: NextPage<PageProps> = ({ params }: PageProps) => {
                 </td>
                 <td>
                   {!receipt?.contractAddress ? (
-                    transaction.to && <Address address={transaction.to} format="long" />
+                    transaction.to && <AddrethComp address={transaction.to as Address} shortenAddress={false} />
                   ) : (
                     <span>
                       Contract Creation:
-                      <Address address={receipt.contractAddress} format="long" />
+                      <AddrethComp address={receipt.contractAddress as Address} shortenAddress={false} />
                     </span>
                   )}
                 </td>

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -4,7 +4,9 @@ import { useReducer } from "react";
 import { ContractReadMethods } from "./ContractReadMethods";
 import { ContractVariables } from "./ContractVariables";
 import { ContractWriteMethods } from "./ContractWriteMethods";
-import { Address, Balance } from "~~/components/scaffold-eth";
+import { Address } from "addreth";
+import { AddrethComp } from "~~/components/AddrethComp";
+import { Balance } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useNetworkColor } from "~~/hooks/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { ContractName } from "~~/utils/scaffold-eth/contract";
@@ -47,7 +49,7 @@ export const ContractUI = ({ contractName, className = "" }: ContractUIProps) =>
             <div className="flex">
               <div className="flex flex-col gap-1">
                 <span className="font-bold">{contractName}</span>
-                <Address address={deployedContractData.address} />
+                <AddrethComp address={deployedContractData.address as Address} />
                 <div className="flex gap-1 items-center">
                   <span className="font-bold text-sm">Balance:</span>
                   <Balance address={deployedContractData.address} className="px-0 h-1.5 min-h-[0.375rem]" />

--- a/packages/nextjs/app/debug/_components/contract/utilsDisplay.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsDisplay.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from "react";
+import { Address } from "addreth";
 import { TransactionBase, TransactionReceipt, formatEther, isAddress } from "viem";
-import { Address } from "~~/components/scaffold-eth";
+import { AddrethComp } from "~~/components/AddrethComp";
 import { replacer } from "~~/utils/scaffold-eth/common";
 
 type DisplayContent =
@@ -35,7 +36,7 @@ export const displayTxResult = (
   }
 
   if (typeof displayContent === "string" && isAddress(displayContent)) {
-    return asText ? displayContent : <Address address={displayContent} />;
+    return asText ? displayContent : <AddrethComp address={displayContent as Address} />;
   }
 
   if (Array.isArray(displayContent)) {

--- a/packages/nextjs/components/AddrethComp.tsx
+++ b/packages/nextjs/components/AddrethComp.tsx
@@ -1,27 +1,57 @@
+"use client";
+
 import { Addreth, ThemeDeclaration } from "addreth";
 import { AddrethProps } from "addreth/dist/Addreth";
 import { useDarkMode } from "~~/hooks/scaffold-eth/useDarkMode";
+import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
+import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
 
 const blockieSizeMap = {
-  xs: 6,
-  sm: 7,
-  base: 8,
-  lg: 9,
-  xl: 10,
-  "2xl": 12,
-  "3xl": 15,
+  xs: 9,
+  sm: 11,
+  base: 13,
+  lg: 14,
+  xl: 15,
+  "2xl": 17,
+  "3xl": 12,
 };
-interface AddrethCompProps extends Pick<AddrethProps, "theme" | "address" | "actions"> {
+
+// Pick<AddrethProps, "theme" | "address" | "actions">
+interface AddrethCompProps extends AddrethProps {
   size?: keyof typeof blockieSizeMap;
 }
 
 export const AddrethComp: React.FC<AddrethCompProps> = ({ theme, ...props }) => {
   const { isDarkMode } = useDarkMode();
+  const { targetNetwork } = useTargetNetwork();
+
+  // Skeleton UI
+  if (!props.address) {
+    return (
+      <div className="animate-pulse flex space-x-4">
+        <div className="rounded-md bg-slate-300 h-6 w-6"></div>
+        <div className="flex items-center space-y-6">
+          <div className="h-2 w-28 bg-slate-300 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  const blockExplorerAddressLink = getBlockExplorerAddressLink(targetNetwork, props.address);
   const customTheme: ThemeDeclaration = theme ?? {
     base: isDarkMode ? "dark" : "light",
     textColor: isDarkMode ? "#fff" : "#000",
     fontSize: blockieSizeMap[props.size ?? "base"],
-    badgeBackground: isDarkMode ? "#212638" : "#93BBFB",
+    badgeBackground: isDarkMode ? "#2A3655" : "#93BBFB",
   };
-  return <Addreth theme={customTheme} {...props} />;
+  return (
+    <Addreth
+      explorer={() => ({
+        name: targetNetwork.name,
+        accountUrl: blockExplorerAddressLink,
+      })}
+      theme={customTheme}
+      {...props}
+    />
+  );
 };

--- a/packages/nextjs/components/AddrethComp.tsx
+++ b/packages/nextjs/components/AddrethComp.tsx
@@ -1,0 +1,27 @@
+import { Addreth, ThemeDeclaration } from "addreth";
+import { AddrethProps } from "addreth/dist/Addreth";
+import { useDarkMode } from "~~/hooks/scaffold-eth/useDarkMode";
+
+const blockieSizeMap = {
+  xs: 6,
+  sm: 7,
+  base: 8,
+  lg: 9,
+  xl: 10,
+  "2xl": 12,
+  "3xl": 15,
+};
+interface AddrethCompProps extends Pick<AddrethProps, "theme" | "address" | "actions"> {
+  size?: keyof typeof blockieSizeMap;
+}
+
+export const AddrethComp: React.FC<AddrethCompProps> = ({ theme, ...props }) => {
+  const { isDarkMode } = useDarkMode();
+  const customTheme: ThemeDeclaration = theme ?? {
+    base: isDarkMode ? "dark" : "light",
+    textColor: isDarkMode ? "#fff" : "#000",
+    fontSize: blockieSizeMap[props.size ?? "base"],
+    badgeBackground: isDarkMode ? "#212638" : "#93BBFB",
+  };
+  return <Addreth theme={customTheme} {...props} />;
+};

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
+import { AddrethConfig } from "addreth";
 import { Toaster } from "react-hot-toast";
 import { WagmiConfig } from "wagmi";
 import { Footer } from "~~/components/Footer";
@@ -47,7 +48,9 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
         avatar={BlockieAvatar}
         theme={isDarkMode ? darkTheme() : lightTheme()}
       >
-        <ScaffoldEthApp>{children}</ScaffoldEthApp>
+        <ScaffoldEthApp>
+          <AddrethConfig>{children}</AddrethConfig>
+        </ScaffoldEthApp>
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { AddrethComp } from "../AddrethComp";
+import { Address } from "addreth";
 import { Address as AddressType, createWalletClient, http, parseEther } from "viem";
 import { hardhat } from "viem/chains";
 import { useNetwork } from "wagmi";
 import { BanknotesIcon } from "@heroicons/react/24/outline";
-import { Address, AddressInput, Balance, EtherInput } from "~~/components/scaffold-eth";
+import { AddressInput, Balance, EtherInput } from "~~/components/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 import { getParsedError, notification } from "~~/utils/scaffold-eth";
 
@@ -101,7 +103,7 @@ export const Faucet = () => {
             <div className="flex space-x-4">
               <div>
                 <span className="text-sm font-bold">From:</span>
-                <Address address={faucetAddress} />
+                <AddrethComp address={faucetAddress as Address} />
               </div>
               <div>
                 <span className="text-sm font-bold pl-3">Available:</span>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
@@ -1,6 +1,7 @@
+import { Address } from "addreth";
 import { QRCodeSVG } from "qrcode.react";
 import { Address as AddressType } from "viem";
-import { Address } from "~~/components/scaffold-eth";
+import { AddrethComp } from "~~/components/AddrethComp";
 
 type AddressQRCodeModalProps = {
   address: AddressType;
@@ -22,7 +23,7 @@ export const AddressQRCodeModal = ({ address, modalId }: AddressQRCodeModalProps
             <div className="space-y-3 py-6">
               <div className="flex space-x-4 flex-col items-center gap-6">
                 <QRCodeSVG value={address} size={256} />
-                <Address address={address} format="long" disableAddressLink />
+                <AddrethComp address={address as Address} shortenAddress={false} actions="copy" />
               </div>
             </div>
           </label>

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -4,6 +4,152 @@
  */
 import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 
-const deployedContracts = {} as const;
+const deployedContracts = {
+  31337: {
+    YourContract: {
+      address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+      abi: [
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "_owner",
+              type: "address",
+            },
+          ],
+          stateMutability: "nonpayable",
+          type: "constructor",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "greetingSetter",
+              type: "address",
+            },
+            {
+              indexed: false,
+              internalType: "string",
+              name: "newGreeting",
+              type: "string",
+            },
+            {
+              indexed: false,
+              internalType: "bool",
+              name: "premium",
+              type: "bool",
+            },
+            {
+              indexed: false,
+              internalType: "uint256",
+              name: "value",
+              type: "uint256",
+            },
+          ],
+          name: "GreetingChange",
+          type: "event",
+        },
+        {
+          inputs: [],
+          name: "greeting",
+          outputs: [
+            {
+              internalType: "string",
+              name: "",
+              type: "string",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "owner",
+          outputs: [
+            {
+              internalType: "address",
+              name: "",
+              type: "address",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "premium",
+          outputs: [
+            {
+              internalType: "bool",
+              name: "",
+              type: "bool",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "string",
+              name: "_newGreeting",
+              type: "string",
+            },
+          ],
+          name: "setGreeting",
+          outputs: [],
+          stateMutability: "payable",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "totalCounter",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "",
+              type: "address",
+            },
+          ],
+          name: "userGreetingCounter",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "withdraw",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          stateMutability: "payable",
+          type: "receive",
+        },
+      ],
+      inheritedFunctions: {},
+    },
+  },
+} as const;
 
 export default deployedContracts satisfies GenericContractsDeclaration;

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -19,6 +19,7 @@
     "@rainbow-me/rainbowkit": "1.3.0",
     "@uniswap/sdk-core": "^4.0.1",
     "@uniswap/v2-sdk": "^3.0.1",
+    "addreth": "^1.2.0",
     "blo": "^1.0.1",
     "daisyui": "^4.4.19",
     "next": "^14.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,6 +1870,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.39.0
     "@uniswap/sdk-core": ^4.0.1
     "@uniswap/v2-sdk": ^3.0.1
+    addreth: ^1.2.0
     autoprefixer: ^10.4.12
     blo: ^1.0.1
     daisyui: ^4.4.19
@@ -3820,6 +3821,20 @@ __metadata:
   version: 1.2.2
   resolution: "address@npm:1.2.2"
   checksum: ace439960c1e3564d8f523aff23a841904bf33a2a7c2e064f7f60a064194075758b9690e65bd9785692a4ef698a998c57eb74d145881a1cecab8ba658ddb1607
+  languageName: node
+  linkType: hard
+
+"addreth@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "addreth@npm:1.2.0"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+    wagmi: ">=1.4.0"
+  peerDependenciesMeta:
+    wagmi:
+      optional: true
+  checksum: 074204f01bcc5a38877f796c9cc87526b762a07ed08323dc438e192bdd4507aca6aac4a6f21a5a9bc3067e104d13198c8e9e548fea7981f794971c47b97da80b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
[Addreth](https://addreth.vercel.app/)'s address component provides a good way to display addresses along with many good and useful features. I've updated the UI to use the [Addreth](https://addreth.vercel.app/) address component to display addresses. 

## Additional Information
### Screenshots
Dark mode
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/56908732/7cd03d18-171a-47d4-b9c1-928adb0bf604)
Light mode
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/56908732/238fe212-2618-4899-8966-4c972510070f)

Pls have a look and lmk if any changes are required

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: nazeeh.eth
