### PR TITLE
Cli add prettier task

### DIFF
--- a/.changeset/silly-coins-share.md
+++ b/.changeset/silly-coins-share.md
@@ -1,0 +1,5 @@
+---
+"create-eth": patch
+---
+
+Add format with prettier task

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import {
   createProjectDirectory,
   installPackages,
   createFirstGitCommit,
+  prettierFormat,
 } from "./tasks";
 import type { Options } from "./types";
 import { renderOutroMessage } from "./utils/render-outro-message";
@@ -43,6 +44,10 @@ export async function createProject(options: Options) {
           return "Manually skipped";
         }
       },
+    },
+    {
+      title: "🪄 Formatting files with prettier",
+      task: () => prettierFormat(targetDirectory),
     },
     {
       title: `📡 Initializing Git repository ${

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -2,3 +2,4 @@ export * from "./copy-template-files";
 export * from "./create-project-directory";
 export * from "./install-packages";
 export * from "./create-first-git-commit";
+export * from "./prettier-format";

--- a/src/tasks/prettier-format.ts
+++ b/src/tasks/prettier-format.ts
@@ -1,0 +1,15 @@
+import { execa } from "execa";
+
+export async function prettierFormat(targetDir: string) {
+  try {
+    const result = await execa("yarn", ["format"], { cwd: targetDir });
+
+    if (result.failed) {
+      throw new Error("There was a problem running the format commend");
+    }
+  } catch (error) {
+    throw new Error("Failed to create directory", { cause: error });
+  }
+
+  return true;
+}

--- a/src/tasks/prettier-format.ts
+++ b/src/tasks/prettier-format.ts
@@ -5,7 +5,7 @@ export async function prettierFormat(targetDir: string) {
     const result = await execa("yarn", ["format"], { cwd: targetDir });
 
     if (result.failed) {
-      throw new Error("There was a problem running the format commend");
+      throw new Error("There was a problem running the format command");
     }
   } catch (error) {
     throw new Error("Failed to create directory", { cause: error });

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -13,6 +13,7 @@
     "next:lint": "yarn workspace @se-2/nextjs lint",
     "next:format": "yarn workspace @se-2/nextjs format",
     "next:check-types": "yarn workspace @se-2/nextjs check-types",
+    "format": "yarn next:format",
     "postinstall": "husky install",
     "precommit": "lint-staged",
     "vercel": "yarn workspace @se-2/nextjs vercel",

--- a/templates/extensions/foundry/package.json
+++ b/templates/extensions/foundry/package.json
@@ -8,8 +8,10 @@
     "deploy:verify": "yarn workspace @se-2/foundry deploy:verify",
     "foundry:lint": "yarn workspace @se-2/foundry lint",
     "foundry:test": "yarn workspace @se-2/foundry test",
+    "foundry:format": "yarn workspace @se-2/foundry format",
     "test": "yarn foundry:test",
     "verify": "yarn workspace @se-2/foundry verify",
-    "generate": "yarn workspace @se-2/foundry generate"
+    "generate": "yarn workspace @se-2/foundry generate",
+    "format": "yarn next:format && yarn foundry:format"
   }
 }

--- a/templates/extensions/foundry/packages/foundry/.prettier.json
+++ b/templates/extensions/foundry/packages/foundry/.prettier.json
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/templates/extensions/foundry/packages/foundry/contracts/YourContract.sol
+++ b/templates/extensions/foundry/packages/foundry/contracts/YourContract.sol
@@ -73,7 +73,7 @@ contract YourContract {
      * The function can only be called by the owner of the contract as defined by the isOwner modifier
      */
     function withdraw() public isOwner {
-        (bool success, ) = owner.call{value: address(this).balance}("");
+        (bool success,) = owner.call{value: address(this).balance}("");
         require(success, "Failed to send Ether");
     }
 

--- a/templates/extensions/foundry/packages/foundry/foundry.toml
+++ b/templates/extensions/foundry/packages/foundry/foundry.toml
@@ -33,4 +33,9 @@ scroll = "https://rpc.scroll.io"
 polygonMumbai = { key = "${ETHERSCAN_API_KEY}" }
 goerli = { key = "${ETHERSCAN_API_KEY}" }
 
+
+[fmt]
+line_length = 80
+multiline_func_header = "params_first"
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/templates/extensions/foundry/packages/foundry/package.json
+++ b/templates/extensions/foundry/packages/foundry/package.json
@@ -10,7 +10,8 @@
     "deploy": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${1:-default_network} --broadcast --legacy && node script/generateTsAbis.js",
     "deploy:verify": "forge build --build-info --build-info-path out/build-info/ && forge script script/Deploy.s.sol --rpc-url ${1:-default_network} --broadcast --legacy --verify ; node script/generateTsAbis.js",
     "verify": "forge build --build-info --build-info-path out/build-info/ && forge script script/VerifyAll.s.sol --ffi --rpc-url ${1:-default_network}",
-    "lint": "forge fmt",
+    "lint": "forge fmt --check && prettier --check ./script/**/*.js",
+    "format": "forge fmt && prettier --write ./script/**/*.js",
     "test": "forge test"
   },
   "devDependencies": {

--- a/templates/extensions/foundry/packages/foundry/script/Deploy.s.sol
+++ b/templates/extensions/foundry/packages/foundry/script/Deploy.s.sol
@@ -15,13 +15,11 @@ contract DeployScript is ScaffoldETHDeploy {
             );
         }
         vm.startBroadcast(deployerPrivateKey);
-        YourContract yourContract = new YourContract(
-            vm.addr(deployerPrivateKey)
-        );
+        YourContract yourContract =
+            new YourContract(vm.addr(deployerPrivateKey));
         console.logString(
             string.concat(
-                "YourContract deployed at: ",
-                vm.toString(address(yourContract))
+                "YourContract deployed at: ", vm.toString(address(yourContract))
             )
         );
         vm.stopBroadcast();

--- a/templates/extensions/foundry/packages/foundry/script/DeployHelpers.s.sol
+++ b/templates/extensions/foundry/packages/foundry/script/DeployHelpers.s.sol
@@ -45,9 +45,7 @@ contract ScaffoldETHDeploy is Script {
 
         for (uint256 i = 0; i < len; i++) {
             vm.serializeString(
-                jsonWrite,
-                vm.toString(deployments[i].addr),
-                deployments[i].name
+                jsonWrite, vm.toString(deployments[i].addr), deployments[i].name
             );
         }
 

--- a/templates/extensions/foundry/packages/foundry/script/VerifyAll.s.sol
+++ b/templates/extensions/foundry/packages/foundry/script/VerifyAll.s.sol
@@ -10,7 +10,6 @@ import "solidity-bytes-utils/BytesLib.sol";
  * @notice calls the tryffi function on the Vm contract
  * @notice will be deleted once the forge/std is updated
  */
-
 struct FfiResult {
     int32 exit_code;
     bytes stdout;
@@ -43,8 +42,7 @@ contract VerifyAll is Script {
     function _verifyIfContractDeployment(string memory content) internal {
         string memory txType = abi.decode(
             vm.parseJson(
-                content,
-                searchStr(currTransactionIdx, "transactionType")
+                content, searchStr(currTransactionIdx, "transactionType")
             ),
             (string)
         );
@@ -55,31 +53,23 @@ contract VerifyAll is Script {
 
     function _verifyContract(string memory content) internal {
         string memory contractName = abi.decode(
-            vm.parseJson(
-                content,
-                searchStr(currTransactionIdx, "contractName")
-            ),
+            vm.parseJson(content, searchStr(currTransactionIdx, "contractName")),
             (string)
         );
         address contractAddr = abi.decode(
             vm.parseJson(
-                content,
-                searchStr(currTransactionIdx, "contractAddress")
+                content, searchStr(currTransactionIdx, "contractAddress")
             ),
             (address)
         );
         bytes memory deployedBytecode = abi.decode(
             vm.parseJson(
-                content,
-                searchStr(currTransactionIdx, "transaction.data")
+                content, searchStr(currTransactionIdx, "transaction.data")
             ),
             (bytes)
         );
         bytes memory compiledBytecode = abi.decode(
-            vm.parseJson(
-                _getCompiledBytecode(contractName),
-                ".bytecode.object"
-            ),
+            vm.parseJson(_getCompiledBytecode(contractName), ".bytecode.object"),
             (bytes)
         );
         bytes memory constructorArgs = BytesLib.slice(
@@ -115,9 +105,11 @@ contract VerifyAll is Script {
         return;
     }
 
-    function nextTransaction(
-        string memory content
-    ) external view returns (bool) {
+    function nextTransaction(string memory content)
+        external
+        view
+        returns (bool)
+    {
         try this.getTransactionFromRaw(content, currTransactionIdx) {
             return true;
         } catch {
@@ -125,17 +117,14 @@ contract VerifyAll is Script {
         }
     }
 
-    function _getCompiledBytecode(
-        string memory contractName
-    ) internal view returns (string memory compiledBytecode) {
+    function _getCompiledBytecode(string memory contractName)
+        internal
+        view
+        returns (string memory compiledBytecode)
+    {
         string memory root = vm.projectRoot();
         string memory path = string.concat(
-            root,
-            "/out/",
-            contractName,
-            ".sol/",
-            contractName,
-            ".json"
+            root, "/out/", contractName, ".sol/", contractName, ".json"
         );
         compiledBytecode = vm.readFile(path);
     }

--- a/templates/extensions/foundry/packages/foundry/script/generateTsAbis.js
+++ b/templates/extensions/foundry/packages/foundry/script/generateTsAbis.js
@@ -39,7 +39,9 @@ function getInheritedFromContracts(artifact) {
   for (const astNode of artifact.ast.nodes) {
     if (astNode.nodeType == "ContractDefinition") {
       if (astNode.baseContracts.length > 0) {
-        inheritedFromContracts = astNode.baseContracts.map(({baseName}) => baseName.name);
+        inheritedFromContracts = astNode.baseContracts.map(
+          ({ baseName }) => baseName.name
+        );
       }
     }
   }
@@ -103,9 +105,7 @@ function main() {
       ] = {
         address: transaction.contractAddress,
         abi: artifact.abi,
-        inheritedFunctions: getInheritedFunctions(
-          artifact,
-        ),
+        inheritedFunctions: getInheritedFunctions(artifact),
       };
     });
   });

--- a/templates/extensions/foundry/packages/foundry/test/YourContract.t.sol
+++ b/templates/extensions/foundry/packages/foundry/test/YourContract.t.sol
@@ -13,16 +13,16 @@ contract YourContractTest is Test {
 
     function testMessageOnDeployment() public view {
         require(
-            keccak256(bytes(yourContract.greeting())) ==
-                keccak256("Building Unstoppable Apps!!!")
+            keccak256(bytes(yourContract.greeting()))
+                == keccak256("Building Unstoppable Apps!!!")
         );
     }
 
     function testSetNewMessage() public {
         yourContract.setGreeting("Learn Scaffold-ETH 2! :)");
         require(
-            keccak256(bytes(yourContract.greeting())) ==
-                keccak256("Learn Scaffold-ETH 2! :)")
+            keccak256(bytes(yourContract.greeting()))
+                == keccak256("Learn Scaffold-ETH 2! :)")
         );
     }
 }

--- a/templates/extensions/hardhat/package.json
+++ b/templates/extensions/hardhat/package.json
@@ -10,7 +10,9 @@
     "generate": "yarn workspace @se-2/hardhat generate",
     "hardhat:lint": "yarn workspace @se-2/hardhat lint",
     "hardhat:lint-staged": "yarn workspace @se-2/hardhat lint-staged",
+    "hardhat:format": "yarn workspace @se-2/hardhat format",
     "hardhat:test": "yarn workspace @se-2/hardhat test",
-    "test": "yarn hardhat:test"
+    "test": "yarn hardhat:test",
+    "format": "yarn next:format && yarn hardhat:format"
   }
 }

--- a/templates/extensions/hardhat/packages/hardhat/package.json
+++ b/templates/extensions/hardhat/packages/hardhat/package.json
@@ -10,6 +10,7 @@
     "generate": "hardhat run scripts/generateAccount.ts",
     "lint": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore ./*.ts ./deploy/**/*.ts ./scripts/**/*.ts ./test/**/*.ts",
     "lint-staged": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore",
+    "format": "prettier --write ./*.ts ./deploy/**/*.ts ./scripts/**/*.ts ./test/**/*.ts",
     "test": "REPORT_GAS=true hardhat test --network hardhat",
     "verify": "hardhat etherscan-verify",
     "hardhat-verify": "hardhat verify"


### PR DESCRIPTION
## Description

Since we have `.template.mjs` file eg [this](https://github.com/scaffold-eth/scaffold-eth-2/blob/cli/templates/base/packages/nextjs/app/blockexplorer/address/%5Baddress%5D/page.tsx.template.mjs). So when the whole project is scaffolded there are some prettier warning left for eg:  #748 logs. 

This PR: 
- Adds base `format` script in root package.json to format both hardhat and foundry
- Adds a new task  "🪄 Formatting files with prettier" to cli
- For foundry 
  - Added [fmt] in foundry.toml kindof inline with our hardhat configuration to format solidity files, formated .sol file with `forge fmt`
  - Formated `.js` file with prettier also added `.prettier.json` in `packages/foundry`
