### PR TITLE
Add metas for a default Farcaster Frame

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -44,6 +44,13 @@ export const metadata: Metadata = {
   icons: {
     icon: [{ url: "/favicon.png", sizes: "32x32", type: "image/png" }],
   },
+  other: {
+    "fc:frame": "vNext",
+    "fc:frame:image": imageUrl,
+    "fc:frame:button:1": "Open my 🏗️ Scaffold-ETH 2 dApp",
+    "fc:frame:button:1:action": "link",
+    "fc:frame:button:1:target": baseUrl,
+  },
 };
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {

--- a/packages/nextjs/utils/scaffold-eth/getMetadata.ts
+++ b/packages/nextjs/utils/scaffold-eth/getMetadata.ts
@@ -30,5 +30,12 @@ export const getMetadata = ({
       description: description,
       images: [imageUrl],
     },
+    other: {
+      "fc:frame": "vNext",
+      "fc:frame:image": imageUrl,
+      "fc:frame:button:1": "Open my 🏗️ Scaffold-ETH 2 dApp",
+      "fc:frame:button:1:action": "link",
+      "fc:frame:button:1:target": baseUrl,
+    },
   };
 };


### PR DESCRIPTION
I was thinking about adding a default "dummy" [Farcaster Frame](https://docs.farcaster.xyz/learn/what-is-farcaster/frames) for SE-2. I say "dummy" because you usually add a backend route to handle different actions within the frame (but that would be too much)

To test locally, you can use: https://github.com/coinbase/onchainkit
-> clone, go to the framegear folder, npm install, npm run dev... and you get this:

![frames](https://github.com/scaffold-eth/scaffold-eth-2/assets/2486142/64078959-29d5-4ebd-9e32-e29ccbc93b8d)

---

A few things:
- Is it worth it to add this?
- About NextJS Metadata. `layout.tsx` and `getMetadata.ts` feel a bit duplicated. Is there a way around it? Feels weird to have to add the frame meta to both places.
- VERCEL_URL: We use it for the base URL, and now Vercel returns the "protected deployment route" (instead of the production one. Related to https://github.com/scaffold-eth/scaffold-eth-2/issues/807 I think).. which make this a bit useless:

```ts
const baseUrl = process.env.VERCEL_URL
  ? `https://${process.env.VERCEL_URL}`
  : `http://localhost:${process.env.PORT || 3000}`;
```

Any ideas? (we can discuss in another issue/PR, sorry haha)

