### PR TITLE
Fix useScaffoldContractWrite so it properly throws errors

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -3,7 +3,7 @@ import { useTargetNetwork } from "./useTargetNetwork";
 import { Abi, ExtractAbiFunctionNames } from "abitype";
 import { useContractWrite, useNetwork } from "wagmi";
 import { useDeployedContractInfo, useTransactor } from "~~/hooks/scaffold-eth";
-import { getParsedError, notification } from "~~/utils/scaffold-eth";
+import { notification } from "~~/utils/scaffold-eth";
 import { ContractAbi, ContractName, UseScaffoldWriteConfig } from "~~/utils/scaffold-eth/contract";
 
 type UpdatedArgs = Parameters<ReturnType<typeof useContractWrite<Abi, string, undefined>>["writeAsync"]>[0];
@@ -83,9 +83,7 @@ export const useScaffoldContractWrite = <
 
         return writeTxResult;
       } catch (e: any) {
-        const message = getParsedError(e);
-        notification.error(message);
-        throw new Error(e);
+        throw e;
       } finally {
         setIsMining(false);
       }

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -85,6 +85,7 @@ export const useScaffoldContractWrite = <
       } catch (e: any) {
         const message = getParsedError(e);
         notification.error(message);
+        throw new Error(e);
       } finally {
         setIsMining(false);
       }

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -95,7 +95,8 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
       }
       console.error("⚡️ ~ file: useTransactor.ts ~ error", error);
       const message = getParsedError(error);
-      throw new Error(message);
+      notification.error(message);
+      throw error;
     }
 
     return transactionHash;

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -95,7 +95,7 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
       }
       console.error("⚡️ ~ file: useTransactor.ts ~ error", error);
       const message = getParsedError(error);
-      notification.error(message);
+      throw new Error(message);
     }
 
     return transactionHash;


### PR DESCRIPTION
## Description

- These changes reflect what is summarized at the bottom of issue #753
- Added line 88 to useScaffoldContractWrite.ts and changed line 98 in useTransactor.tsx
- These changes throw errors forward to a function utilizing useScaffoldContractWrite, and removes one notification error to prevent duplicate error notifications displaying.

## Additional Information

- I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #753_

Your ENS/address:  zurriken.eth