### PR TITLE
show blockexplorer link when transaction receipt is reverted

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -1,5 +1,5 @@
 import { getPublicClient } from "@wagmi/core";
-import { Hash, SendTransactionParameters, WalletClient } from "viem";
+import { Hash, SendTransactionParameters, TransactionReceipt, WalletClient } from "viem";
 import { Config, useWalletClient } from "wagmi";
 import { SendTransactionMutate } from "wagmi/query";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
@@ -48,6 +48,8 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
 
     let notificationId = null;
     let transactionHash: Hash | undefined = undefined;
+    let transactionReceipt: TransactionReceipt | undefined;
+    let blockExplorerTxURL = "";
     try {
       const network = await walletClient.getChainId();
       // Get full transaction from public client
@@ -65,13 +67,13 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
       }
       notification.remove(notificationId);
 
-      const blockExplorerTxURL = network ? getBlockExplorerTxLink(network, transactionHash) : "";
+      blockExplorerTxURL = network ? getBlockExplorerTxLink(network, transactionHash) : "";
 
       notificationId = notification.loading(
         <TxnNotification message="Waiting for transaction to complete." blockExplorerLink={blockExplorerTxURL} />,
       );
 
-      const transactionReceipt = await publicClient.waitForTransactionReceipt({
+      transactionReceipt = await publicClient.waitForTransactionReceipt({
         hash: transactionHash,
         confirmations: options?.blockConfirmations,
       });
@@ -93,6 +95,13 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
       }
       console.error("⚡️ ~ file: useTransactor.ts ~ error", error);
       const message = getParsedError(error);
+
+      // if receipt was reverted, show notification with block explorer link and return error
+      if (transactionReceipt?.status === "reverted") {
+        notification.error(<TxnNotification message={message} blockExplorerLink={blockExplorerTxURL} />);
+        throw error;
+      }
+
       notification.error(message);
       throw error;
     }


### PR DESCRIPTION
## Description

I think its nice UX to point to user to block explorer when transaction receipt is reverted. Viem does not give us the actual reason for transaction receipt revert as mentioned [here](https://github.com/wevm/viem/issues/1767#issuecomment-1925986197) they only give you status "reverted". So maybe its nice idea to point to block explorer for actual reason. 

<img width="239" alt="image" src="https://github.com/user-attachments/assets/153754b9-87e2-43ae-a754-26ac22b12ea7">

To test you could checkout: 
```shel
git switch tx-revert-example
```

Checkout home page on how to make transaction revert or you could checkout Matt's video [here](https://www.loom.com/share/2727672272374fbba1c4afcc33b8d9a3?sid=d22eb180-f1de-4629-8256-413802920376). I have just bought Matt's example branch here and updated `useTransactor` with this branch code. 

<details>

<summary>
Demo video : 
</summary>


https://github.com/user-attachments/assets/f894c898-4094-4b28-b823-954d096173ff



</details>
