### PR TITLE
(docs) Fixed the main frontend path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ Visit your app on: `http://localhost:3000`. You can interact with your smart con
 
 Run smart contract test with `yarn hardhat:test`
 
+**What's next**:
+
 - Edit your smart contract `YourContract.sol` in `packages/hardhat/contracts`
-- Edit your frontend in `packages/nextjs/app`
+- Edit your frontend homepage at `packages/nextjs/app/page.tsx`. For guidance on [routing](https://nextjs.org/docs/app/building-your-application/routing/defining-routes) and configuring [pages/layouts](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts) checkout the Next.js documentation.
 - Edit your deployment scripts in `packages/hardhat/deploy`
+- Edit your smart contract test in: `packages/hardhat/test`. To run test use `yarn hardhat:test`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Visit your app on: `http://localhost:3000`. You can interact with your smart con
 Run smart contract test with `yarn hardhat:test`
 
 - Edit your smart contract `YourContract.sol` in `packages/hardhat/contracts`
-- Edit your frontend in `packages/nextjs/pages`
+- Edit your frontend in `packages/nextjs/app`
 - Edit your deployment scripts in `packages/hardhat/deploy`
 
 ## Documentation


### PR DESCRIPTION
## Description

Previously the main frontend path was `nextjs/pages`. Now the project switched to the Next.js App Router and the `nextjs/app` folder correspondingly. We need to update the README correspondingly.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
