### PR TITLE
Adjust QR Code modal spacing to fix copy icon size on bigger fonts

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
@@ -20,7 +20,7 @@ export const AddressQRCodeModal = ({ address, modalId }: AddressQRCodeModalProps
               ✕
             </label>
             <div className="space-y-3 py-6">
-              <div className="flex space-x-4 flex-col items-center gap-6">
+              <div className="flex flex-col items-center gap-6">
                 <QRCodeSVG value={address} size={256} />
                 <Address address={address} format="long" disableAddressLink />
               </div>


### PR DESCRIPTION
## Description

Fixes #835 

Feel free to close this PR if we should not handle issues on different fonts 🙌. Thought it would good to create because was happening in SRE challenges, but maybe not!

For address `0x04AAa2B551eaAb54568a5546be5d61407cA9D70c` is looking like this in Challeneges after fix:

![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/55535804/30abd48f-7244-4499-b5bc-46349d11bf4f)


