### PR TITLE
cli: skip prettier formatting if install dependency is skipped

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,11 @@ export async function createProject(options: Options) {
     {
       title: "🪄 Formatting files with prettier",
       task: () => prettierFormat(targetDirectory),
+      skip: () => {
+        if (!options.install) {
+          return "Skipping because prettier install was skipped";
+        }
+      },
     },
     {
       title: `📡 Initializing Git repository ${

--- a/src/tasks/prettier-format.ts
+++ b/src/tasks/prettier-format.ts
@@ -1,6 +1,6 @@
 import { execa } from "execa";
 
-// TODO: Instead of using execa, use prettier pacakge from cli to format targetDir
+// TODO: Instead of using execa, use prettier package from cli to format targetDir
 export async function prettierFormat(targetDir: string) {
   try {
     const result = await execa("yarn", ["format"], { cwd: targetDir });

--- a/src/tasks/prettier-format.ts
+++ b/src/tasks/prettier-format.ts
@@ -1,5 +1,6 @@
 import { execa } from "execa";
 
+// TODO: Instead of using execa, use prettier pacakge from cli to format targetDir
 export async function prettierFormat(targetDir: string) {
   try {
     const result = await execa("yarn", ["format"], { cwd: targetDir });


### PR DESCRIPTION
## Description

Fixes #783, This is kind of short-term solution for now since if you skip install dependency it will not install prettier, which in turn will not format files. 

We added a prettier formatting file task because we get a prettier warning : 

![Screenshot 2024-03-23 at 12 20 22 AM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/182a1b36-4c8f-4a37-b2de-481aaaa2847f)

Also checkout #750 for more context 🙌
