### PR TITLE
lock typescript and abitype version

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -43,7 +43,7 @@
     "@types/react": "^18.0.9",
     "@types/react-copy-to-clipboard": "^5.0.4",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
-    "abitype": "^1.0.2",
+    "abitype": "1.0.2",
     "autoprefixer": "^10.4.12",
     "eslint": "^8.15.0",
     "eslint-config-next": "^14.0.4",
@@ -53,7 +53,7 @@
     "prettier": "^2.8.4",
     "tailwindcss": "^3.4.3",
     "type-fest": "^4.6.0",
-    "typescript": "^5.1.6",
+    "typescript": "5.1.6",
     "vercel": "^32.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,7 +2151,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.39.0
     "@uniswap/sdk-core": ^4.0.1
     "@uniswap/v2-sdk": ^3.0.1
-    abitype: ^1.0.2
+    abitype: 1.0.2
     autoprefixer: ^10.4.12
     blo: ^1.0.1
     burner-connector: ^0.0.8
@@ -2172,7 +2172,7 @@ __metadata:
     react-hot-toast: ^2.4.0
     tailwindcss: ^3.4.3
     type-fest: ^4.6.0
-    typescript: ^5.1.6
+    typescript: 5.1.6
     use-debounce: ^8.0.4
     usehooks-ts: ^2.13.0
     vercel: ^32.4.1
@@ -3847,7 +3847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abitype@npm:^1.0.2":
+"abitype@npm:1.0.2":
   version: 1.0.2
   resolution: "abitype@npm:1.0.2"
   peerDependencies:
@@ -13923,6 +13923,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.1.6":
+  version: 5.1.6
+  resolution: "typescript@npm:5.1.6"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.1.6":
   version: 5.2.2
   resolution: "typescript@npm:5.2.2"
@@ -13940,6 +13950,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@5.1.6#~builtin<compat/typescript>":
+  version: 5.1.6
+  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=a1c5e5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description: 

Seems there is some problem in new typescript version, it not registering AddressType properly. So for now locked it's version. 

Also locked the version of abitype (just to be future proof, since we have also locked viem and wagmi version). 

Fixes #870 

### To test: 
Run on main branch and it fails : 

```shell
yarn vercel
```


Switch to this pr branch and run `yarn vercel` and it should work