### PR TITLE
Potential improvements to address prop to make it more customizable

### DIFF
--- a/packages/nextjs/app/blockexplorer/_components/AddressComponent.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/AddressComponent.tsx
@@ -1,6 +1,6 @@
 import { BackButton } from "./BackButton";
 import { ContractTabs } from "./ContractTabs";
-import { Address, Balance } from "~~/components/scaffold-eth";
+import { Balance, ScaffoldAddress } from "~~/components/scaffold-eth";
 
 export const AddressComponent = ({
   address,
@@ -19,7 +19,7 @@ export const AddressComponent = ({
           <div className="bg-base-100 border-base-300 border shadow-md shadow-secondary rounded-3xl px-6 lg:px-8 mb-6 space-y-1 py-4 overflow-x-auto">
             <div className="flex">
               <div className="flex flex-col gap-1">
-                <Address address={address} format="long" />
+                <ScaffoldAddress address={address} format="long" />
                 <div className="flex gap-1 items-center">
                   <span className="font-bold text-sm">Balance:</span>
                   <Balance address={address} className="text" />

--- a/packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx
@@ -1,6 +1,6 @@
 import { TransactionHash } from "./TransactionHash";
 import { formatEther } from "viem";
-import { Address } from "~~/components/scaffold-eth";
+import { ScaffoldAddress } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { TransactionWithFunction } from "~~/utils/scaffold-eth";
 import { TransactionsTableProps } from "~~/utils/scaffold-eth/";
@@ -44,14 +44,14 @@ export const TransactionsTable = ({ blocks, transactionReceipts }: TransactionsT
                     <td className="w-1/12 md:py-4">{block.number?.toString()}</td>
                     <td className="w-2/1 md:py-4">{timeMined}</td>
                     <td className="w-2/12 md:py-4">
-                      <Address address={tx.from} size="sm" />
+                      <ScaffoldAddress address={tx.from} size="sm" />
                     </td>
                     <td className="w-2/12 md:py-4">
                       {!receipt?.contractAddress ? (
-                        tx.to && <Address address={tx.to} size="sm" />
+                        tx.to && <ScaffoldAddress address={tx.to} size="sm" />
                       ) : (
                         <div className="relative">
-                          <Address address={receipt.contractAddress} size="sm" />
+                          <ScaffoldAddress address={receipt.contractAddress} size="sm" />
                           <small className="absolute top-4 left-4">(Contract Creation)</small>
                         </div>
                       )}

--- a/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
@@ -6,7 +6,7 @@ import type { NextPage } from "next";
 import { Hash, Transaction, TransactionReceipt, formatEther, formatUnits } from "viem";
 import { hardhat } from "viem/chains";
 import { usePublicClient } from "wagmi";
-import { Address } from "~~/components/scaffold-eth";
+import { ScaffoldAddress } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { decodeTransactionData, getFunctionDetails } from "~~/utils/scaffold-eth";
 import { replacer } from "~~/utils/scaffold-eth/common";
@@ -69,7 +69,7 @@ const TransactionPage: NextPage<PageProps> = ({ params }: PageProps) => {
                   <strong>From:</strong>
                 </td>
                 <td>
-                  <Address address={transaction.from} format="long" />
+                  <ScaffoldAddress address={transaction.from} format="long" />
                 </td>
               </tr>
               <tr>
@@ -78,11 +78,11 @@ const TransactionPage: NextPage<PageProps> = ({ params }: PageProps) => {
                 </td>
                 <td>
                   {!receipt?.contractAddress ? (
-                    transaction.to && <Address address={transaction.to} format="long" />
+                    transaction.to && <ScaffoldAddress address={transaction.to} format="long" />
                   ) : (
                     <span>
                       Contract Creation:
-                      <Address address={receipt.contractAddress} format="long" />
+                      <ScaffoldAddress address={receipt.contractAddress} format="long" />
                     </span>
                   )}
                 </td>

--- a/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractUI.tsx
@@ -5,7 +5,7 @@ import { useReducer } from "react";
 import { ContractReadMethods } from "./ContractReadMethods";
 import { ContractVariables } from "./ContractVariables";
 import { ContractWriteMethods } from "./ContractWriteMethods";
-import { Address, Balance } from "~~/components/scaffold-eth";
+import { Balance, ScaffoldAddress } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useNetworkColor } from "~~/hooks/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { ContractName } from "~~/utils/scaffold-eth/contract";
@@ -48,7 +48,7 @@ export const ContractUI = ({ contractName, className = "" }: ContractUIProps) =>
             <div className="flex">
               <div className="flex flex-col gap-1">
                 <span className="font-bold">{contractName}</span>
-                <Address address={deployedContractData.address} />
+                <ScaffoldAddress address={deployedContractData.address} />
                 <div className="flex gap-1 items-center">
                   <span className="font-bold text-sm">Balance:</span>
                   <Balance address={deployedContractData.address} className="px-0 h-1.5 min-h-[0.375rem]" />

--- a/packages/nextjs/app/debug/_components/contract/utilsDisplay.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsDisplay.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import { TransactionBase, TransactionReceipt, formatEther, isAddress } from "viem";
-import { Address } from "~~/components/scaffold-eth";
+import { ScaffoldAddress } from "~~/components/scaffold-eth";
 import { replacer } from "~~/utils/scaffold-eth/common";
 
 type DisplayContent =
@@ -35,7 +35,7 @@ export const displayTxResult = (
   }
 
   if (typeof displayContent === "string" && isAddress(displayContent)) {
-    return asText ? displayContent : <Address address={displayContent} />;
+    return asText ? displayContent : <ScaffoldAddress address={displayContent} />;
   }
 
   if (Array.isArray(displayContent)) {

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -21,17 +21,19 @@ const Home: NextPage = () => {
 
           <div className="flex justify-center items-center space-x-2">
             <p className="my-2 font-medium">Connected Address:</p>
-            <ScaffoldAddress address={connectedAddress} />
+            <ScaffoldAddress address={connectedAddress} disableAddressLink={false} format={"short"} size="base" />
           </div>
 
           <div className="flex justify-center items-center space-x-2">
             <div className="bg-base-300">
               <BaseAddress
                 address={connectedAddress}
+                disableAddressLink={false}
+                format={"short"}
                 blockieSize="3xl"
                 wrapperClassName="flex flex-col items-center"
-                duplicateIconSize={10}
                 textClassName={`ml-1.5 text-4xl font-normal`}
+                duplicateIconSize={10}
               />
             </div>
           </div>

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -30,7 +30,7 @@ const Home: NextPage = () => {
                 address={connectedAddress}
                 disableAddressLink={false}
                 format={"short"}
-                blockieSize="3xl"
+                blockieSize={128}
                 wrapperClassName="flex flex-col items-center"
                 textClassName={`ml-1.5 text-4xl font-normal`}
                 duplicateIconSize={10}

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -4,7 +4,8 @@ import Link from "next/link";
 import type { NextPage } from "next";
 import { useAccount } from "wagmi";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
-import { Address } from "~~/components/scaffold-eth";
+import { BaseAddress } from "~~/components/scaffold-eth";
+import { ScaffoldAddress } from "~~/components/scaffold-eth/ScaffoldAddress";
 
 const Home: NextPage = () => {
   const { address: connectedAddress } = useAccount();
@@ -17,10 +18,24 @@ const Home: NextPage = () => {
             <span className="block text-2xl mb-2">Welcome to</span>
             <span className="block text-4xl font-bold">Scaffold-ETH 2</span>
           </h1>
+
           <div className="flex justify-center items-center space-x-2">
             <p className="my-2 font-medium">Connected Address:</p>
-            <Address address={connectedAddress} />
+            <ScaffoldAddress address={connectedAddress} />
           </div>
+
+          <div className="flex justify-center items-center space-x-2">
+            <div className="bg-base-300">
+              <BaseAddress
+                address={connectedAddress}
+                blockieSize="3xl"
+                wrapperClassName="flex flex-col items-center"
+                duplicateIconSize={10}
+                textClassName={`ml-1.5 text-4xl font-normal`}
+              />
+            </div>
+          </div>
+
           <p className="text-center text-lg">
             Get started by editing{" "}
             <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all inline-block">

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -34,6 +34,7 @@ const Home: NextPage = () => {
                 wrapperClassName="flex flex-col items-center"
                 textClassName={`ml-1.5 text-4xl font-normal`}
                 duplicateIconSize={10}
+                renderOrder={["address", "blockie", "copy"]}
               />
             </div>
           </div>

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -40,7 +40,7 @@ export const Address = ({
   format,
   size = "base",
   textClasses = "ml-1.5 text-base font-normal",
-  cardClasses = "flex items-center rounded-lg my-5 flex items-center justify-center bg-base-300",
+  cardClasses = "flex items-center",
 }: AddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -16,6 +16,8 @@ type AddressProps = {
   disableAddressLink?: boolean;
   format?: "short" | "long";
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+  textClasses?: string;
+  cardClasses?: string;
 };
 
 const blockieSizeMap = {
@@ -31,7 +33,15 @@ const blockieSizeMap = {
 /**
  * Displays an address (or ENS) with a Blockie image and option to copy address.
  */
-export const Address = ({ address, disableAddressLink, format, size = "base" }: AddressProps) => {
+
+export const Address = ({
+  address,
+  disableAddressLink,
+  format,
+  size = "base",
+  textClasses = "ml-1.5 text-base font-normal",
+  cardClasses = "flex items-center rounded-lg my-5 flex items-center justify-center bg-base-300",
+}: AddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
@@ -86,7 +96,7 @@ export const Address = ({ address, disableAddressLink, format, size = "base" }: 
   }
 
   return (
-    <div className="flex items-center">
+    <div className={`${cardClasses} `}>
       <div className="flex-shrink-0">
         <BlockieAvatar
           address={checkSumAddress}
@@ -95,18 +105,13 @@ export const Address = ({ address, disableAddressLink, format, size = "base" }: 
         />
       </div>
       {disableAddressLink ? (
-        <span className={`ml-1.5 text-${size} font-normal`}>{displayAddress}</span>
+        <span className={textClasses}>{displayAddress}</span>
       ) : targetNetwork.id === hardhat.id ? (
-        <span className={`ml-1.5 text-${size} font-normal`}>
+        <span className={textClasses}>
           <Link href={blockExplorerAddressLink}>{displayAddress}</Link>
         </span>
       ) : (
-        <a
-          className={`ml-1.5 text-${size} font-normal`}
-          target="_blank"
-          href={blockExplorerAddressLink}
-          rel="noopener noreferrer"
-        >
+        <a className={textClasses} target="_blank" href={blockExplorerAddressLink} rel="noopener noreferrer">
           {displayAddress}
         </a>
       )}

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -16,8 +16,8 @@ type AddressProps = {
   disableAddressLink?: boolean;
   format?: "short" | "long";
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
-  textClasses?: string;
-  cardClasses?: string;
+  textClassName?: string;
+  wrapperClassName?: string;
 };
 
 const blockieSizeMap = {
@@ -39,8 +39,8 @@ export const Address = ({
   disableAddressLink,
   format,
   size = "base",
-  textClasses = "ml-1.5 text-base font-normal",
-  cardClasses = "flex items-center",
+  textClassName = "ml-1.5 text-base font-normal",
+  wrapperClassName = "flex items-center",
 }: AddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
@@ -96,7 +96,7 @@ export const Address = ({
   }
 
   return (
-    <div className={`${cardClasses} `}>
+    <div className={`${wrapperClassName} `}>
       <div className="flex-shrink-0">
         <BlockieAvatar
           address={checkSumAddress}
@@ -105,13 +105,13 @@ export const Address = ({
         />
       </div>
       {disableAddressLink ? (
-        <span className={textClasses}>{displayAddress}</span>
+        <span className={textClassName}>{displayAddress}</span>
       ) : targetNetwork.id === hardhat.id ? (
-        <span className={textClasses}>
+        <span className={textClassName}>
           <Link href={blockExplorerAddressLink}>{displayAddress}</Link>
         </span>
       ) : (
-        <a className={textClasses} target="_blank" href={blockExplorerAddressLink} rel="noopener noreferrer">
+        <a className={textClassName} target="_blank" href={blockExplorerAddressLink} rel="noopener noreferrer">
           {displayAddress}
         </a>
       )}

--- a/packages/nextjs/components/scaffold-eth/BaseAddress.tsx
+++ b/packages/nextjs/components/scaffold-eth/BaseAddress.tsx
@@ -11,13 +11,14 @@ import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
 
-type AddressProps = {
+export type BaseAddressProps = {
   address?: AddressType;
   disableAddressLink?: boolean;
   format?: "short" | "long";
-  size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+  blockieSize?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
   textClassName?: string;
   wrapperClassName?: string;
+  duplicateIconSize?: number;
 };
 
 const blockieSizeMap = {
@@ -34,14 +35,15 @@ const blockieSizeMap = {
  * Displays an address (or ENS) with a Blockie image and option to copy address.
  */
 
-export const Address = ({
+export const BaseAddress = ({
   address,
   disableAddressLink,
   format,
-  size = "base",
-  textClassName = "ml-1.5 text-base font-normal",
-  wrapperClassName = "flex items-center",
-}: AddressProps) => {
+  blockieSize = "base",
+  textClassName,
+  wrapperClassName,
+  duplicateIconSize,
+}: BaseAddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
@@ -101,7 +103,7 @@ export const Address = ({
         <BlockieAvatar
           address={checkSumAddress}
           ensImage={ensAvatar}
-          size={(blockieSizeMap[size] * 24) / blockieSizeMap["base"]}
+          size={(blockieSizeMap[blockieSize] * 24) / blockieSizeMap["base"]}
         />
       </div>
       {disableAddressLink ? (
@@ -131,7 +133,7 @@ export const Address = ({
           }}
         >
           <DocumentDuplicateIcon
-            className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+            className={`ml-1.5 text-xl font-normal text-sky-600 h-${duplicateIconSize} w-${duplicateIconSize} cursor-pointer`}
             aria-hidden="true"
           />
         </CopyToClipboard>

--- a/packages/nextjs/components/scaffold-eth/BaseAddress.tsx
+++ b/packages/nextjs/components/scaffold-eth/BaseAddress.tsx
@@ -15,20 +15,10 @@ export type BaseAddressProps = {
   address?: AddressType;
   disableAddressLink?: boolean;
   format?: "short" | "long";
-  blockieSize?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+  blockieSize: number;
   textClassName?: string;
   wrapperClassName?: string;
   duplicateIconSize?: number;
-};
-
-const blockieSizeMap = {
-  xs: 6,
-  sm: 7,
-  base: 8,
-  lg: 9,
-  xl: 10,
-  "2xl": 12,
-  "3xl": 15,
 };
 
 /**
@@ -39,7 +29,7 @@ export const BaseAddress = ({
   address,
   disableAddressLink,
   format,
-  blockieSize = "base",
+  blockieSize,
   textClassName,
   wrapperClassName,
   duplicateIconSize,
@@ -100,11 +90,7 @@ export const BaseAddress = ({
   return (
     <div className={`${wrapperClassName} `}>
       <div className="flex-shrink-0">
-        <BlockieAvatar
-          address={checkSumAddress}
-          ensImage={ensAvatar}
-          size={(blockieSizeMap[blockieSize] * 24) / blockieSizeMap["base"]}
-        />
+        <BlockieAvatar address={checkSumAddress} ensImage={ensAvatar} size={blockieSize} />
       </div>
       {disableAddressLink ? (
         <span className={textClassName}>{displayAddress}</span>

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -5,7 +5,7 @@ import { Address as AddressType, createWalletClient, http, parseEther } from "vi
 import { hardhat } from "viem/chains";
 import { useNetwork } from "wagmi";
 import { BanknotesIcon } from "@heroicons/react/24/outline";
-import { Address, AddressInput, Balance, EtherInput } from "~~/components/scaffold-eth";
+import { AddressInput, Balance, EtherInput, ScaffoldAddress } from "~~/components/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 import { notification } from "~~/utils/scaffold-eth";
 
@@ -99,7 +99,7 @@ export const Faucet = () => {
             <div className="flex space-x-4">
               <div>
                 <span className="text-sm font-bold">From:</span>
-                <Address address={faucetAddress} />
+                <ScaffoldAddress address={faucetAddress} />
               </div>
               <div>
                 <span className="text-sm font-bold pl-3">Available:</span>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
@@ -1,6 +1,6 @@
 import { QRCodeSVG } from "qrcode.react";
 import { Address as AddressType } from "viem";
-import { Address } from "~~/components/scaffold-eth";
+import { ScaffoldAddress } from "~~/components/scaffold-eth";
 
 type AddressQRCodeModalProps = {
   address: AddressType;
@@ -22,7 +22,7 @@ export const AddressQRCodeModal = ({ address, modalId }: AddressQRCodeModalProps
             <div className="space-y-3 py-6">
               <div className="flex space-x-4 flex-col items-center gap-6">
                 <QRCodeSVG value={address} size={256} />
-                <Address address={address} format="long" disableAddressLink />
+                <ScaffoldAddress address={address} format="long" disableAddressLink />
               </div>
             </div>
           </label>

--- a/packages/nextjs/components/scaffold-eth/ScaffoldAddress.tsx
+++ b/packages/nextjs/components/scaffold-eth/ScaffoldAddress.tsx
@@ -14,17 +14,29 @@ export type ScaffoldAddressProps = {
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
 };
 
+const blockieSizeMap = {
+  xs: 6,
+  sm: 7,
+  base: 8,
+  lg: 9,
+  xl: 10,
+  "2xl": 12,
+  "3xl": 15,
+};
+
 export const ScaffoldAddress = ({ address, disableAddressLink, format, size = "base" }: ScaffoldAddressProps) => {
   const wrapperClassName = "flex items-center";
   const textClassName = `ml-1.5 text-${size} font-normal`;
   const duplicateIconSize = 5;
+
+  const blockieSize = (blockieSizeMap[size] * 24) / blockieSizeMap["base"];
 
   return (
     <BaseAddress
       address={address}
       disableAddressLink={disableAddressLink}
       format={format}
-      blockieSize={size}
+      blockieSize={blockieSize}
       textClassName={textClassName}
       wrapperClassName={wrapperClassName}
       duplicateIconSize={duplicateIconSize}

--- a/packages/nextjs/components/scaffold-eth/ScaffoldAddress.tsx
+++ b/packages/nextjs/components/scaffold-eth/ScaffoldAddress.tsx
@@ -12,6 +12,7 @@ export type ScaffoldAddressProps = {
   disableAddressLink?: boolean;
   format?: "short" | "long";
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+  renderOrder?: ("blockie" | "address" | "copy")[];
 };
 
 const blockieSizeMap = {
@@ -24,12 +25,19 @@ const blockieSizeMap = {
   "3xl": 15,
 };
 
-export const ScaffoldAddress = ({ address, disableAddressLink, format, size = "base" }: ScaffoldAddressProps) => {
+export const ScaffoldAddress = ({
+  address,
+  disableAddressLink,
+  format,
+  size = "base",
+  renderOrder = ["blockie", "address", "copy"],
+}: ScaffoldAddressProps) => {
   const wrapperClassName = "flex items-center";
   const textClassName = `ml-1.5 text-${size} font-normal`;
   const duplicateIconSize = 5;
 
   const blockieSize = (blockieSizeMap[size] * 24) / blockieSizeMap["base"];
+  // const renderOrder: any[] = ["blockie", "address", "copy"];
 
   return (
     <BaseAddress
@@ -40,6 +48,7 @@ export const ScaffoldAddress = ({ address, disableAddressLink, format, size = "b
       textClassName={textClassName}
       wrapperClassName={wrapperClassName}
       duplicateIconSize={duplicateIconSize}
+      renderOrder={renderOrder}
     />
   );
 };

--- a/packages/nextjs/components/scaffold-eth/ScaffoldAddress.tsx
+++ b/packages/nextjs/components/scaffold-eth/ScaffoldAddress.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Address as AddressType } from "viem";
+import { BaseAddress } from "~~/components/scaffold-eth";
+
+/**
+ * Displays an address (or ENS) with a Blockie image and option to copy address.
+ */
+
+export type ScaffoldAddressProps = {
+  address?: AddressType;
+  disableAddressLink?: boolean;
+  format?: "short" | "long";
+  size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+};
+
+export const ScaffoldAddress = ({ address, disableAddressLink, format, size = "base" }: ScaffoldAddressProps) => {
+  const wrapperClassName = "flex items-center";
+  const textClassName = `ml-1.5 text-${size} font-normal`;
+  const duplicateIconSize = 5;
+
+  return (
+    <BaseAddress
+      address={address}
+      disableAddressLink={disableAddressLink}
+      format={format}
+      blockieSize={size}
+      textClassName={textClassName}
+      wrapperClassName={wrapperClassName}
+      duplicateIconSize={duplicateIconSize}
+    />
+  );
+};

--- a/packages/nextjs/components/scaffold-eth/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/index.tsx
@@ -1,4 +1,5 @@
-export * from "./Address";
+export * from "./BaseAddress";
+export * from "./ScaffoldAddress";
 export * from "./Balance";
 export * from "./BlockieAvatar";
 export * from "./Faucet";


### PR DESCRIPTION
## Description

Address.tsx updates that allow for better customization of the card while retaining default values that work out of the box.
<img width="427" alt="Screenshot 2024-03-11 at 3 43 03 PM" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/32080359/2d3c72ba-7e2a-4455-b9fb-abd4a4ae6d51">
Address.tsx continued...
<img width="702" alt="Screenshot 2024-03-11 at 3 48 54 PM" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/32080359/487cf45c-5275-45b5-bf67-e8b8aca38f1c">


Possible usage of customizing the address card in an implementation.
<img width="687" alt="Screenshot 2024-03-11 at 3 46 41 PM" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/32080359/9511f804-5d9e-4c44-8764-758d05e40722">


Possible result of the implementation's customizations
<img width="438" alt="Screenshot 2024-03-11 at 3 46 30 PM" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/32080359/d3403f15-5295-4ef3-895d-12d72f5174c6">




## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


Your ENS/address: JacobHomanics.eth
