### PR TITLE
chore: adding engines fields in package.json to hint people

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "devDependencies": {
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3"
+  },
+  "engines": {
+    "node": ">=18.17.0"
   }
 }


### PR DESCRIPTION
## Description

I have added 'engines' to the package.json file. This practice ensures consistency in the development environment, which is crucial when collaborating with colleagues who may have different versions of Node.js installed

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: wolfcito.eth
