### PR TITLE
fix: useScaffoldWatchContractEvent logs args types

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -14,7 +14,6 @@ import type { MergeDeepRecord } from "type-fest/source/merge-deep";
 import {
   Address,
   Block,
-  ContractEventName,
   GetEventArgs,
   GetTransactionReceiptReturnType,
   GetTransactionReturnType,
@@ -215,24 +214,19 @@ export type UseScaffoldEventConfig<
   >,
 > = {
   contractName: TContractName;
+  eventName: TEventName;
 } & IsContractDeclarationMissing<
-  Omit<UseWatchContractEventParameters, "onLogs" | "address" | "abi"> & {
+  Omit<UseWatchContractEventParameters, "onLogs" | "address" | "abi" | "eventName"> & {
     onLogs: (
       logs: Simplify<
         Omit<Log<bigint, number, any>, "args" | "eventName"> & {
           args: Record<string, unknown>;
-          eventName: TEventName;
+          eventName: string;
         }
       >[],
     ) => void;
   },
-  Omit<
-    UseWatchContractEventParameters<
-      ContractAbi<TContractName>,
-      TEventName extends ContractEventName<ContractAbi<TContractName>> ? TEventName : never
-    >,
-    "onLogs" | "address" | "abi"
-  > & {
+  Omit<UseWatchContractEventParameters<ContractAbi<TContractName>>, "onLogs" | "address" | "abi" | "eventName"> & {
     onLogs: (
       logs: Simplify<
         Omit<Log<bigint, number, false, TEvent, false, [TEvent], TEventName>, "args"> & {

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -14,6 +14,7 @@ import type { MergeDeepRecord } from "type-fest/source/merge-deep";
 import {
   Address,
   Block,
+  ContractEventName,
   GetEventArgs,
   GetTransactionReceiptReturnType,
   GetTransactionReturnType,
@@ -220,12 +221,18 @@ export type UseScaffoldEventConfig<
       logs: Simplify<
         Omit<Log<bigint, number, any>, "args" | "eventName"> & {
           args: Record<string, unknown>;
-          eventName: string;
+          eventName: TEventName;
         }
       >[],
     ) => void;
   },
-  Omit<UseWatchContractEventParameters<ContractAbi<TContractName>>, "onLogs" | "address" | "abi"> & {
+  Omit<
+    UseWatchContractEventParameters<
+      ContractAbi<TContractName>,
+      TEventName extends ContractEventName<ContractAbi<TContractName>> ? TEventName : never
+    >,
+    "onLogs" | "address" | "abi"
+  > & {
     onLogs: (
       logs: Simplify<
         Omit<Log<bigint, number, false, TEvent, false, [TEvent], TEventName>, "args"> & {


### PR DESCRIPTION
## Description

Currently, types of arguments doesn't work as expected when contract has more that one event. Example:

if I just add `event SomeOtherEvent(string someString, uint256 someValue);` to `YourContract.sol`, I'm receiving this error when trying to work with logs from `useScaffoldWatchContractEvent`.

<img width="1088" alt="Снимок экрана 2024-05-03 в 20 31 39" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/25638585/960eb5d5-0db6-400b-9e5c-6e3478889101">


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
