### PR TITLE
Reformat assembly display in AddressCodeTab

### DIFF
--- a/packages/nextjs/app/blockexplorer/_components/AddressCodeTab.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/AddressCodeTab.tsx
@@ -5,8 +5,8 @@ type AddressCodeTabProps = {
 
 export const AddressCodeTab = ({ bytecode, assembly }: AddressCodeTabProps) => {
   const formattedAssembly = Array.from(assembly.matchAll(/\w+( 0x[a-fA-F0-9]+)?/g))
-    .map((it) => it[0])
-    .join('\n');
+    .map(it => it[0])
+    .join("\n");
 
   return (
     <div className="flex flex-col gap-3 p-4">

--- a/packages/nextjs/app/blockexplorer/_components/AddressCodeTab.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/AddressCodeTab.tsx
@@ -4,7 +4,9 @@ type AddressCodeTabProps = {
 };
 
 export const AddressCodeTab = ({ bytecode, assembly }: AddressCodeTabProps) => {
-  const formattedAssembly = assembly.split(" ").join("\n");
+  const formattedAssembly = Array.from(assembly.matchAll(/\w+( 0x[a-fA-F0-9]+)?/g))
+    .map((it) => it[0])
+    .join('\n');
 
   return (
     <div className="flex flex-col gap-3 p-4">


### PR DESCRIPTION
## Description

This reformats the assembly view so it keeps hex characters (`PUSH` parameters) on the same line.

Before:
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/104588511/780dc06c-463b-43a9-a75c-29f4931676cd)
(Notice how there's a newline between the `PUSH1` and `0xE0`)

After:
![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/104588511/02397a01-e139-4926-9c3f-5a209571a49b)
(Now, `PUSH1` and `0xE0` are on the same line).

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

N/A

Your ENS/address: `0x598cb95773D9b66a27a5780DB5EED2d018685879`
