### PR TITLE
Add Optimism Sepolia config

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -74,6 +74,10 @@ const config: HardhatUserConfig = {
       url: `https://opt-goerli.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
+    optimismSepolia: {
+      url: `https://opt-sepolia.g.alchemy.com/v2/${providerApiKey}`,
+      accounts: [deployerPrivateKey],
+    },
     polygon: {
       url: `https://polygon-mainnet.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -70,10 +70,6 @@ const config: HardhatUserConfig = {
       url: `https://opt-mainnet.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
-    optimismGoerli: {
-      url: `https://opt-goerli.g.alchemy.com/v2/${providerApiKey}`,
-      accounts: [deployerPrivateKey],
-    },
     optimismSepolia: {
       url: `https://opt-sepolia.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -35,6 +35,9 @@ export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
     color: "#92D9FA",
     nativeCurrencyTokenAddress: "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
   },
+  [chains.optimismSepolia.id]: {
+    color: "#f01a37",
+  },
   [chains.optimismGoerli.id]: {
     color: "#f01a37",
   },

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -38,9 +38,6 @@ export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
   [chains.optimismSepolia.id]: {
     color: "#f01a37",
   },
-  [chains.optimismGoerli.id]: {
-    color: "#f01a37",
-  },
   [chains.optimism.id]: {
     color: "#f01a37",
   },


### PR DESCRIPTION
## Description

Optimism testnet migrated from Optimism Goerli to Optimism Sepolia early this year, as per this [announcement](https://blog.oplabs.co/op-sepolia/). The [testnet faucets](https://app.optimism.io/faucet) now all drip Sepolia. Proposing this PR to keep up with this migration. 

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Your ENS/address: winnster.eth
