### PR TITLE
Fix cursor stealing & display loading for AddressInput

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -11,7 +11,7 @@ import { CommonInputProps, InputBase, isENS } from "~~/components/scaffold-eth";
 export const AddressInput = ({ value, name, placeholder, onChange, disabled }: CommonInputProps<Address | string>) => {
   // Debounce the input to keep clean RPC calls when resolving ENS names
   // If the input is an address, we don't need to debounce it
-  const [_debouncedValue] = useDebounceValue(value, 900);
+  const [_debouncedValue] = useDebounceValue(value, 500);
   const debouncedValue = isAddress(value) ? value : _debouncedValue;
   const isDebouncedValueLive = debouncedValue === value;
 

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { blo } from "blo";
-import { useDebounce } from "usehooks-ts";
+import { useDebounceValue } from "usehooks-ts";
 import { Address, isAddress } from "viem";
 import { useEnsAddress, useEnsAvatar, useEnsName } from "wagmi";
 import { CommonInputProps, InputBase, isENS } from "~~/components/scaffold-eth";
@@ -11,7 +11,7 @@ import { CommonInputProps, InputBase, isENS } from "~~/components/scaffold-eth";
 export const AddressInput = ({ value, name, placeholder, onChange, disabled }: CommonInputProps<Address | string>) => {
   // Debounce the input to keep clean RPC calls when resolving ENS names
   // If the input is an address, we don't need to debounce it
-  const _debouncedValue = useDebounce(value, 900);
+  const [_debouncedValue] = useDebounceValue(value, 900);
   const debouncedValue = isAddress(value) ? value : _debouncedValue;
   const isDebouncedValueLive = debouncedValue === value;
 

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -21,8 +21,8 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
   const {
     data: ensAddress,
     isLoading: isEnsAddressLoading,
-    isError: ensAddressError,
-    isSuccess: ensAddressSuccess,
+    isError: isEnsAddressError,
+    isSuccess: isEnsAddressSuccess,
   } = useEnsAddress({
     name: settledValue,
     enabled: isDebouncedValueLive && isENS(debouncedValue),
@@ -34,8 +34,8 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
   const {
     data: ensName,
     isLoading: isEnsNameLoading,
-    isError: ensNameError,
-    isSuccess: ensNameSuccess,
+    isError: isEnsNameError,
+    isSuccess: isEnsNameSuccess,
   } = useEnsName({
     address: settledValue as Address,
     enabled: isAddress(debouncedValue),
@@ -68,7 +68,13 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
   );
 
   const reFocus =
-    ensAddressError || ensNameError || ensNameSuccess || ensAddressSuccess || ensName === null || ensAddress === null;
+    isEnsAddressError ||
+    isEnsNameError ||
+    isEnsNameSuccess ||
+    isEnsAddressSuccess ||
+    ensName === null ||
+    ensAddress === null;
+
   return (
     <InputBase<Address>
       name={name}

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -43,7 +43,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
     cacheTime: 30_000,
   });
 
-  const { data: ensAvatar } = useEnsAvatar({
+  const { data: ensAvatar, isLoading: isEnsAvtarLoading } = useEnsAvatar({
     name: ensName,
     enabled: Boolean(ensName),
     chainId: 1,
@@ -87,6 +87,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
       prefix={
         ensName ? (
           <div className="flex bg-base-300 rounded-l-full items-center">
+            {isEnsAvtarLoading && <div className="skeleton bg-base-200 w-[35px] h-[35px] rounded-full shrink-0"></div>}
             {ensAvatar ? (
               <span className="w-[35px]">
                 {
@@ -98,15 +99,10 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
             <span className="text-accent px-2">{enteredEnsName ?? ensName}</span>
           </div>
         ) : (
-          (isEnsAddressLoading || isEnsNameLoading) && (
-            <div className="flex bg-base-300 rounded-l-full items-center">
-              <div className="w-[35px]">
-                <div className="h-[35px] w-[35px] rounded-full bg-gray-500 animate-pulse"></div>
-              </div>
-              <div className="text-accent px-2 flex items-end space-x-1">
-                <span>Resolving</span>
-                <span className="loading loading-dots loading-xs"></span>
-              </div>
+          (isEnsNameLoading || isEnsAddressLoading) && (
+            <div className="flex bg-base-300 rounded-l-full items-center gap-2 pr-2">
+              <div className="skeleton bg-base-200 w-[35px] h-[35px] rounded-full shrink-0"></div>
+              <div className="skeleton bg-base-200 h-3 w-20"></div>
             </div>
           )
         )

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -22,6 +22,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
     data: ensAddress,
     isLoading: isEnsAddressLoading,
     isError: ensAddressError,
+    isSuccess: ensAddressSuccess,
   } = useEnsAddress({
     name: settledValue,
     enabled: isDebouncedValueLive && isENS(debouncedValue),
@@ -34,6 +35,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
     data: ensName,
     isLoading: isEnsNameLoading,
     isError: ensNameError,
+    isSuccess: ensNameSuccess,
   } = useEnsName({
     address: settledValue as Address,
     enabled: isAddress(debouncedValue),
@@ -65,7 +67,8 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
     [onChange],
   );
 
-  const reFocus = ensAddressError || ensNameError || ensName === null || ensAddress === null;
+  const reFocus =
+    ensAddressError || ensNameError || ensNameSuccess || ensAddressSuccess || ensName === null || ensAddress === null;
   return (
     <InputBase<Address>
       name={name}

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ReactNode, useCallback, useEffect, useRef } from "react";
+import { ChangeEvent, FocusEvent, ReactNode, useCallback, useEffect, useRef } from "react";
 import { CommonInputProps } from "~~/components/scaffold-eth";
 
 type InputBaseProps<T> = CommonInputProps<T> & {
@@ -35,8 +35,16 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
     [onChange],
   );
 
+  // Runs only when reFocus prop is passed, usefull for setting the cursor
+  // at the end of the input. Example AddressInput
+  const onFocus = (e: FocusEvent<HTMLInputElement, Element>) => {
+    if (reFocus !== undefined) {
+      console.log("Running OnFocus", reFocus);
+      e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length);
+    }
+  };
   useEffect(() => {
-    if (reFocus) inputReft.current?.focus();
+    if (reFocus !== undefined && reFocus === true) inputReft.current?.focus();
   }, [reFocus]);
 
   return (
@@ -51,6 +59,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
         disabled={disabled}
         autoComplete="off"
         ref={inputReft}
+        onFocus={onFocus}
       />
       {suffix}
     </div>

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -39,7 +39,6 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   // at the end of the input. Example AddressInput
   const onFocus = (e: FocusEvent<HTMLInputElement, Element>) => {
     if (reFocus !== undefined) {
-      console.log("Running OnFocus", reFocus);
       e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length);
     }
   };

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -1,10 +1,11 @@
-import { ChangeEvent, ReactNode, useCallback } from "react";
+import { ChangeEvent, ReactNode, useCallback, useEffect, useRef } from "react";
 import { CommonInputProps } from "~~/components/scaffold-eth";
 
 type InputBaseProps<T> = CommonInputProps<T> & {
   error?: boolean;
   prefix?: ReactNode;
   suffix?: ReactNode;
+  reFocus?: boolean;
 };
 
 export const InputBase = <T extends { toString: () => string } | undefined = string>({
@@ -16,7 +17,10 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   disabled,
   prefix,
   suffix,
+  reFocus,
 }: InputBaseProps<T>) => {
+  const inputReft = useRef<HTMLInputElement>(null);
+
   let modifier = "";
   if (error) {
     modifier = "border-error";
@@ -31,6 +35,10 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
     [onChange],
   );
 
+  useEffect(() => {
+    if (reFocus) inputReft.current?.focus();
+  }, [reFocus]);
+
   return (
     <div className={`flex border-2 border-base-300 bg-base-200 rounded-full text-accent ${modifier}`}>
       {prefix}
@@ -42,6 +50,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
         onChange={handleChange}
         disabled={disabled}
         autoComplete="off"
+        ref={inputReft}
       />
       {suffix}
     </div>


### PR DESCRIPTION
## Description

### Reason for #710:

#### How AddressInput internally works:

- We have debounce time of 500ms for the input field.
- Actually we have isEns util which when true (carletex.e is valid ens), the hook useEnsAddress makes a request for corresponding ENS address
- We are disabling the input filed when the request is in progress.
- Input focus looses when its is disabled (it does not regain focus when enabled again)

#### Cause of the issue:

1. Since we have 500ms debounce time, as soon as you write carletex.e (valid ens), the request is made and input is disabled.So if there is delay >= 500ms b/w "e" & "t" of "eth" then input looses focus(and our key strokes are not registered).

### Solution:

1. Increase the debounce time to 900ms (So we give user a bit more window to type in "eth").
2. Incase the user is slow typer, We refocus the input after trying to resolve the ens address.

#### Some minor tweak to imporve UX:

1. Show "Resolving..." indicator when request is in progress(To just tell user the keystrokes won't be registered and some background process is going on)
2. Re focusing the input if there was error, success etc, So that user can continue typing if there was typo or wants to update to new value.

### Demo: 


https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/4ad2f1cb-146c-4be5-b465-477d06eab169

Closes #710 