### PR TITLE
use relative import in blockexplorer/[address] page

### DIFF
--- a/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
@@ -1,7 +1,7 @@
+import { AddressComponent } from "../../_components/AddressComponent";
 import fs from "fs";
 import path from "path";
 import { hardhat } from "viem/chains";
-import { AddressComponent } from "~~/app/blockexplorer/_components/AddressComponent";
 import deployedContracts from "~~/contracts/deployedContracts";
 import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 


### PR DESCRIPTION
## Description

This will allow people to use static build, by just renaming `blockexplorer` => `_blockexplorer`. 

Currently if you add `output: "export"` in `next.config.js` then do `yarn next:build` it fails checkout #785 for more details. 

A workaround is to not build any page in `blockexplorer` so by appending `_` before its name we mark it as private dir and nextjs ignores it. 

But currently in `main` branch if you add `output: "export"` in next.config.js and rename to `_blockexplorer` it fails because the import inside `blockexplorer/[address]/page.tsx` is messed up. 

Using relative import solves this problem, also I think it makes sense to have this relative import so people can just easily ignore `blockexplorer` dir while doing normal build too. 

Not the efficient / best solution, so please feel free to close this PR if it doesn't makes sense ! 


