### PR TITLE
Add OP Retro Funding round 4 verification

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,5 @@
+{
+  "opRetro": {
+    "projectId": "0x79196c0af1a1f78fe5a009a4753c46d2271b17fc2836e1f6635822f8f4cb3b61"
+  }
+}


### PR DESCRIPTION
## Description

Adding a few repositories to our OP Retro Funding Round 4 submission. In order to verify, OP asks to add this json file at the root folder of the repo.

We are adding to our submission these repos:

- [x] Scaffold-ETH
- [x] SE-2 Challenges
- [x] SE-2 docs
- [x] Scaffold-ETH 2
- [x] Sand Garden
- [x] Scaffold-Base

I guess we'll be able to delete after the round. Hopefully in Round 7 (Dev Tooling) they can add other kind of verification.

![image](https://github.com/scaffold-eth/scaffold-eth-2/assets/55535804/8d2ff887-a942-4d53-8303-aafc9153ab95)
