### PR TITLE
improve debug struct UI

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/ContractInput.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractInput.tsx
@@ -73,8 +73,8 @@ export const ContractInput = ({ setForm, form, stateObjectKey, paramType }: Cont
   };
 
   return (
-    <div className="flex flex-col gap-1 w-full">
-      <div className="flex items-center">
+    <div className="flex flex-col gap-1.5 w-full">
+      <div className="flex items-center ml-2">
         {paramType.name && <span className="text-xs font-medium mr-2 leading-none">{paramType.name}</span>}
         <span className="block text-xs font-extralight leading-none">{paramType.type}</span>
       </div>

--- a/packages/nextjs/app/debug/_components/contract/ContractInput.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractInput.tsx
@@ -73,7 +73,7 @@ export const ContractInput = ({ setForm, form, stateObjectKey, paramType }: Cont
   };
 
   return (
-    <div className="flex flex-col gap-1 w-full pl-2">
+    <div className="flex flex-col gap-1 w-full">
       <div className="flex items-center">
         {paramType.name && <span className="text-xs font-medium mr-2 leading-none">{paramType.name}</span>}
         <span className="block text-xs font-extralight leading-none">{paramType.type}</span>

--- a/packages/nextjs/app/debug/_components/contract/Tuple.tsx
+++ b/packages/nextjs/app/debug/_components/contract/Tuple.tsx
@@ -27,7 +27,7 @@ export const Tuple = ({ abiTupleParameter, setParentForm, parentStateObjectKey }
 
   return (
     <div>
-      <div className="collapse collapse-arrow">
+      <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 mt-1 border-2 border-secondary">
         <input type="checkbox" className="min-h-fit peer" />
         <div className="collapse-title p-0 min-h-fit peer-checked:mb-2">
           <p className="m-0 p-0 text-[1rem]">{abiTupleParameter.internalType}</p>

--- a/packages/nextjs/app/debug/_components/contract/Tuple.tsx
+++ b/packages/nextjs/app/debug/_components/contract/Tuple.tsx
@@ -29,7 +29,7 @@ export const Tuple = ({ abiTupleParameter, setParentForm, parentStateObjectKey }
     <div>
       <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 border-2 border-secondary">
         <input type="checkbox" className="min-h-fit peer" />
-        <div className="collapse-title p-0 min-h-fit peer-checked:mb-2 text-accent">
+        <div className="collapse-title p-0 min-h-fit peer-checked:mb-2 text-primary-content/50">
           <p className="m-0 p-0 text-[1rem]">{abiTupleParameter.internalType}</p>
         </div>
         <div className="ml-3 flex-col space-y-4 border-secondary/80 border-l-2 pl-4 collapse-content">

--- a/packages/nextjs/app/debug/_components/contract/Tuple.tsx
+++ b/packages/nextjs/app/debug/_components/contract/Tuple.tsx
@@ -32,7 +32,7 @@ export const Tuple = ({ abiTupleParameter, setParentForm, parentStateObjectKey }
         <div className="collapse-title p-0 min-h-fit peer-checked:mb-2">
           <p className="m-0 p-0 text-[1rem]">{abiTupleParameter.internalType}</p>
         </div>
-        <div className="ml-3 flex-col space-y-4 border-secondary/80 border-l-2 pl-2 collapse-content">
+        <div className="ml-3 flex-col space-y-4 border-secondary/80 border-l-2 pl-4 collapse-content">
           {abiTupleParameter?.components?.map((param, index) => {
             const key = getFunctionInputKey(abiTupleParameter.name || "tuple", param, index);
             return <ContractInput setForm={setForm} form={form} key={key} stateObjectKey={key} paramType={param} />;

--- a/packages/nextjs/app/debug/_components/contract/Tuple.tsx
+++ b/packages/nextjs/app/debug/_components/contract/Tuple.tsx
@@ -27,7 +27,7 @@ export const Tuple = ({ abiTupleParameter, setParentForm, parentStateObjectKey }
 
   return (
     <div>
-      <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 border-2 border-secondary">
+      <div className="collapse collapse-arrow bg-base-200 pl-4 py-1.5 border-2 border-secondary">
         <input type="checkbox" className="min-h-fit peer" />
         <div className="collapse-title p-0 min-h-fit peer-checked:mb-2 text-primary-content/50">
           <p className="m-0 p-0 text-[1rem]">{abiTupleParameter.internalType}</p>

--- a/packages/nextjs/app/debug/_components/contract/Tuple.tsx
+++ b/packages/nextjs/app/debug/_components/contract/Tuple.tsx
@@ -27,9 +27,9 @@ export const Tuple = ({ abiTupleParameter, setParentForm, parentStateObjectKey }
 
   return (
     <div>
-      <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 mt-1 border-2 border-secondary">
+      <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 border-2 border-secondary">
         <input type="checkbox" className="min-h-fit peer" />
-        <div className="collapse-title p-0 min-h-fit peer-checked:mb-2">
+        <div className="collapse-title p-0 min-h-fit peer-checked:mb-2 text-accent">
           <p className="m-0 p-0 text-[1rem]">{abiTupleParameter.internalType}</p>
         </div>
         <div className="ml-3 flex-col space-y-4 border-secondary/80 border-l-2 pl-4 collapse-content">

--- a/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
@@ -105,9 +105,9 @@ export const TupleArray = ({ abiTupleParameter, setParentForm, parentStateObject
         <div className="ml-3 flex-col space-y-2 border-secondary/70 border-l-2 pl-4 collapse-content">
           {additionalInputs.map((additionalInput, additionalIndex) => (
             <div key={additionalIndex} className="space-y-1">
-              <p className="m-0 ml-2 text-[0.95rem]">
+              <span className="badge badge-secondary badge-sm">
                 {depth > 1 ? `${additionalIndex}` : `tuple[${additionalIndex}]`}
-              </p>
+              </span>
               <div className="space-y-4">
                 {additionalInput.map((param, index) => {
                   const key = getFunctionInputKey(

--- a/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
@@ -97,7 +97,7 @@ export const TupleArray = ({ abiTupleParameter, setParentForm, parentStateObject
 
   return (
     <div>
-      <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 border-2 border-secondary">
+      <div className="collapse collapse-arrow bg-base-200 pl-4 py-1.5 border-2 border-secondary">
         <input type="checkbox" className="min-h-fit peer" />
         <div className="collapse-title p-0 min-h-fit peer-checked:mb-1 text-primary-content/50">
           <p className="m-0 text-[1rem]">{abiTupleParameter.internalType}</p>

--- a/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
@@ -123,11 +123,11 @@ export const TupleArray = ({ abiTupleParameter, setParentForm, parentStateObject
             </div>
           ))}
           <div className="flex space-x-2">
-            <button className="btn btn-sm" onClick={addInput}>
+            <button className="btn btn-sm btn-secondary" onClick={addInput}>
               +
             </button>
             {additionalInputs.length > 0 && (
-              <button className="btn btn-sm" onClick={removeInput}>
+              <button className="btn btn-sm btn-secondary" onClick={removeInput}>
                 -
               </button>
             )}

--- a/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
@@ -97,9 +97,9 @@ export const TupleArray = ({ abiTupleParameter, setParentForm, parentStateObject
 
   return (
     <div>
-      <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 mt-1 border-2 border-secondary">
+      <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 border-2 border-secondary">
         <input type="checkbox" className="min-h-fit peer" />
-        <div className="collapse-title p-0 min-h-fit peer-checked:mb-1">
+        <div className="collapse-title p-0 min-h-fit peer-checked:mb-1 text-accent">
           <p className="m-0 text-[1rem]">{abiTupleParameter.internalType}</p>
         </div>
         <div className="ml-3 flex-col space-y-2 border-secondary/70 border-l-2 pl-4 collapse-content">

--- a/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
@@ -97,7 +97,7 @@ export const TupleArray = ({ abiTupleParameter, setParentForm, parentStateObject
 
   return (
     <div>
-      <div className="collapse collapse-arrow">
+      <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 mt-1 border-2 border-secondary">
         <input type="checkbox" className="min-h-fit peer" />
         <div className="collapse-title p-0 min-h-fit peer-checked:mb-1">
           <p className="m-0 text-[1rem]">{abiTupleParameter.internalType}</p>

--- a/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
@@ -99,7 +99,7 @@ export const TupleArray = ({ abiTupleParameter, setParentForm, parentStateObject
     <div>
       <div className="collapse collapse-arrow bg-base-200 pl-2 py-1.5 border-2 border-secondary">
         <input type="checkbox" className="min-h-fit peer" />
-        <div className="collapse-title p-0 min-h-fit peer-checked:mb-1 text-accent">
+        <div className="collapse-title p-0 min-h-fit peer-checked:mb-1 text-primary-content/50">
           <p className="m-0 text-[1rem]">{abiTupleParameter.internalType}</p>
         </div>
         <div className="ml-3 flex-col space-y-2 border-secondary/70 border-l-2 pl-4 collapse-content">

--- a/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
@@ -105,7 +105,7 @@ export const TupleArray = ({ abiTupleParameter, setParentForm, parentStateObject
         <div className="ml-3 flex-col space-y-2 border-secondary/70 border-l-2 pl-4 collapse-content">
           {additionalInputs.map((additionalInput, additionalIndex) => (
             <div key={additionalIndex} className="space-y-1">
-              <span className="badge badge-secondary badge-sm">
+              <span className="badge bg-base-300 badge-sm">
                 {depth > 1 ? `${additionalIndex}` : `tuple[${additionalIndex}]`}
               </span>
               <div className="space-y-4">

--- a/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TupleArray.tsx
@@ -102,7 +102,7 @@ export const TupleArray = ({ abiTupleParameter, setParentForm, parentStateObject
         <div className="collapse-title p-0 min-h-fit peer-checked:mb-1">
           <p className="m-0 text-[1rem]">{abiTupleParameter.internalType}</p>
         </div>
-        <div className="ml-3 flex-col space-y-2 border-secondary/70 border-l-2 pl-2 collapse-content">
+        <div className="ml-3 flex-col space-y-2 border-secondary/70 border-l-2 pl-4 collapse-content">
           {additionalInputs.map((additionalInput, additionalIndex) => (
             <div key={additionalIndex} className="space-y-1">
               <p className="m-0 ml-2 text-[0.95rem]">

--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -100,14 +100,20 @@ export const WriteOnlyFunctionForm = ({
         </p>
         {inputs}
         {abiFunction.stateMutability === "payable" ? (
-          <IntegerInput
-            value={txValue}
-            onChange={updatedTxValue => {
-              setDisplayedTxResult(undefined);
-              setTxValue(updatedTxValue);
-            }}
-            placeholder="value (wei)"
-          />
+          <div className="flex flex-col gap-1.5 w-full">
+            <div className="flex items-center ml-2">
+              <span className="text-xs font-medium mr-2 leading-none">payable value</span>
+              <span className="block text-xs font-extralight leading-none">wei</span>
+            </div>
+            <IntegerInput
+              value={txValue}
+              onChange={updatedTxValue => {
+                setDisplayedTxResult(undefined);
+                setTxValue(updatedTxValue);
+              }}
+              placeholder="value (wei)"
+            />
+          </div>
         ) : null}
         <div className="flex justify-between gap-2">
           {!zeroInputs && (


### PR DESCRIPTION
First iteration on #725 

### 1. Fix padding 
This odd padding won't let me sleep haha (also making sure the inner structs padding looks good too)
![304829304-0d18fc28-b681-48f1-bf40-1f7644d62207](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/f92354ea-417a-491b-8b77-d1a4cb001a96)

Now: 
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/4569fd88-8047-447b-8558-53442d47e349)

As Shiv mentioned, maybe it's a good idea to have a label on the value input too.

### Fix accordion style
In the current version, the text felt a bit "lost"
![304828797-4416cf52-a63f-4030-b983-49025fac8f5e](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/2f3ca58b-4141-4a74-99cc-5f3da5b108f9)

Made a couple of tweaks:
1. add some background
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/429ec4bc-833c-4de0-b7f5-21a5add3a35c)
2. Add a border. If not, the inner struct will have the same problem (its background is the same as the parent bg). A border fixed it
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/0af16c29-0c3e-4905-a0ff-03f5150a7493)

----

We can add more stuff here, or keep iterating in another PR.
