### PR TITLE
Match link name with actual tab name in Homepage

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -46,7 +46,7 @@ const Home: NextPage = () => {
               <p>
                 Tinker with your smart contract using the{" "}
                 <Link href="/debug" passHref className="link">
-                  Debug Contract
+                  Debug Contracts
                 </Link>{" "}
                 tab.
               </p>


### PR DESCRIPTION
## Description

This PR changes Debug Contract to Debug Contracts in the homepage card since the actual tab name is "Debug Contracts".

Before:
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/108868128/749f1fee-68bf-4440-8802-d56ed7a7e984)

After:
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/108868128/055ef12c-894a-43a6-8b96-38feaca6501a)

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
