### PR TITLE
fix: inputs parsing numbers instead of address

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsContract.tsx
@@ -19,7 +19,7 @@ const isJsonString = (str: string) => {
 };
 
 const isBigInt = (str: string) => {
-  if (str.trim().length === 0) return false;
+  if (str.trim().length === 0 || str.startsWith("0")) return false;
   try {
     BigInt(str);
     return true;


### PR DESCRIPTION
### Description :

Actually this was caused due to #893. 

When people try to enter address is converted to BigInt. 


https://github.com/user-attachments/assets/5cda53c3-8e16-4cdf-b5e1-c23cf70f1e03

