### PR TITLE
add .vercelignore

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,58 @@
+#Hardhat files
+
+packages/hardhat/node_modules
+packages/hardhat/.env
+packages/hardhat/coverage
+packages/hardhat/coverage.json
+packages/hardhat/typechain
+packages/hardhat/typechain-types
+packages/hardhat/temp
+
+packages/hardhat/cache
+packages/hardhat/artifacts
+
+packages/hardhat/artifacts-zk
+packages/hardhat/cache-zk
+
+packages/hardhat/deployments
+
+# -------------------------
+
+# Next.js files
+
+# dependencies
+packages/nextjs/node_modules
+packages/nextjs/.pnp
+packages/nextjs/.pnp.js
+
+# testing
+packages/nextjs/coverage
+
+# next.js
+packages/nextjs/.next/
+packages/nextjs/out/
+
+# production
+packages/nextjs/build
+
+# misc
+packages/nextjs/.DS_Store
+packages/nextjs/*.pem
+
+# debug
+packages/nextjs/npm-debug.log*
+packages/nextjs/yarn-debug.log*
+packages/nextjs/yarn-error.log*
+packages/nextjs/.pnpm-debug.log*
+
+# local env files
+packages/nextjs/.env.local
+packages/nextjs/.env.development.local
+packages/nextjs/.env.test.local
+packages/nextjs/.env.production.local
+
+# vercel
+packages/nextjs/.vercel
+
+# typescript
+packages/nextjs/*.tsbuildinfo

--- a/.vercelignore
+++ b/.vercelignore
@@ -31,9 +31,6 @@ packages/nextjs/.env.development.local
 packages/nextjs/.env.test.local
 packages/nextjs/.env.production.local
 
-# vercel
-packages/nextjs/.vercel
-
 # typescript
 packages/nextjs/*.tsbuildinfo
 

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,3 +1,16 @@
+# --- Monorepo files ---
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+.eslintcache
+.DS_Store
+.vscode
+.idea
+.vercel
+
 # --- Next.js files ---
 
 # dependencies

--- a/.vercelignore
+++ b/.vercelignore
@@ -34,7 +34,6 @@ packages/nextjs/.env.production.local
 # typescript
 packages/nextjs/*.tsbuildinfo
 
-
 # --- Hardhat files ---
 
 packages/hardhat/node_modules

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,4 +1,4 @@
-# Next.js files
+# --- Next.js files ---
 
 # dependencies
 packages/nextjs/node_modules
@@ -35,10 +35,7 @@ packages/nextjs/.env.production.local
 packages/nextjs/*.tsbuildinfo
 
 
-# -------------------------
-
-
-#Hardhat files
+# --- Hardhat files ---
 
 packages/hardhat/node_modules
 packages/hardhat/.env

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,23 +1,3 @@
-#Hardhat files
-
-packages/hardhat/node_modules
-packages/hardhat/.env
-packages/hardhat/coverage
-packages/hardhat/coverage.json
-packages/hardhat/typechain
-packages/hardhat/typechain-types
-packages/hardhat/temp
-
-packages/hardhat/cache
-packages/hardhat/artifacts
-
-packages/hardhat/artifacts-zk
-packages/hardhat/cache-zk
-
-packages/hardhat/deployments
-
-# -------------------------
-
 # Next.js files
 
 # dependencies
@@ -56,3 +36,25 @@ packages/nextjs/.vercel
 
 # typescript
 packages/nextjs/*.tsbuildinfo
+
+
+# -------------------------
+
+
+#Hardhat files
+
+packages/hardhat/node_modules
+packages/hardhat/.env
+packages/hardhat/coverage
+packages/hardhat/coverage.json
+packages/hardhat/typechain
+packages/hardhat/typechain-types
+packages/hardhat/temp
+
+packages/hardhat/cache
+packages/hardhat/artifacts
+
+packages/hardhat/artifacts-zk
+packages/hardhat/cache-zk
+
+packages/hardhat/deployments

--- a/packages/nextjs/.gitignore
+++ b/packages/nextjs/.gitignore
@@ -31,8 +31,5 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 
-# vercel
-.vercel
-
 # typescript
 *.tsbuildinfo


### PR DESCRIPTION
## Description

It's sad that Vercel don't respect `.gitgnore` inside it each package of monorepo, it was even uploading `.env` of hardhat :( : 

![Screenshot 2024-03-11 at 10 47 00 AM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/760c6508-3c6f-4d05-acfb-e12ae57d8ed8)

--- 

Also vercel doesn't respect `.vercelignore` inside each package, so had to copy all the things from each package `.gitignore` and append `packages/{packageName}` in `.vercelignore` at the root

Not sure what would be the better approach 

Here are docs : 
https://vercel.com/docs/deployments/vercel-ignore

Fixes #767 
