### PR TITLE
Handle tx revert in `useTransactor`

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -77,16 +77,14 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
       });
       notification.remove(notificationId);
 
-      if (transactionReceipt.status === "success") {
-        notification.success(
-          <TxnNotification message="Transaction completed successfully!" blockExplorerLink={blockExplorerTxURL} />,
-          {
-            icon: "🎉",
-          },
-        );
-      } else {
-        throw new Error("Transaction reverted");
-      }
+      if (transactionReceipt.status === "reverted") throw new Error("Transaction reverted");
+
+      notification.success(
+        <TxnNotification message="Transaction completed successfully!" blockExplorerLink={blockExplorerTxURL} />,
+        {
+          icon: "🎉",
+        },
+      );
 
       if (options?.onBlockConfirmation) options.onBlockConfirmation(transactionReceipt);
     } catch (error: any) {

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -77,12 +77,18 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
       });
       notification.remove(notificationId);
 
-      notification.success(
-        <TxnNotification message="Transaction completed successfully!" blockExplorerLink={blockExplorerTxURL} />,
-        {
-          icon: "🎉",
-        },
-      );
+      if (transactionReceipt.status === "success") {
+        notification.success(
+          <TxnNotification message="Transaction completed successfully!" blockExplorerLink={blockExplorerTxURL} />,
+          {
+            icon: "🎉",
+          },
+        );
+      } else {
+        notification.error(<TxnNotification message="Transaction reverted" blockExplorerLink={blockExplorerTxURL} />, {
+          icon: "⛔",
+        });
+      }
 
       if (options?.onBlockConfirmation) options.onBlockConfirmation(transactionReceipt);
     } catch (error: any) {

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -85,9 +85,7 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
           },
         );
       } else {
-        notification.error(<TxnNotification message="Transaction reverted" blockExplorerLink={blockExplorerTxURL} />, {
-          icon: "⛔",
-        });
+        throw new Error("Transaction reverted");
       }
 
       if (options?.onBlockConfirmation) options.onBlockConfirmation(transactionReceipt);


### PR DESCRIPTION
## Video Demo
https://www.loom.com/share/2727672272374fbba1c4afcc33b8d9a3?sid=d22eb180-f1de-4629-8256-413802920376

## Issue
- The `useTransactor` hook displays a success notification even if the transaction reverts, which is confusing for users.
- When using tanstack's `useMutation`, the `onSuccess` will trigger even when the tx reverts 

## Proposal
- Only show success notification when tx receipt status is success
- Throw a "Transaction reverted" error if tx receipt status is not `"success"` 
    - so that `useMutation`'s `onError` is triggered 
    - so that user sees a "Transaction reverted" notification
    - so developer that is relying on transaction successfully executing doesnt get wrecked :melting_face: 


## Example Resources

- https://use-transactor-example.vercel.app/
- https://github.com/MattPereira/scaffold-eth-2/tree/tx-revert-example

