### PR TITLE
foundry: separate out your contract deployments

### DIFF
--- a/packages/foundry/script/00_deploy_your_contract.s.sol
+++ b/packages/foundry/script/00_deploy_your_contract.s.sol
@@ -1,0 +1,21 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../contracts/YourContract.sol";
+import "./DeployHelpers.s.sol";
+
+contract DeployYourContract is ScaffoldETHDeploy {
+  function run() external {
+    uint256 deployerPrivateKey = setupLocalhostEnv();
+    vm.startBroadcast(deployerPrivateKey);
+
+    YourContract yourContract = new YourContract(vm.addr(deployerPrivateKey));
+    console.logString(
+      string.concat(
+        "YourContract deployed at: ", vm.toString(address(yourContract))
+      )
+    );
+
+    vm.stopBroadcast();
+  }
+}

--- a/packages/foundry/script/Deploy.s.sol
+++ b/packages/foundry/script/Deploy.s.sol
@@ -6,27 +6,30 @@ import "./DeployHelpers.s.sol";
 import { DeployYourContract } from "./00_deploy_your_contract.s.sol";
 
 contract DeployScript is ScaffoldETHDeploy {
+  uint256 deployerPrivateKey;
+
   error InvalidPrivateKey(string);
 
-  function run() external {
-    // check for the deployer account
-    uint256 deployerPrivateKey = setupLocalhostEnv();
+  constructor() {
+    deployerPrivateKey = setupLocalhostEnv();
+  }
+
+  function run() external checkDeployerPrivateKey deploymentExporter {
+    DeployYourContract deployYourContract = new DeployYourContract();
+    deployYourContract.run();
+  }
+
+  modifier checkDeployerPrivateKey() {
     if (deployerPrivateKey == 0) {
       revert InvalidPrivateKey(
         "You don't have a deployer account. Make sure you have set DEPLOYER_PRIVATE_KEY in .env or use `yarn generate` to generate a new random account"
       );
     }
-
-    DeployYourContract deployYourContract = new DeployYourContract();
-    deployYourContract.run();
-
-    /**
-     * This function generates the file containing the contracts Abi definitions.
-     * These definitions are used to derive the types needed in the custom scaffold-eth hooks, for example.
-     * This function should be called last.
-     */
-    exportDeployments();
+    _;
   }
 
-  function test() public { }
+  modifier deploymentExporter() {
+    _;
+    exportDeployments();
+  }
 }

--- a/packages/foundry/script/Deploy.s.sol
+++ b/packages/foundry/script/Deploy.s.sol
@@ -17,6 +17,10 @@ contract DeployScript is ScaffoldETHDeploy {
   function run() external ScaffoldEthDeployerRunner {
     DeployYourContract deployYourContract = new DeployYourContract();
     deployYourContract.run();
+
+    // deploy more contracts here
+    // DeployMyContract deployMyContract = new DeployMyContract();
+    // deployMyContract.run();
   }
 
   modifier ScaffoldEthDeployerRunner() {

--- a/packages/foundry/script/Deploy.s.sol
+++ b/packages/foundry/script/Deploy.s.sol
@@ -3,27 +3,22 @@ pragma solidity ^0.8.19;
 
 import "../contracts/YourContract.sol";
 import "./DeployHelpers.s.sol";
+import { DeployYourContract } from "./00_deploy_your_contract.s.sol";
 
 contract DeployScript is ScaffoldETHDeploy {
   error InvalidPrivateKey(string);
 
   function run() external {
+    // check for the deployer account
     uint256 deployerPrivateKey = setupLocalhostEnv();
     if (deployerPrivateKey == 0) {
       revert InvalidPrivateKey(
         "You don't have a deployer account. Make sure you have set DEPLOYER_PRIVATE_KEY in .env or use `yarn generate` to generate a new random account"
       );
     }
-    vm.startBroadcast(deployerPrivateKey);
 
-    YourContract yourContract = new YourContract(vm.addr(deployerPrivateKey));
-    console.logString(
-      string.concat(
-        "YourContract deployed at: ", vm.toString(address(yourContract))
-      )
-    );
-
-    vm.stopBroadcast();
+    DeployYourContract deployYourContract = new DeployYourContract();
+    deployYourContract.run();
 
     /**
      * This function generates the file containing the contracts Abi definitions.

--- a/packages/foundry/script/Deploy.s.sol
+++ b/packages/foundry/script/Deploy.s.sol
@@ -14,21 +14,17 @@ contract DeployScript is ScaffoldETHDeploy {
     deployerPrivateKey = setupLocalhostEnv();
   }
 
-  function run() external checkDeployerPrivateKey deploymentExporter {
+  function run() external ScaffoldEthDeployerRunner {
     DeployYourContract deployYourContract = new DeployYourContract();
     deployYourContract.run();
   }
 
-  modifier checkDeployerPrivateKey() {
+  modifier ScaffoldEthDeployerRunner() {
     if (deployerPrivateKey == 0) {
       revert InvalidPrivateKey(
         "You don't have a deployer account. Make sure you have set DEPLOYER_PRIVATE_KEY in .env or use `yarn generate` to generate a new random account"
       );
     }
-    _;
-  }
-
-  modifier deploymentExporter() {
     _;
     exportDeployments();
   }


### PR DESCRIPTION
### Description: 

Separate your contract deploy script from so that we enforce people to follow a pattern. 

The reason we need to enforce this pattern is because `exportDeployments()` should be called only once and too after all the deployments are done. 

So basically `Deploy.s.sol` file is the main file which import different deploy script of different contracts and in the end it calls the `exportDeployments()` which creates all the necessary files for generateTsAbi.js fucntion. 

Checkout second part of this for more details : https://github.com/scaffold-eth/scaffold-eth-2/pull/781#issuecomment-2018642266

CC @jrcarlos2000 feel free suggest some cleanups / better practices in foundry. 

### Some notes: 

- Kindof similar patter followed in this twitter thread https://x.com/jj_ranalli/status/1656384664020434949
- Foundry discussion / issue having better deployment mangement flow : https://github.com/foundry-rs/foundry/issues/4732
- [forge-deploy](https://github.com/wighawag/forge-deploy) from the creator of `hardhat-deploy` (which we are currently using for better dev flow in hardhat) but forge-deploy seems to add extra steps / commands? (saying this without trying, and something we need to maybe tinker in future PR's) 

