### PR TITLE
fix broken blockexplorer address page

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/index.ts
+++ b/packages/nextjs/components/scaffold-eth/Input/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export * from "./AddressInput";
 export * from "./Bytes32Input";
 export * from "./BytesInput";


### PR DESCRIPTION
### Context : 

This was introduced in #688 which we recently merged. We removed "use client" from components like `AddressInput`, `EtherInput` etc in #688 because there was lint warning in them as mentioned in #686. 

### Reason why #698 happened : 

![Screenshot 2024-01-23 at 8 03 18 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/b19cbf82-41f9-49ee-9a09-cf031da2a99c)


If you look at the error it occurred at `blockexplorer/address/[address]/page.tsx` and the cause of the error is `AddressInput`, but we are not using `AddressInput` anywhere instead we are using `Address` component which comes from `~~/components/scaffold-eth/index.ts` barrel file and since this barrel file also exports inputs barrel we are indirectly importing `AddressInput` in address page (although we are not using it). 


### Solution : 

I would suggest going through this comment discussion https://github.com/vercel/next.js/discussions/46795#discussioncomment-5248407 once its really nice. 

For now, I added a quick fix which is completely fine. An alternate solution is we can add "use client" to `~~/components/scaffold-eth/index.ts` since all the SE-2 components are reactive and expected to be used on the client. 

But yeah I think a future-proof solution might be removing barrel files at least from the components  folder
