### PR TITLE
Fixes BigInt parsing losing precision in IntegerInput

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
@@ -21,6 +21,11 @@ const isJsonString = (str: string) => {
 // Recursive function to deeply parse JSON strings, correctly handling nested arrays and encoded JSON strings
 const deepParseValues = (value: any): any => {
   if (typeof value === "string") {
+    try {
+      return BigInt(value);
+    } catch (e) {
+      // It's not a BigInt, continue
+    }
     if (isJsonString(value)) {
       const parsed = JSON.parse(value);
       return deepParseValues(parsed);

--- a/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
@@ -18,21 +18,31 @@ const isJsonString = (str: string) => {
   }
 };
 
+const isBigInt = (str: string) => {
+  if (str.trim().length === 0) return false;
+  try {
+    BigInt(str);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
 // Recursive function to deeply parse JSON strings, correctly handling nested arrays and encoded JSON strings
 const deepParseValues = (value: any): any => {
   if (typeof value === "string") {
-    try {
+    // first try with bigInt because we losse precision with JSON.parse
+    if (isBigInt(value)) {
       return BigInt(value);
-    } catch (e) {
-      // It's not a BigInt, continue
     }
+
     if (isJsonString(value)) {
       const parsed = JSON.parse(value);
       return deepParseValues(parsed);
-    } else {
-      // It's a string but not a JSON string, return as is
-      return value;
     }
+
+    // It's a string but not a JSON string, return as is
+    return value;
   } else if (Array.isArray(value)) {
     // If it's an array, recursively parse each element
     return value.map(element => deepParseValues(element));


### PR DESCRIPTION
## Description

When entering a large number into an `IntegerInput` component, it is parsed as a JSON string and loses precision.

For example, entering `85604566775863511922702956178915374775782418036268384638508224920020197708340` is parsed into `85604566775863516368369806302131844469805175632226226214501379502487210295296`.

This is fixed by first attempting to convert the `string` value to a `BigInt` and then returning that value if successful.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: paulburke.eth
