### PR TITLE
Add TokenSelector component and useToken

### DIFF
--- a/packages/nextjs/components/scaffold-eth/TokenSelector.tsx
+++ b/packages/nextjs/components/scaffold-eth/TokenSelector.tsx
@@ -32,6 +32,7 @@ const TokenListing = ({
       onClick={() => onClick(token)}
     >
       {token.logoURI ? (
+        // eslint-disable-next-line @next/next/no-img-element
         <img src={token.logoURI} alt={token.name} className="h-6 w-6 rounded-full" />
       ) : (
         <div className="avatar placeholder">
@@ -224,6 +225,7 @@ export const TokenSelector = ({
                   onClick={() => selectToken(token)}
                 >
                   {token.logoURI ? (
+                    // eslint-disable-next-line @next/next/no-img-element
                     <img src={token.logoURI} alt={token.name} className="h-6 w-6 rounded-full" />
                   ) : (
                     <div className="avatar placeholder">

--- a/packages/nextjs/components/scaffold-eth/TokenSelector.tsx
+++ b/packages/nextjs/components/scaffold-eth/TokenSelector.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useLocalStorage } from "usehooks-ts";
+import { useAccount } from "wagmi";
+import { ArrowRightIcon } from "@heroicons/react/24/outline";
+import { InputBase } from "~~/components/scaffold-eth";
+import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
+import { Token, useToken } from "~~/hooks/scaffold-eth/useToken";
+
+type TokenSelectorProps = {
+  chainId?: number | undefined;
+  suggestedTokens?: string[] | undefined;
+  button?: ((selectedToken: Token | undefined) => React.ReactNode) | undefined;
+  onChange?: ((token: Token) => void) | undefined;
+};
+
+const TokenListing = ({
+  token,
+  isChosen,
+  onClick,
+  importStatus = "not-imported",
+}: {
+  token: Token;
+  isChosen: boolean;
+  onClick: (token: Token) => void;
+  importStatus: "to-import" | "imported" | "not-imported";
+}) => {
+  return (
+    <button
+      className={`group flex items-center gap-x-2 px-6 py-2 transition-colors duration-75 ${
+        isChosen ? "brightness-75 cursor-default" : "hover:bg-base-300"
+      }`}
+      onClick={() => onClick(token)}
+    >
+      {token.logoURI ? (
+        <img src={token.logoURI} alt={token.name} className="h-6 w-6 rounded-full" />
+      ) : (
+        <div className="avatar placeholder">
+          <div className="bg-neutral text-neutral-content rounded-full w-6">
+            <span className="text-xl">?</span>
+          </div>
+        </div>
+      )}
+      <div className="flex flex-col items-start">
+        <span className="font-bold">{token.symbol}</span>
+        <span className="text-slate-400">
+          {importStatus === "imported" && "Imported • "}
+          {token.name}
+        </span>
+      </div>
+
+      {importStatus === "to-import" ? (
+        <button className="btn btn-primary ml-auto">Import</button>
+      ) : (
+        <ArrowRightIcon
+          className={`ml-auto h-6 w-6 transition-transform ${!isChosen && "group-hover:translate-x-2"}`}
+        />
+      )}
+    </button>
+  );
+};
+
+export const TokenList = ({
+  isLoadingTokens,
+  tokens,
+  importedToken,
+  onClick,
+  onImportClick,
+}: {
+  isLoadingTokens: boolean;
+  tokens: Token[];
+  importedToken: { data: Token | null; isLoading: boolean };
+  onClick: (token: Token) => void;
+  onImportClick: (token: Token) => void;
+}) => {
+  if (isLoadingTokens || importedToken.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-slate-300">Loading tokens...</p>
+      </div>
+    );
+  }
+
+  if (tokens.length === 0 && !importedToken.data) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-slate-300">No tokens found</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {importedToken.data && (
+        <TokenListing token={importedToken.data} isChosen={false} onClick={onImportClick} importStatus="imported" />
+      )}
+
+      {tokens.map(token => (
+        <TokenListing
+          key={token.address}
+          token={token}
+          isChosen={false}
+          onClick={onClick}
+          importStatus="not-imported"
+        />
+      ))}
+    </>
+  );
+};
+
+export const TokenSelector = ({
+  chainId: chainIdOverride,
+  suggestedTokens: suggestedTokenAddresses = [],
+  button,
+  onChange,
+}: TokenSelectorProps) => {
+  const { chain: accountChain } = useAccount();
+  const { targetNetwork } = useTargetNetwork();
+
+  // use provided chainId, default to currently connected chain, with fallback to targetNetwork
+  const chainId = chainIdOverride ?? accountChain?.id ?? targetNetwork.id;
+
+  const modalCheckbox = useRef<HTMLInputElement>(null);
+
+  const [selectedToken, setSelectedToken] = useState<Token | undefined>(undefined);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const [allTokens, setAllTokens] = useState<Token[]>([]);
+  const [importedTokens, setImportedTokens] = useLocalStorage<(Token & { imported: true })[]>(
+    "scaffold-eth.importedTokens",
+    [],
+  );
+
+  const [tokens, setTokens] = useState<Token[]>([]);
+
+  useEffect(() => {
+    setTokens(
+      [...importedTokens, ...allTokens].filter(token => {
+        if (token.chainId !== chainId) return false;
+
+        const processedSearchQuery = searchQuery.trim();
+
+        if (!processedSearchQuery) return true;
+
+        // either the token name includes the search input or the address matches the search inputs
+        if (token.name.toLowerCase().includes(processedSearchQuery.toLowerCase())) return true;
+        return token.address.toLowerCase() === processedSearchQuery.toLowerCase();
+      }),
+    );
+  }, [allTokens, importedTokens, chainId, searchQuery]);
+
+  const suggestedTokens = useMemo(
+    () =>
+      suggestedTokenAddresses
+        .map(address => tokens.find(token => token.address === address))
+        .filter(Boolean) as Token[],
+    [suggestedTokenAddresses, tokens],
+  );
+
+  const [isLoadingTokens, setIsLoadingTokens] = useState(false);
+
+  useEffect(() => {
+    const fetchTokens = async () => {
+      setIsLoadingTokens(true);
+      const res = await fetch("https://tokens.uniswap.org");
+
+      const data = await res.json();
+
+      setAllTokens(data.tokens);
+      setIsLoadingTokens(false);
+    };
+
+    fetchTokens();
+  }, []);
+
+  const selectToken = (newSelectedToken: Token) => {
+    if (newSelectedToken.address === selectedToken?.address) {
+      return;
+    }
+    setSelectedToken(newSelectedToken);
+    if (modalCheckbox.current) {
+      modalCheckbox.current.checked = false;
+    }
+    onChange?.(newSelectedToken);
+  };
+
+  console.log(tokens);
+
+  const importedToken = useToken({
+    address: searchQuery,
+    enabled: tokens.length === 0,
+    chainId,
+  });
+
+  return (
+    <div>
+      <label htmlFor="token-modal" className="btn btn-primary gap-1 font-normal">
+        {button?.(selectedToken) ?? "Select a Token"}
+      </label>
+      <input type="checkbox" id="token-modal" className="modal-toggle" ref={modalCheckbox} />
+      <label htmlFor="token-modal" className="modal cursor-pointer">
+        <label className="modal-box relative px-0">
+          <input className="absolute left-0 top-0 h-0 w-0" />
+
+          <div className="mb-4 px-6">
+            <h3 className="mb-3 text-xl font-bold">Select a Token</h3>
+            <label htmlFor="token-modal" className="btn btn-circle btn-ghost btn-sm absolute right-3 top-3">
+              {" "}
+              ✕{" "}
+            </label>
+
+            <div className="divider" />
+
+            <InputBase
+              value={searchQuery}
+              onChange={query => setSearchQuery(query)}
+              placeholder="Search name or paste address"
+            />
+
+            <div className="mt-2 flex gap-2">
+              {suggestedTokens.map(token => (
+                <button
+                  key={token.address}
+                  className="flex gap-x-2 rounded-lg border border-primary p-1.5 transition-colors duration-75 hover:bg-primary"
+                  onClick={() => selectToken(token)}
+                >
+                  {token.logoURI ? (
+                    <img src={token.logoURI} alt={token.name} className="h-6 w-6 rounded-full" />
+                  ) : (
+                    <div className="avatar placeholder">
+                      <div className="bg-neutral text-neutral-content rounded-full w-6">
+                        <span className="text-xl">?</span>
+                      </div>
+                    </div>
+                  )}
+
+                  <span>{token.symbol}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="scrollbar flex h-[50vh] flex-col overflow-x-auto">
+            <TokenList
+              isLoadingTokens={isLoadingTokens}
+              tokens={tokens}
+              importedToken={importedToken}
+              onClick={selectToken}
+              onImportClick={token => {
+                setImportedTokens([...importedTokens, { ...token, imported: true }]);
+                selectToken(token);
+              }}
+            />
+          </div>
+        </label>
+      </label>
+    </div>
+  );
+};

--- a/packages/nextjs/hooks/scaffold-eth/index.ts
+++ b/packages/nextjs/hooks/scaffold-eth/index.ts
@@ -12,3 +12,4 @@ export * from "./useScaffoldEventHistory";
 export * from "./useTransactor";
 export * from "./useFetchBlocks";
 export * from "./useContractLogs";
+export * from "./useToken";

--- a/packages/nextjs/hooks/scaffold-eth/useToken.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useToken.ts
@@ -1,0 +1,70 @@
+import { useTargetNetwork } from "./useTargetNetwork";
+import { Address, erc20Abi, isAddress } from "viem";
+import { useReadContract } from "wagmi";
+
+export type Token = {
+  chainId: number;
+  address: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  logoURI?: string;
+};
+
+export const useToken = ({
+  address,
+  chainId: chainIdOverride,
+  enabled = true,
+}: {
+  address: Address | undefined;
+  chainId?: number | undefined;
+  enabled?: boolean | undefined;
+}): { data: Token | null; isLoading: boolean } => {
+  const { targetNetwork } = useTargetNetwork();
+  const chainId = chainIdOverride ?? targetNetwork.id;
+
+  const name = useReadContract({
+    chainId,
+    address,
+    abi: erc20Abi,
+    functionName: "name",
+    query: {
+      enabled: Boolean(address && isAddress(address) && enabled),
+    },
+  });
+
+  const symbol = useReadContract({
+    chainId,
+    address,
+    abi: erc20Abi,
+    functionName: "symbol",
+    query: {
+      enabled: Boolean(address && isAddress(address) && enabled),
+    },
+  });
+
+  const decimals = useReadContract({
+    chainId,
+    address,
+    abi: erc20Abi,
+    functionName: "decimals",
+    query: {
+      enabled: Boolean(address && isAddress(address) && enabled),
+    },
+  });
+
+  if (!address || !isAddress(address) || !name.data || !symbol.data || !decimals.data) {
+    return { data: null, isLoading: false };
+  }
+
+  return {
+    data: {
+      chainId,
+      address,
+      name: name.data,
+      symbol: symbol.data,
+      decimals: decimals.data,
+    },
+    isLoading: name.isLoading || symbol.isLoading || decimals.isLoading,
+  };
+};


### PR DESCRIPTION
## Description

I have added the TokenSelector component, a direct port of the ChooseTokenModal component from [scaffold-eth-svelte](https://github.com/ByteAtATime/scaffold-eth-svelte). It allows the user to choose a token (from the list provided by Uniswap) or input an address, in which case the token data will be read and, if the user chooses so, stored in localStorage. It also allows you to "suggest" common tokens, which are displayed as chips on the top.

I have also added a utility hook, `useToken`, that simply reads the `name`, `symbol`, and `decimals` of an ERC20 contract.

Here is an image of the TokenSelector:

![TokenSelector](https://github.com/scaffold-eth/scaffold-eth-2/assets/104588511/6404647e-a269-4d97-9c0f-e347a8d2ab8c)

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

I have not created an issue for this, as @austintgriffith has expressed interest in getting the component ported from my Svelte implementation here.

The corresponding pull request in the docs repository is scaffold-eth/se2-docs#65.

Your ENS/address: `byteatatime.eth`
