### PR TITLE
allow json module imports

### DIFF
--- a/packages/hardhat/tsconfig.json
+++ b/packages/hardhat/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2020",
     "module": "commonjs",
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Description

This allows importing json in `.ts` files for example in scripts. 

to test : 

```shell
cd packages/hardhat
```

```shell
echo '{"test": "value"}' > scripts/test.json
```

then create a new file in `scripts/test.ts` and try importing it: 

```ts
import test from "./test.json";
console.log(test);
```

^ on main branch above should give you ts error: 

"Cannot find module './test.json'. Consider using '--resolveJsonModule' to import module with '.json' extension. [2732]"

But on this branch it should work. 

Also to see if script runs at runtime properly make sure you are `cd packages/hardhat` and then run :

```shell
yarn hardhat run scripts/test.ts
```


