### PR TITLE
Add default favicon

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/getMetadata.ts
+++ b/packages/nextjs/utils/scaffold-eth/getMetadata.ts
@@ -42,5 +42,8 @@ export const getMetadata = ({
       description: description,
       images: [imageUrl],
     },
+    icons: {
+      icon: [{ url: "/favicon.png", sizes: "32x32", type: "image/png" }],
+    },
   };
 };


### PR DESCRIPTION
## Description

Fixes #850 

In order to get our default favicon back, we could follow different approaches (let me know if I missed a better approach!):

1. Add it explicitly to `getMetadata`.
2. Add it as optional prop with default value to `getMetadata`, similar to how we handling unfurl image with `imageRelativePath` prop.
3. Moving `favicon.png` from /public to /app and rename it to `icon.png` or change the format to `favicon.ico`. See [this](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/app-icons)

I went for 1 just because it felt simple, and if I had to change the favicon for my app, I'd probably search favicon/icon in the code. 

I don't have a strong opinion about this, would love to know what do you think the best practice would be. TYSM ♥