### PR TITLE
Cli solidity framework option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ const config: Config = {
   questions: [
     typedQuestion({
       type: "single-select",
-      name: "solidity-framework",
+      name: "solidityFramework",
       message: "What solidity framework do you want to use?",
       extensions: ["hardhat", "foundry", null],
       default: "hardhat",

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,8 +55,8 @@ export async function createProject(options: Options) {
       },
     },
     {
-      title: `📡 Initializing Git repository ${
-        options.extensions.includes("foundry") ? "and submodules" : ""
+      title: `📡 Initializing Git repository${
+        options.extensions.includes("foundry") ? " and submodules" : ""
       }`,
       task: () => createFirstGitCommit(targetDirectory, options),
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,22 +2,30 @@ import type { Question } from "inquirer";
 
 export type Args = string[];
 
-export type RawOptions = {
+type BaseOptions = {
   project: string | null;
   install: boolean | null;
   dev: boolean;
-  extensions: Extension[] | null;
 };
 
-type NonNullableRawOptions = {
-  [Prop in keyof RawOptions]: NonNullable<RawOptions[Prop]>;
+export type RawOptions = BaseOptions & {
+  solidityFramework: SolidityFramework | "none" | null;
 };
 
-export type Options = NonNullableRawOptions;
+type MergedOptions = BaseOptions & {
+  extensions: Extension[];
+};
 
-export type Extension =
-  | "hardhat"
-  | "foundry"
+type NonNullableMergedOptions = {
+  [Prop in keyof MergedOptions]: NonNullable<MergedOptions[Prop]>;
+};
+
+export type Options = NonNullableMergedOptions;
+
+export type SolidityFramework = "hardhat" | "foundry";
+
+export type Extension = SolidityFramework;
+
 type NullExtension = null;
 export type ExtensionOrNull = Extension | NullExtension;
 // corresponds to inquirer question types:

--- a/src/utils/parse-arguments-into-options.ts
+++ b/src/utils/parse-arguments-into-options.ts
@@ -12,6 +12,9 @@ export function parseArgumentsIntoOptions(rawArgs: Args): RawOptions {
       "--skip": "--skip-install",
       "-s": "--skip-install",
 
+      "--solidity-framework": solidityFrameworkHandler,
+      "-f": "--solidity-framework",
+
       "--dev": Boolean,
     },
     {
@@ -34,10 +37,26 @@ export function parseArgumentsIntoOptions(rawArgs: Args): RawOptions {
 
   const project = args._[0] ?? null;
 
+  const solidityFramework = args["--solidity-framework"] ?? null;
+
   return {
     project,
     install: hasInstallRelatedFlag ? install || !skipInstall : null,
     dev,
-    extensions: null, // TODO add extensions flags
+    solidityFramework,
   };
+}
+
+function solidityFrameworkHandler(value: string) {
+  const lowercasedValue = value.toLowerCase();
+  if (
+    lowercasedValue === "hardhat" ||
+    lowercasedValue === "foundry" ||
+    lowercasedValue === "none"
+  ) {
+    return lowercasedValue;
+  }
+
+  // choose from cli prompts
+  return null;
 }

--- a/src/utils/parse-arguments-into-options.ts
+++ b/src/utils/parse-arguments-into-options.ts
@@ -21,6 +21,13 @@ export function parseArgumentsIntoOptions(rawArgs: Args): RawOptions {
 
   const install = args["--install"] ?? null;
   const skipInstall = args["--skip-install"] ?? null;
+
+  if (install && skipInstall) {
+    throw new Error(
+      'Please select only one of the options: "--install" or "--skip-install".'
+    );
+  }
+
   const hasInstallRelatedFlag = install || skipInstall;
 
   const dev = args["--dev"] ?? false; // info: use false avoid asking user

--- a/src/utils/prompt-for-missing-options.ts
+++ b/src/utils/prompt-for-missing-options.ts
@@ -6,7 +6,7 @@ import {
   RawOptions,
   extensionWithSubextensions,
   isDefined,
-  isExtension
+  isExtension,
 } from "../types";
 import inquirer, { Answers } from "inquirer";
 import { extensionDict } from "./extensions-tree";
@@ -16,14 +16,14 @@ const defaultOptions: RawOptions = {
   project: "my-dapp-example",
   install: true,
   dev: false,
-  extensions: [],
+  solidityFramework: "none",
 };
 
 const invalidQuestionNames = ["project", "install"];
 const nullExtensionChoice = {
-  name: 'None',
-  value: null
-}
+  name: "none",
+  value: null,
+};
 
 export async function promptForMissingOptions(
   options: RawOptions
@@ -78,18 +78,21 @@ export async function promptForMissingOptions(
           .join(", ")}`
       );
     }
+
     const extensions = question.extensions
       .filter(isExtension)
       .map((ext) => extensionDict[ext])
       .filter(isDefined);
 
-    const hasNoneOption = question.extensions.includes(null)
+    const hasNoneOption = question.extensions.includes(null);
 
     questions.push({
       type: question.type === "multi-select" ? "checkbox" : "list",
       name: question.name,
       message: question.message,
-      choices: hasNoneOption ? [...extensions, nullExtensionChoice] : extensions,
+      choices: hasNoneOption
+        ? [...extensions, nullExtensionChoice]
+        : extensions,
     });
 
     recurringAddFollowUps(extensions, question.name);
@@ -108,14 +111,17 @@ export async function promptForMissingOptions(
     project: options.project ?? answers.project,
     install: options.install ?? answers.install,
     dev: options.dev ?? defaultOptions.dev,
-    extensions: [],
+    extensions: [options.solidityFramework ?? answers.solidityFramework].filter(
+      (ext) => Boolean(ext) && ext !== "none"
+    ),
   };
 
-  config.questions.forEach((question) => {
-    const { name } = question;
-    const choice: Extension[] = [answers[name]].flat().filter(isDefined);
-    mergedOptions.extensions.push(...choice);
-  });
+  // TODO: check if it needed for nested extensions
+  // config.questions.forEach((question) => {
+  //   const { name } = question;
+  //   const choice: Extension[] = [answers[name]].flat().filter(isDefined);
+  //   mergedOptions.extensions.push(...choice);
+  // });
 
   const recurringAddNestedExtensions = (baseExtensions: Extension[]) => {
     baseExtensions.forEach((extValue) => {


### PR DESCRIPTION
## Description

Solidity framework option from CLI. It could be a discussion but I think in this case it's easier to discuss when you already see the code. Feel free to add suggestions 🙂 

usage examples (dev):
```
yarn cli --solidity-framework hardhat
yarn cli --solidity-framework=foundry
yarn cli -f none
```
In case of several solidity framework flags, last will be taken

Other options I thought about.
1. `--hardhat`, `--foundry` and `--skip-solidity-framework`. Looks bad. Need to check if two or more flags chosen and add additional `if`s to fix/throw error
2. `--extensions` flag. It's not clear how to add let's say `none`, and how to mix it with other extensions non-related to solidity frameworks

Not sure how it will work with nested extensions but I think it's not a problem to update recurring logic if needed.

Also in this pr I added error if both `--install` and `--skip-install` chosen

Thanks!

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
