### PR TITLE
fix contract code tab in blockexplorer

### DIFF
--- a/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
@@ -60,7 +60,7 @@ const getContractData = async (address: string) => {
 
   const deployedContractsOnChain = contracts ? contracts[chainId] : {};
   for (const [contractName, contractInfo] of Object.entries(deployedContractsOnChain)) {
-    if (contractInfo.address.toLowerCase() === address) {
+    if (contractInfo.address.toLowerCase() === address.toLowerCase()) {
       contractPath = `contracts/${contractName}.sol`;
       break;
     }


### PR DESCRIPTION
## Description

Actually in #734, we are now using ERC-55 [checksum](https://viem.sh/docs/utilities/getAddress) format in address because of which `contractInfo.address.toLowerCase() === address` was failing and we were displaying empty thing in `code tab` of blockexplorer

| Before | After | 
| ------- | ----- | 
| ![Screenshot 2024-02-26 at 8 33 49 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/d26735d8-adc9-434a-8785-9f14ee8801b5) | ![Screenshot 2024-02-26 at 8 34 33 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/62484011-a89d-4d1e-87f2-a715fde04a70) | 

Noticed this while testing #740 

