### PR TITLE
Fix vercel deployment mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules
 .eslintcache
 .vscode/**
 .DS_Store
+.vercel

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "packageManager": "yarn@3.2.3",
   "devDependencies": {
     "husky": "^8.0.1",
-    "lint-staged": "^13.0.3"
+    "lint-staged": "^13.0.3",
+    "vercel": "^32.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "next:lint": "yarn workspace @se-2/nextjs lint",
     "next:format": "yarn workspace @se-2/nextjs format",
     "next:check-types": "yarn workspace @se-2/nextjs check-types",
+    "next:build": "yarn workspace @se-2/nextjs build",
     "postinstall": "husky install",
     "precommit": "lint-staged",
-    "vercel": "yarn workspace @se-2/nextjs vercel",
-    "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo"
+    "vercel": "vercel",
+    "vercel:yolo": "vercel --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true"
   },
   "packageManager": "yarn@3.2.3",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
+    "next": "^14.0.4",
     "vercel": "^32.4.1"
   }
 }

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -51,7 +51,6 @@
     "prettier": "^2.8.4",
     "tailwindcss": "^3.3.3",
     "type-fest": "^4.6.0",
-    "typescript": "^5.1.6",
-    "vercel": "^32.4.1"
+    "typescript": "^5.1.6"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "installCommand": "yarn install --frozen-lockfile",
+  "buildCommand": "yarn next:build",
+  "outputDirectory": "packages/nextjs/.next",
+  "framework": "nextjs"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,7 +1891,6 @@ __metadata:
     typescript: ^5.1.6
     use-debounce: ^8.0.4
     usehooks-ts: ^2.13.0
-    vercel: ^32.4.1
     viem: 1.19.9
     wagmi: 1.4.12
     zustand: ^4.1.2
@@ -12274,6 +12273,7 @@ __metadata:
   dependencies:
     husky: ^8.0.1
     lint-staged: ^13.0.3
+    vercel: ^32.4.1
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12273,6 +12273,7 @@ __metadata:
   dependencies:
     husky: ^8.0.1
     lint-staged: ^13.0.3
+    next: ^14.0.4
     vercel: ^32.4.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

My 99th try of trying to fix this. 

context #419 and all referenced PR inside it. 

Obviously there is a catch, had to add `next` as devDependency of monorepo because of https://github.com/orgs/vercel/discussions/6047 but now atleast it uploads whole monorepo (mainly `yarn.lock`) which fixes all the issues

Work flow doesn't change at all you just need to choose all defualt options and add vercel project : 


https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/32a76d20-c6e2-49fc-9072-bdac9f7a947b

