### PR TITLE
Exclude external links from triggering progress bar

### DIFF
--- a/packages/nextjs/components/scaffold-eth/ProgressBar.tsx
+++ b/packages/nextjs/components/scaffold-eth/ProgressBar.tsx
@@ -49,9 +49,8 @@ export function ProgressBar() {
       const targetUrl = anchor.href;
       const currentUrl = location.href;
       const isTargetBlank = anchor?.target === "_blank";
-      if (targetUrl !== currentUrl && !isTargetBlank) {
-        NProgress.start();
-      }
+      if (targetUrl === currentUrl || isTargetBlank) return;
+      NProgress.start();
     };
 
     const handleMutation: MutationCallback = () => {

--- a/packages/nextjs/components/scaffold-eth/ProgressBar.tsx
+++ b/packages/nextjs/components/scaffold-eth/ProgressBar.tsx
@@ -45,9 +45,10 @@ export function ProgressBar() {
     NProgress.configure({ showSpinner: false });
 
     const handleAnchorClick = (event: MouseEvent) => {
-      const targetUrl = (event.currentTarget as HTMLAnchorElement).href;
+      const anchor = event.currentTarget as HTMLAnchorElement;
+      const targetUrl = anchor.href;
       const currentUrl = location.href;
-      if (targetUrl !== currentUrl) {
+      if (targetUrl !== currentUrl && !anchor.target) {
         NProgress.start();
       }
     };

--- a/packages/nextjs/components/scaffold-eth/ProgressBar.tsx
+++ b/packages/nextjs/components/scaffold-eth/ProgressBar.tsx
@@ -48,7 +48,8 @@ export function ProgressBar() {
       const anchor = event.currentTarget as HTMLAnchorElement;
       const targetUrl = anchor.href;
       const currentUrl = location.href;
-      if (targetUrl !== currentUrl && !anchor.target) {
+      const isTargetBlank = anchor?.target === "_blank";
+      if (targetUrl !== currentUrl && !isTargetBlank) {
         NProgress.start();
       }
     };


### PR DESCRIPTION
## Description

-> Modifies the nprogress bar so that it only forks for non external links.


-> Implements the changes from:
https://github.com/BuidlGuidl/extensions-hackathon/pull/23#event-13881221641



https://github.com/user-attachments/assets/0f191f3c-b02b-4782-981c-89192d958b21


## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Fixes #908 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
