### PR TITLE
adds yarn setup commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     ]
   },
   "scripts": {
+    "setup": "yarn workspace @se-2/hardhat setup",
     "account": "yarn workspace @se-2/hardhat account",
     "chain": "yarn workspace @se-2/hardhat chain",
     "fork": "yarn workspace @se-2/hardhat fork",

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -2,6 +2,7 @@
   "name": "@se-2/hardhat",
   "version": "0.0.1",
   "scripts": {
+    "setup": "cp .env.example .env",
     "account": "hardhat run scripts/listAccount.ts",
     "chain": "hardhat node --network hardhat --no-deploy",
     "compile": "hardhat compile",


### PR DESCRIPTION
## Description

Simplifies the setup process when cloning a new project by adding `yarn setup` as a command from the root directory. As a result, it copies .env.example to .env. Without doing this command, you will receive an error when you try to deploy to localhost (atleast on projects using Foundry).

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


Your ENS/address: JacobHomanics.eth
