### PR TITLE
Fix #805 - Check property exists before using it

### DIFF
--- a/templates/extensions/foundry/packages/foundry/script/generateTsAbis.js
+++ b/templates/extensions/foundry/packages/foundry/script/generateTsAbis.js
@@ -36,7 +36,7 @@ function getArtifactOfContract(contractName) {
 
 function getInheritedFromContracts(artifact) {
   let inheritedFromContracts = [];
-  if('ast' in artifact) {
+  if (artifact?.ast) {
     for (const astNode of artifact.ast.nodes) {
       if (astNode.nodeType == "ContractDefinition") {
         if (astNode.baseContracts.length > 0) {

--- a/templates/extensions/foundry/packages/foundry/script/generateTsAbis.js
+++ b/templates/extensions/foundry/packages/foundry/script/generateTsAbis.js
@@ -36,12 +36,14 @@ function getArtifactOfContract(contractName) {
 
 function getInheritedFromContracts(artifact) {
   let inheritedFromContracts = [];
-  for (const astNode of artifact.ast.nodes) {
-    if (astNode.nodeType == "ContractDefinition") {
-      if (astNode.baseContracts.length > 0) {
-        inheritedFromContracts = astNode.baseContracts.map(
-          ({ baseName }) => baseName.name
-        );
+  if('ast' in artifact) {
+    for (const astNode of artifact.ast.nodes) {
+      if (astNode.nodeType == "ContractDefinition") {
+        if (astNode.baseContracts.length > 0) {
+          inheritedFromContracts = astNode.baseContracts.map(
+            ({ baseName }) => baseName.name
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Fixes: https://github.com/scaffold-eth/scaffold-eth-2/issues/805

Sometimes (reproducible by me but not @technophile-04) the `yarn deploy` would error complaining about using an undefined property. This fixes that.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #805_

Your ENS/address:
