### PR TITLE
remove extra notifications when using useTransactor

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -16,7 +16,6 @@ import {
 import { IntegerInput } from "~~/components/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
-import { getParsedError, notification } from "~~/utils/scaffold-eth";
 
 type WriteOnlyFunctionFormProps = {
   abi: Abi;
@@ -58,8 +57,7 @@ export const WriteOnlyFunctionForm = ({
         await writeTxn(makeWriteWithParams);
         onChange();
       } catch (e: any) {
-        const message = getParsedError(e);
-        notification.error(message);
+        console.error("⚡️ ~ file: WriteOnlyFunctionForm.tsx:handleWrite ~ error", e);
       }
     }
   };

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -7,7 +7,7 @@ import { useNetwork } from "wagmi";
 import { BanknotesIcon } from "@heroicons/react/24/outline";
 import { Address, AddressInput, Balance, EtherInput } from "~~/components/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth";
-import { getParsedError, notification } from "~~/utils/scaffold-eth";
+import { notification } from "~~/utils/scaffold-eth";
 
 // Account index to use from generated hardhat accounts.
 const FAUCET_ACCOUNT_INDEX = 0;
@@ -70,9 +70,7 @@ export const Faucet = () => {
       setInputAddress(undefined);
       setSendValue("");
     } catch (error) {
-      const parsedError = getParsedError(error);
       console.error("⚡️ ~ file: Faucet.tsx:sendETH ~ error", error);
-      notification.error(parsedError);
       setLoading(false);
     }
   };


### PR DESCRIPTION
## Description

Noticed this while testing #756, it was caused in #758 : 

https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/b85785fb-594e-4a9d-992c-17004c04a553

When you get an error while sending transaction, it shows notification two times, this is due to since in #758, we are not eating up error in `useTransactor` instead showing notification + throwing it forward. 

In 27468772f82636bbbdf7ebf04e5299094a3bd38d removed our own showing of notification or error again since its same already shown in `useTransactor`

For more details checkout : https://github.com/scaffold-eth/scaffold-eth-2/pull/758#pullrequestreview-1921719734