### PR TITLE
Add zeros to native currency price when price is integer

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -26,7 +26,7 @@ export const Footer = () => {
               <div>
                 <div className="btn btn-primary btn-sm font-normal gap-1 cursor-auto">
                   <CurrencyDollarIcon className="h-4 w-4" />
-                  <span>{nativeCurrencyPrice}</span>
+                  <span>{nativeCurrencyPrice.toFixed(2)}</span>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Description
Add zeros to native currency price when price is integer

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Before:
<img width="118" alt="Снимок экрана 2024-05-28 в 12 38 48" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/25638585/7748418a-3e4f-423d-8601-c9b65685f233">

After:
<img width="128" alt="Снимок экрана 2024-05-28 в 12 39 27" src="https://github.com/scaffold-eth/scaffold-eth-2/assets/25638585/60935afd-f892-451c-b1f8-ff5135920b98">


