### PR TITLE
Reset enteredEns on Address input when changing the value

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { blo } from "blo";
 import { useDebounceValue } from "usehooks-ts";
 import { Address, isAddress } from "viem";
@@ -70,14 +70,6 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
     setEnteredEnsName(undefined);
   }, [value]);
 
-  const handleChange = useCallback(
-    (newValue: Address) => {
-      setEnteredEnsName(undefined);
-      onChange(newValue);
-    },
-    [onChange],
-  );
-
   const reFocus =
     isEnsAddressError ||
     isEnsNameError ||
@@ -92,7 +84,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
       placeholder={placeholder}
       error={ensAddress === null}
       value={value as Address}
-      onChange={handleChange}
+      onChange={onChange}
       disabled={isEnsAddressLoading || isEnsNameLoading || disabled}
       reFocus={reFocus}
       prefix={

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -66,6 +66,10 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
     onChange(ensAddress);
   }, [ensAddress, onChange, debouncedValue]);
 
+  useEffect(() => {
+    setEnteredEnsName(undefined);
+  }, [value]);
+
   const handleChange = useCallback(
     (newValue: Address) => {
       setEnteredEnsName(undefined);


### PR DESCRIPTION
There is a bug in the AddressInput component that shows when changing the value from the outside without triggering `onChange`.

To test:

1. Enter `atg.eth` => it resolves and shows the blockie, ensName, and avatar
2. Click the Change address button. Everything works except the ensName which remains the same.

```tsx
"use client";

import { useState } from "react";
import type { NextPage } from "next";
import { useAccount } from "wagmi";
import { AddressInput } from "~~/components/scaffold-eth";

const Home: NextPage = () => {
  const [inputAddress, setInputAddress] = useState("");
  return (
    <>
      <div className="flex items-center flex-col flex-grow pt-10 gap-2">
        <AddressInput value={inputAddress} onChange={setInputAddress} />
        <button
          className="btn btn-primary"
          onClick={() => setInputAddress("0x60583563d5879c2e59973e5718c7de2147971807")}
        >
          Change Address
        </button>
      </div>
    </>
  );
};

export default Home;
```

----

We found this while working on https://github.com/BuidlGuidl/buidlguidl.com/pull/33