### PR TITLE
Add use effect on Balance component for the price

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Address, formatEther } from "viem";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { useWatchBalance } from "~~/hooks/scaffold-eth/useWatchBalance";
@@ -27,6 +27,10 @@ export const Balance = ({ address, className = "", usdMode }: BalanceProps) => {
   });
 
   const [displayUsdMode, setDisplayUsdMode] = useState(price > 0 ? Boolean(usdMode) : false);
+
+  useEffect(() => {
+    setDisplayUsdMode(price > 0 ? Boolean(usdMode) : false);
+  }, [usdMode, price]);
 
   const toggleBalanceMode = () => {
     if (price > 0) {


### PR DESCRIPTION
The `usdMode` flag wasn't working on our `Balance` component, since the price takes some time to load and we were always setting `displayUsdMode` to false on the first render (price > 0 condition)

You can test in `page.tsx` 
```tsx
/* This will always show the Balance in ETH mode, even if we say usdMode */
<Balance address={connectedAddress} usdMode /> 
```

This PR adds the missing `useEffect` (as in EtherInput).




