### PR TITLE
add generateStaticParams to blockexplorer address and txHash

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "next:format": "yarn workspace @se-2/nextjs format",
     "next:check-types": "yarn workspace @se-2/nextjs check-types",
     "next:build": "yarn workspace @se-2/nextjs build",
+    "next:serve": "yarn workspace @se-2/nextjs serve",
     "postinstall": "husky install",
     "precommit": "lint-staged",
     "vercel": "yarn workspace @se-2/nextjs vercel",

--- a/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
@@ -82,6 +82,8 @@ export function generateStaticParams() {
 
 const AddressPage = async ({ params }: PageProps) => {
   const address = params?.address as string;
+  if (address === "0x0000000000000000000000000000000000000000") return null;
+
   const contractData: { bytecode: string; assembly: string } | null = await getContractData(address);
   return <AddressComponent address={address} contractData={contractData} />;
 };

--- a/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
@@ -76,6 +76,10 @@ const getContractData = async (address: string) => {
   return { bytecode, assembly };
 };
 
+export function generateStaticParams() {
+  return [{ address: "0x0000000000000000000000000000000000000000" }];
+}
+
 const AddressPage = async ({ params }: PageProps) => {
   const address = params?.address as string;
   const contractData: { bytecode: string; assembly: string } | null = await getContractData(address);

--- a/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
@@ -3,6 +3,7 @@ import path from "path";
 import { hardhat } from "viem/chains";
 import { AddressComponent } from "~~/app/blockexplorer/_components/AddressComponent";
 import deployedContracts from "~~/contracts/deployedContracts";
+import { isZeroAddress } from "~~/utils/scaffold-eth/common";
 import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 
 type PageProps = {
@@ -77,13 +78,14 @@ const getContractData = async (address: string) => {
 };
 
 export function generateStaticParams() {
-  // An workaround to enable static exports in Next.js
+  // An workaround to enable static exports in Next.js, generating single dummy page.
   return [{ address: "0x0000000000000000000000000000000000000000" }];
 }
 
 const AddressPage = async ({ params }: PageProps) => {
   const address = params?.address as string;
-  if (address === "0x0000000000000000000000000000000000000000") return null;
+
+  if (isZeroAddress(address)) return null;
 
   const contractData: { bytecode: string; assembly: string } | null = await getContractData(address);
   return <AddressComponent address={address} contractData={contractData} />;

--- a/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
@@ -77,6 +77,7 @@ const getContractData = async (address: string) => {
 };
 
 export function generateStaticParams() {
+  // An workaround to enable static exports in Next.js
   return [{ address: "0x0000000000000000000000000000000000000000" }];
 }
 

--- a/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
@@ -1,153 +1,17 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import TransactionComp from "../_components/TransactionComp";
 import type { NextPage } from "next";
-import { Hash, Transaction, TransactionReceipt, formatEther, formatUnits } from "viem";
-import { hardhat } from "viem/chains";
-import { usePublicClient } from "wagmi";
-import { Address } from "~~/components/scaffold-eth";
-import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
-import { decodeTransactionData, getFunctionDetails } from "~~/utils/scaffold-eth";
-import { replacer } from "~~/utils/scaffold-eth/common";
+import { Hash } from "viem";
 
 type PageProps = {
   params: { txHash?: Hash };
 };
+
+export function generateStaticParams() {
+  return [{ txHash: "0x0000000000000000000000000000000000000000" }];
+}
 const TransactionPage: NextPage<PageProps> = ({ params }: PageProps) => {
-  const client = usePublicClient({ chainId: hardhat.id });
   const txHash = params?.txHash as Hash;
-  const router = useRouter();
-  const [transaction, setTransaction] = useState<Transaction>();
-  const [receipt, setReceipt] = useState<TransactionReceipt>();
-  const [functionCalled, setFunctionCalled] = useState<string>();
-
-  const { targetNetwork } = useTargetNetwork();
-
-  useEffect(() => {
-    if (txHash && client) {
-      const fetchTransaction = async () => {
-        const tx = await client.getTransaction({ hash: txHash });
-        const receipt = await client.getTransactionReceipt({ hash: txHash });
-
-        const transactionWithDecodedData = decodeTransactionData(tx);
-        setTransaction(transactionWithDecodedData);
-        setReceipt(receipt);
-
-        const functionCalled = transactionWithDecodedData.input.substring(0, 10);
-        setFunctionCalled(functionCalled);
-      };
-
-      fetchTransaction();
-    }
-  }, [client, txHash]);
-
-  return (
-    <div className="container mx-auto mt-10 mb-20 px-10 md:px-0">
-      <button className="btn btn-sm btn-primary" onClick={() => router.back()}>
-        Back
-      </button>
-      {transaction ? (
-        <div className="overflow-x-auto">
-          <h2 className="text-3xl font-bold mb-4 text-center text-primary-content">Transaction Details</h2>{" "}
-          <table className="table rounded-lg bg-base-100 w-full shadow-lg md:table-lg table-md">
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Transaction Hash:</strong>
-                </td>
-                <td>{transaction.hash}</td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Block Number:</strong>
-                </td>
-                <td>{Number(transaction.blockNumber)}</td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>From:</strong>
-                </td>
-                <td>
-                  <Address address={transaction.from} format="long" />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>To:</strong>
-                </td>
-                <td>
-                  {!receipt?.contractAddress ? (
-                    transaction.to && <Address address={transaction.to} format="long" />
-                  ) : (
-                    <span>
-                      Contract Creation:
-                      <Address address={receipt.contractAddress} format="long" />
-                    </span>
-                  )}
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Value:</strong>
-                </td>
-                <td>
-                  {formatEther(transaction.value)} {targetNetwork.nativeCurrency.symbol}
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Function called:</strong>
-                </td>
-                <td>
-                  <div className="w-full md:max-w-[600px] lg:max-w-[800px] overflow-x-auto whitespace-nowrap">
-                    {functionCalled === "0x" ? (
-                      "This transaction did not call any function."
-                    ) : (
-                      <>
-                        <span className="mr-2">{getFunctionDetails(transaction)}</span>
-                        <span className="badge badge-primary font-bold">{functionCalled}</span>
-                      </>
-                    )}
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Gas Price:</strong>
-                </td>
-                <td>{formatUnits(transaction.gasPrice || 0n, 9)} Gwei</td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Data:</strong>
-                </td>
-                <td className="form-control">
-                  <textarea readOnly value={transaction.input} className="p-0 textarea-primary bg-inherit h-[150px]" />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Logs:</strong>
-                </td>
-                <td>
-                  <ul>
-                    {receipt?.logs?.map((log, i) => (
-                      <li key={i}>
-                        <strong>Log {i} topics:</strong> {JSON.stringify(log.topics, replacer, 2)}
-                      </li>
-                    ))}
-                  </ul>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <p className="text-2xl text-base-content">Loading...</p>
-      )}
-    </div>
-  );
+  return <TransactionComp txHash={txHash} />;
 };
 
 export default TransactionPage;

--- a/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
@@ -1,19 +1,21 @@
 import TransactionComp from "../_components/TransactionComp";
 import type { NextPage } from "next";
 import { Hash } from "viem";
+import { isZeroAddress } from "~~/utils/scaffold-eth/common";
 
 type PageProps = {
   params: { txHash?: Hash };
 };
 
 export function generateStaticParams() {
-  // An workaround to enable static exports in Next.js
+  // An workaround to enable static exports in Next.js, generating single dummy page.
   return [{ txHash: "0x0000000000000000000000000000000000000000" }];
 }
 const TransactionPage: NextPage<PageProps> = ({ params }: PageProps) => {
   const txHash = params?.txHash as Hash;
 
-  if (txHash === "0x0000000000000000000000000000000000000000") return null;
+  if (isZeroAddress(txHash)) return null;
+
   return <TransactionComp txHash={txHash} />;
 };
 

--- a/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
@@ -11,6 +11,8 @@ export function generateStaticParams() {
 }
 const TransactionPage: NextPage<PageProps> = ({ params }: PageProps) => {
   const txHash = params?.txHash as Hash;
+
+  if (txHash === "0x0000000000000000000000000000000000000000") return null;
   return <TransactionComp txHash={txHash} />;
 };
 

--- a/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/transaction/[txHash]/page.tsx
@@ -7,6 +7,7 @@ type PageProps = {
 };
 
 export function generateStaticParams() {
+  // An workaround to enable static exports in Next.js
   return [{ txHash: "0x0000000000000000000000000000000000000000" }];
 }
 const TransactionPage: NextPage<PageProps> = ({ params }: PageProps) => {

--- a/packages/nextjs/app/blockexplorer/transaction/_components/TransactionComp.tsx
+++ b/packages/nextjs/app/blockexplorer/transaction/_components/TransactionComp.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Hash, Transaction, TransactionReceipt, formatEther, formatUnits } from "viem";
+import { hardhat } from "viem/chains";
+import { usePublicClient } from "wagmi";
+import { Address } from "~~/components/scaffold-eth";
+import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
+import { decodeTransactionData, getFunctionDetails } from "~~/utils/scaffold-eth";
+import { replacer } from "~~/utils/scaffold-eth/common";
+
+const TransactionComp = ({ txHash }: { txHash: Hash }) => {
+  const client = usePublicClient({ chainId: hardhat.id });
+  const router = useRouter();
+  const [transaction, setTransaction] = useState<Transaction>();
+  const [receipt, setReceipt] = useState<TransactionReceipt>();
+  const [functionCalled, setFunctionCalled] = useState<string>();
+
+  const { targetNetwork } = useTargetNetwork();
+
+  useEffect(() => {
+    if (txHash && client) {
+      const fetchTransaction = async () => {
+        const tx = await client.getTransaction({ hash: txHash });
+        const receipt = await client.getTransactionReceipt({ hash: txHash });
+
+        const transactionWithDecodedData = decodeTransactionData(tx);
+        setTransaction(transactionWithDecodedData);
+        setReceipt(receipt);
+
+        const functionCalled = transactionWithDecodedData.input.substring(0, 10);
+        setFunctionCalled(functionCalled);
+      };
+
+      fetchTransaction();
+    }
+  }, [client, txHash]);
+
+  return (
+    <div className="container mx-auto mt-10 mb-20 px-10 md:px-0">
+      <button className="btn btn-sm btn-primary" onClick={() => router.back()}>
+        Back
+      </button>
+      {transaction ? (
+        <div className="overflow-x-auto">
+          <h2 className="text-3xl font-bold mb-4 text-center text-primary-content">Transaction Details</h2>{" "}
+          <table className="table rounded-lg bg-base-100 w-full shadow-lg md:table-lg table-md">
+            <tbody>
+              <tr>
+                <td>
+                  <strong>Transaction Hash:</strong>
+                </td>
+                <td>{transaction.hash}</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Block Number:</strong>
+                </td>
+                <td>{Number(transaction.blockNumber)}</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>From:</strong>
+                </td>
+                <td>
+                  <Address address={transaction.from} format="long" />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>To:</strong>
+                </td>
+                <td>
+                  {!receipt?.contractAddress ? (
+                    transaction.to && <Address address={transaction.to} format="long" />
+                  ) : (
+                    <span>
+                      Contract Creation:
+                      <Address address={receipt.contractAddress} format="long" />
+                    </span>
+                  )}
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Value:</strong>
+                </td>
+                <td>
+                  {formatEther(transaction.value)} {targetNetwork.nativeCurrency.symbol}
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Function called:</strong>
+                </td>
+                <td>
+                  <div className="w-full md:max-w-[600px] lg:max-w-[800px] overflow-x-auto whitespace-nowrap">
+                    {functionCalled === "0x" ? (
+                      "This transaction did not call any function."
+                    ) : (
+                      <>
+                        <span className="mr-2">{getFunctionDetails(transaction)}</span>
+                        <span className="badge badge-primary font-bold">{functionCalled}</span>
+                      </>
+                    )}
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Gas Price:</strong>
+                </td>
+                <td>{formatUnits(transaction.gasPrice || 0n, 9)} Gwei</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Data:</strong>
+                </td>
+                <td className="form-control">
+                  <textarea readOnly value={transaction.input} className="p-0 textarea-primary bg-inherit h-[150px]" />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Logs:</strong>
+                </td>
+                <td>
+                  <ul>
+                    {receipt?.logs?.map((log, i) => (
+                      <li key={i}>
+                        <strong>Log {i} topics:</strong> {JSON.stringify(log.topics, replacer, 2)}
+                      </li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-2xl text-base-content">Loading...</p>
+      )}
+    </div>
+  );
+};
+
+export default TransactionComp;

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -14,6 +14,7 @@ const nextConfig = {
     config.externals.push("pino-pretty", "lokijs", "encoding");
     return config;
   },
+  output: "export",
 };
 
 module.exports = nextConfig;

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -14,7 +14,6 @@ const nextConfig = {
     config.externals.push("pino-pretty", "lokijs", "encoding");
     return config;
   },
-  output: "export",
 };
 
 module.exports = nextConfig;

--- a/packages/nextjs/utils/scaffold-eth/common.ts
+++ b/packages/nextjs/utils/scaffold-eth/common.ts
@@ -1,3 +1,7 @@
 // To be used in JSON.stringify when a field might be bigint
 // https://wagmi.sh/react/faq#bigint-serialization
 export const replacer = (_key: string, value: unknown) => (typeof value === "bigint" ? value.toString() : value);
+
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export const isZeroAddress = (address: string) => address === ZERO_ADDRESS;


### PR DESCRIPTION
## Description

An alternate solution to #824 (which doesn't require manual work) 

As the error mentioned in #785 : 

> Error: Page "/blockexplorer/transaction/[txHash]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.


Therefore used [`generateStaticParams`](https://nextjs.org/docs/app/api-reference/functions/generate-static-params) from NextJs. 

```ts
export function generateStaticParams() {
  return [{ address: "0x0000000000000000000000000000000000000000" }];
}
```

having the above code in blockexplorers `/[address]` & `/[txHash]`, when NextJs build the prod version it will generate 2 static dummy pages and won't fail. 

--- 

Does having  `generateStaticParams` break the blockexplorer when tinkering around on localnetwork ? 

No, since [`dynamicPramas`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams) are enabled by default it should generate that page on demand. 

So TLDR; nothing breaks (at least In my testing) there is no side effect to current version of SE-2 and also having `output:export` in next.config.ts works out of the box.

The downside of the above thing, lol we have to add very hacky code in our codebase. 

---

<details>
<summary>

### Side quest : 

</summary>

Also an difference which I noticed on vercel deployment: 

| Main | This Branch | 
| ----- | ------------ | 
| ![Screenshot 2024-04-23 at 11 59 53 PM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/a49d3c42-093e-4b37-9ec8-0c65dc4453ef) | ![Screenshot 2024-04-24 at 12 01 01 AM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/0dcd362e-6d3b-42e5-bce2-76b92347a5e8) | 

Notice how on `main` branch is explicitly mentioned it spun up serverless functions for handling `/blockexplorer` page but didn't mention about it on this branch deployment. 

Since `dynamicParams` are enabled are by default it ideally should have shown right ? 

If I go to logs of request I made, it shows their that its using serverless functions : 

<details>
<summary>
Demo image: 
</summary>

![Screenshot 2024-04-24 at 12 01 33 AM](https://github.com/scaffold-eth/scaffold-eth-2/assets/80153681/515341f8-3eba-425d-8978-d91f2d539f10)


</details>



</details>




