### PR TITLE
 Add .env to .gitignore in nextjs package #797

### DIFF
--- a/packages/nextjs/.gitignore
+++ b/packages/nextjs/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
 Add .env to .gitignore in nextjs package #797 - Although Next [docs](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#default-environment-variables) has this and makes complete sense. But sometimes people tinkering with both hardhat and nextjs package might loose the context and add secrets to .env in nextjs assuming it is gitignored similar to hardhat pacakge
 
 Discussed with @technophile-04 on telegram

## Related Issues

_Closes #797 _

Your ENS/address: websculpt.eth
