### PR TITLE
Fix: Redundant error notifications on block explorer

### DIFF
--- a/packages/nextjs/app/blockexplorer/page.tsx
+++ b/packages/nextjs/app/blockexplorer/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { PaginationButton, SearchBar, TransactionsTable } from "./_components";
 import type { NextPage } from "next";
 import { hardhat } from "viem/chains";
@@ -11,24 +11,23 @@ import { notification } from "~~/utils/scaffold-eth";
 const BlockExplorer: NextPage = () => {
   const { blocks, transactionReceipts, currentPage, totalBlocks, setCurrentPage, error } = useFetchBlocks();
   const { targetNetwork } = useTargetNetwork();
+  const [isLocalNetwork, setIsLocalNetwork] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    if (targetNetwork.id !== hardhat.id) {
+      setIsLocalNetwork(false);
+    }
+  }, [targetNetwork.id]);
 
   useEffect(() => {
     if (targetNetwork.id === hardhat.id && error) {
-      notification.error(
-        <>
-          <p className="font-bold mt-0 mb-1">Cannot connect to local provider</p>
-          <p className="m-0">
-            - Did you forget to run <code className="italic bg-base-300 text-base font-bold">yarn chain</code> ?
-          </p>
-          <p className="mt-1 break-normal">
-            - Or you can change <code className="italic bg-base-300 text-base font-bold">targetNetwork</code> in{" "}
-            <code className="italic bg-base-300 text-base font-bold">scaffold.config.ts</code>
-          </p>
-        </>,
-      );
+      setHasError(true);
     }
+  }, [targetNetwork.id, error]);
 
-    if (targetNetwork.id !== hardhat.id) {
+  useEffect(() => {
+    if (!isLocalNetwork) {
       notification.error(
         <>
           <p className="font-bold mt-0 mb-1">
@@ -48,7 +47,29 @@ const BlockExplorer: NextPage = () => {
         </>,
       );
     }
-  }, [error, targetNetwork]);
+  }, [
+    isLocalNetwork,
+    targetNetwork.blockExplorers?.default.name,
+    targetNetwork.blockExplorers?.default.url,
+    targetNetwork.name,
+  ]);
+
+  useEffect(() => {
+    if (hasError) {
+      notification.error(
+        <>
+          <p className="font-bold mt-0 mb-1">Cannot connect to local provider</p>
+          <p className="m-0">
+            - Did you forget to run <code className="italic bg-base-300 text-base font-bold">yarn chain</code> ?
+          </p>
+          <p className="mt-1 break-normal">
+            - Or you can change <code className="italic bg-base-300 text-base font-bold">targetNetwork</code> in{" "}
+            <code className="italic bg-base-300 text-base font-bold">scaffold.config.ts</code>
+          </p>
+        </>,
+      );
+    }
+  }, [hasError]);
 
   return (
     <div className="container mx-auto my-10">


### PR DESCRIPTION
## Description

The `toast` error notifications that are on `blockexplorer/page.tsx` will currently render 3-4 times on the initial page visit. If you reload the page and there are errors, it will keep spamming the toast notifications.

This PR breaks up the `useEffect` that checks for `targetNetwork` and `error`. It also adds in 2 new `useState` hooks to control the triggering of error notifications.

BEFORE:

https://github.com/scaffold-eth/scaffold-eth-2/assets/716376/fac375e7-8b66-402d-9fde-c45e57ee30fa

AFTER:

https://github.com/scaffold-eth/scaffold-eth-2/assets/716376/d47777d7-543e-4903-a48a-575d9e7cecd6

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)