### PR TITLE
Shadcn rainbowkit button + dropdown

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -133,7 +133,7 @@ export const AddressInfoDropdown = ({
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full justify-start text-red-600"
+                className="w-full justify-start text-destructive"
                 onClick={() => {
                   disconnect();
                   closeDropdown();

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -1,4 +1,5 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
+import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { NetworkOptions } from "./NetworkOptions";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { getAddress } from "viem";
@@ -14,7 +15,13 @@ import {
   QrCodeIcon,
 } from "@heroicons/react/24/outline";
 import { BlockieAvatar, isENS } from "~~/components/scaffold-eth";
-import { useOutsideClick } from "~~/hooks/scaffold-eth";
+import { Button } from "~~/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "~~/components/ui/dropdown-menu";
 import { getTargetNetworks } from "~~/utils/scaffold-eth";
 
 const allowedNetworks = getTargetNetworks();
@@ -34,104 +41,111 @@ export const AddressInfoDropdown = ({
 }: AddressInfoDropdownProps) => {
   const { disconnect } = useDisconnect();
   const checkSumAddress = getAddress(address);
+  const [open, setOpen] = useState(false);
 
   const [addressCopied, setAddressCopied] = useState(false);
 
   const [selectingNetwork, setSelectingNetwork] = useState(false);
-  const dropdownRef = useRef<HTMLDetailsElement>(null);
   const closeDropdown = () => {
     setSelectingNetwork(false);
-    dropdownRef.current?.removeAttribute("open");
+    setOpen(false);
   };
-  useOutsideClick(dropdownRef, closeDropdown);
 
   return (
-    <>
-      <details ref={dropdownRef} className="dropdown dropdown-end leading-3">
-        <summary tabIndex={0} className="btn btn-secondary btn-sm pl-0 pr-2 shadow-md dropdown-toggle gap-0 !h-auto">
+    <DropdownMenu open={open}>
+      <DropdownMenuTrigger asChild onClick={() => setOpen(open => !open)}>
+        <Button size="sm" variant="secondary" className="pl-0 pr-2 gap-0 h-auto">
           <BlockieAvatar address={checkSumAddress} size={30} ensImage={ensAvatar} />
           <span className="ml-2 mr-1">
             {isENS(displayName) ? displayName : checkSumAddress?.slice(0, 6) + "..." + checkSumAddress?.slice(-4)}
           </span>
           <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
-        </summary>
-        <ul
-          tabIndex={0}
-          className="dropdown-content menu z-[2] p-2 mt-2 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
-        >
-          <NetworkOptions hidden={!selectingNetwork} />
-          <li className={selectingNetwork ? "hidden" : ""}>
-            {addressCopied ? (
-              <div className="btn-sm !rounded-xl flex gap-3 py-3">
-                <CheckCircleIcon
-                  className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
-                  aria-hidden="true"
-                />
-                <span className=" whitespace-nowrap">Copy address</span>
-              </div>
-            ) : (
-              <CopyToClipboard
-                text={checkSumAddress}
-                onCopy={() => {
-                  setAddressCopied(true);
-                  setTimeout(() => {
-                    setAddressCopied(false);
-                  }, 800);
-                }}
-              >
-                <div className="btn-sm !rounded-xl flex gap-3 py-3">
-                  <DocumentDuplicateIcon
-                    className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
-                    aria-hidden="true"
-                  />
-                  <span className=" whitespace-nowrap">Copy address</span>
-                </div>
-              </CopyToClipboard>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="border-none bg-base-200 rounded-2xl"
+        onInteractOutside={closeDropdown}
+      >
+        <NetworkOptions hidden={!selectingNetwork} />
+        {!selectingNetwork && (
+          <>
+            <DropdownMenuItem asChild>
+              <Button variant="ghost" size="sm" className="w-full justify-start">
+                {addressCopied ? (
+                  <div className="flex items-center">
+                    <CheckCircleIcon
+                      className="text-xl font-normal h-6 w-4 cursor-pointer mr-2 ml-2 sm:ml-0"
+                      aria-hidden="true"
+                    />
+                    <span className="whitespace-nowrap">Copied!</span>
+                  </div>
+                ) : (
+                  <CopyToClipboard
+                    text={checkSumAddress}
+                    onCopy={() => {
+                      setAddressCopied(true);
+                      setTimeout(() => {
+                        setAddressCopied(false);
+                      }, 800);
+                    }}
+                  >
+                    <div className="flex items-center w-full">
+                      <DocumentDuplicateIcon className="text-xl font-normal h-6 w-4 mr-2" aria-hidden="true" />
+                      <span className="whitespace-nowrap">Copy address</span>
+                    </div>
+                  </CopyToClipboard>
+                )}
+              </Button>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Button variant="ghost" size="sm" className="w-full justify-start">
+                <AddressQRCodeModal address={address}>
+                  <div className="flex items-center w-full">
+                    <QrCodeIcon className="mr-2 h-4 w-4" />
+                    <span>View QR Code</span>
+                  </div>
+                </AddressQRCodeModal>
+              </Button>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Button variant="ghost" size="sm" className="w-full justify-start" asChild>
+                <a target="_blank" href={blockExplorerAddressLink} rel="noopener noreferrer">
+                  <ArrowTopRightOnSquareIcon className="mr-2 h-4 w-4" />
+                  View on Block Explorer
+                </a>
+              </Button>
+            </DropdownMenuItem>
+            {allowedNetworks.length > 1 && (
+              <DropdownMenuItem asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start"
+                  onClick={() => setSelectingNetwork(true)}
+                >
+                  <ArrowsRightLeftIcon className="mr-2 h-4 w-4" />
+                  <span>Switch Network</span>
+                </Button>
+              </DropdownMenuItem>
             )}
-          </li>
-          <li className={selectingNetwork ? "hidden" : ""}>
-            <label htmlFor="qrcode-modal" className="btn-sm !rounded-xl flex gap-3 py-3">
-              <QrCodeIcon className="h-6 w-4 ml-2 sm:ml-0" />
-              <span className="whitespace-nowrap">View QR Code</span>
-            </label>
-          </li>
-          <li className={selectingNetwork ? "hidden" : ""}>
-            <button className="menu-item btn-sm !rounded-xl flex gap-3 py-3" type="button">
-              <ArrowTopRightOnSquareIcon className="h-6 w-4 ml-2 sm:ml-0" />
-              <a
-                target="_blank"
-                href={blockExplorerAddressLink}
-                rel="noopener noreferrer"
-                className="whitespace-nowrap"
-              >
-                View on Block Explorer
-              </a>
-            </button>
-          </li>
-          {allowedNetworks.length > 1 ? (
-            <li className={selectingNetwork ? "hidden" : ""}>
-              <button
-                className="btn-sm !rounded-xl flex gap-3 py-3"
-                type="button"
+            <DropdownMenuItem asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start text-red-600"
                 onClick={() => {
-                  setSelectingNetwork(true);
+                  disconnect();
+                  closeDropdown();
                 }}
               >
-                <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Switch Network</span>
-              </button>
-            </li>
-          ) : null}
-          <li className={selectingNetwork ? "hidden" : ""}>
-            <button
-              className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"
-              type="button"
-              onClick={() => disconnect()}
-            >
-              <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
-            </button>
-          </li>
-        </ul>
-      </details>
-    </>
+                <ArrowLeftOnRectangleIcon className="mr-2 h-4 w-4" />
+                <span>Disconnect</span>
+              </Button>
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -67,7 +67,7 @@ export const AddressInfoDropdown = ({
         {!selectingNetwork && (
           <>
             <DropdownMenuItem asChild>
-              <Button variant="ghost" size="sm">
+              <Button variant="ghost" size="sm" className="w-full justify-start">
                 {addressCopied ? (
                   <div className="flex items-center">
                     <CheckCircleIcon
@@ -96,7 +96,7 @@ export const AddressInfoDropdown = ({
             </DropdownMenuItem>
             <AddressQRCodeModal address={address}>
               <DropdownMenuItem asChild>
-                <Button variant="ghost" size="sm">
+                <Button variant="ghost" size="sm" className="w-full">
                   <div className="flex items-center w-full">
                     <QrCodeIcon className="mr-2 h-4 w-4" />
                     <span>View QR Code</span>
@@ -105,7 +105,7 @@ export const AddressInfoDropdown = ({
               </DropdownMenuItem>
             </AddressQRCodeModal>
             <DropdownMenuItem asChild>
-              <Button variant="ghost" size="sm" asChild>
+              <Button variant="ghost" size="sm" className="w-full" asChild>
                 <a target="_blank" href={blockExplorerAddressLink} rel="noopener noreferrer">
                   <ArrowTopRightOnSquareIcon className="mr-2 h-4 w-4" />
                   View on Block Explorer
@@ -114,7 +114,12 @@ export const AddressInfoDropdown = ({
             </DropdownMenuItem>
             {allowedNetworks.length > 1 && (
               <DropdownMenuItem asChild>
-                <Button variant="ghost" size="sm" onClick={() => setSelectingNetwork(true)}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start"
+                  onClick={() => setSelectingNetwork(true)}
+                >
                   <ArrowsRightLeftIcon className="mr-2 h-4 w-4" />
                   <span>Switch Network</span>
                 </Button>
@@ -124,6 +129,7 @@ export const AddressInfoDropdown = ({
               <Button
                 variant="ghost"
                 size="sm"
+                className="w-full justify-start"
                 onClick={() => {
                   disconnect();
                   closeDropdown();

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -52,7 +52,7 @@ export const AddressInfoDropdown = ({
   };
 
   return (
-    <DropdownMenu open={open}>
+    <DropdownMenu open={open} onOpenChange={open ? undefined : setOpen}>
       <DropdownMenuTrigger asChild onClick={() => setOpen(open => !open)}>
         <Button size="sm" variant="secondary" className="pl-0 pr-2 gap-0 h-auto">
           <BlockieAvatar address={checkSumAddress} size={30} ensImage={ensAvatar} />
@@ -66,6 +66,7 @@ export const AddressInfoDropdown = ({
         align="end"
         className="border-none bg-base-200 rounded-2xl"
         onInteractOutside={closeDropdown}
+        onEscapeKeyDown={closeDropdown}
       >
         <NetworkOptions hidden={!selectingNetwork} />
         {!selectingNetwork && (
@@ -98,16 +99,16 @@ export const AddressInfoDropdown = ({
                 )}
               </Button>
             </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Button variant="ghost" size="sm" className="w-full justify-start">
-                <AddressQRCodeModal address={address}>
+            <AddressQRCodeModal address={address}>
+              <DropdownMenuItem asChild>
+                <Button variant="ghost" size="sm" className="w-full justify-start">
                   <div className="flex items-center w-full">
                     <QrCodeIcon className="mr-2 h-4 w-4" />
                     <span>View QR Code</span>
                   </div>
-                </AddressQRCodeModal>
-              </Button>
-            </DropdownMenuItem>
+                </Button>
+              </DropdownMenuItem>
+            </AddressQRCodeModal>
             <DropdownMenuItem asChild>
               <Button variant="ghost" size="sm" className="w-full justify-start" asChild>
                 <a target="_blank" href={blockExplorerAddressLink} rel="noopener noreferrer">

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -54,7 +54,7 @@ export const AddressInfoDropdown = ({
   return (
     <DropdownMenu open={open} onOpenChange={open ? undefined : setOpen}>
       <DropdownMenuTrigger asChild onClick={() => setOpen(open => !open)}>
-        <Button size="sm" variant="secondary" className="pl-0 pr-2 gap-0 h-auto">
+        <Button size="sm" variant="secondary">
           <BlockieAvatar address={checkSumAddress} size={30} ensImage={ensAvatar} />
           <span className="ml-2 mr-1">
             {isENS(displayName) ? displayName : checkSumAddress?.slice(0, 6) + "..." + checkSumAddress?.slice(-4)}
@@ -62,17 +62,12 @@ export const AddressInfoDropdown = ({
           <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        className="border-none bg-base-200 rounded-2xl"
-        onInteractOutside={closeDropdown}
-        onEscapeKeyDown={closeDropdown}
-      >
+      <DropdownMenuContent align="end" onInteractOutside={closeDropdown} onEscapeKeyDown={closeDropdown}>
         <NetworkOptions hidden={!selectingNetwork} />
         {!selectingNetwork && (
           <>
             <DropdownMenuItem asChild>
-              <Button variant="ghost" size="sm" className="w-full justify-start">
+              <Button variant="ghost" size="sm">
                 {addressCopied ? (
                   <div className="flex items-center">
                     <CheckCircleIcon
@@ -101,7 +96,7 @@ export const AddressInfoDropdown = ({
             </DropdownMenuItem>
             <AddressQRCodeModal address={address}>
               <DropdownMenuItem asChild>
-                <Button variant="ghost" size="sm" className="w-full justify-start">
+                <Button variant="ghost" size="sm">
                   <div className="flex items-center w-full">
                     <QrCodeIcon className="mr-2 h-4 w-4" />
                     <span>View QR Code</span>
@@ -110,7 +105,7 @@ export const AddressInfoDropdown = ({
               </DropdownMenuItem>
             </AddressQRCodeModal>
             <DropdownMenuItem asChild>
-              <Button variant="ghost" size="sm" className="w-full justify-start" asChild>
+              <Button variant="ghost" size="sm" asChild>
                 <a target="_blank" href={blockExplorerAddressLink} rel="noopener noreferrer">
                   <ArrowTopRightOnSquareIcon className="mr-2 h-4 w-4" />
                   View on Block Explorer
@@ -119,12 +114,7 @@ export const AddressInfoDropdown = ({
             </DropdownMenuItem>
             {allowedNetworks.length > 1 && (
               <DropdownMenuItem asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="w-full justify-start"
-                  onClick={() => setSelectingNetwork(true)}
-                >
+                <Button variant="ghost" size="sm" onClick={() => setSelectingNetwork(true)}>
                   <ArrowsRightLeftIcon className="mr-2 h-4 w-4" />
                   <span>Switch Network</span>
                 </Button>
@@ -134,7 +124,6 @@ export const AddressInfoDropdown = ({
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full justify-start text-destructive"
                 onClick={() => {
                   disconnect();
                   closeDropdown();

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -62,7 +62,12 @@ export const AddressInfoDropdown = ({
           <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" onInteractOutside={closeDropdown} onEscapeKeyDown={closeDropdown}>
+      <DropdownMenuContent
+        align="end"
+        onInteractOutside={closeDropdown}
+        onEscapeKeyDown={closeDropdown}
+        className={open ? "" : "!pointer-events-none"}
+      >
         <NetworkOptions hidden={!selectingNetwork} />
         {!selectingNetwork && (
           <>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
@@ -1,33 +1,26 @@
 import { QRCodeSVG } from "qrcode.react";
 import { Address as AddressType } from "viem";
 import { Address } from "~~/components/scaffold-eth";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "~~/components/ui/dialog";
 
 type AddressQRCodeModalProps = {
   address: AddressType;
-  modalId: string;
+  children: React.ReactNode;
 };
 
-export const AddressQRCodeModal = ({ address, modalId }: AddressQRCodeModalProps) => {
+export const AddressQRCodeModal = ({ address, children }: AddressQRCodeModalProps) => {
   return (
-    <>
-      <div>
-        <input type="checkbox" id={`${modalId}`} className="modal-toggle" />
-        <label htmlFor={`${modalId}`} className="modal cursor-pointer">
-          <label className="modal-box relative">
-            {/* dummy input to capture event onclick on modal box */}
-            <input className="h-0 w-0 absolute top-0 left-0" />
-            <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3">
-              ✕
-            </label>
-            <div className="space-y-3 py-6">
-              <div className="flex flex-col items-center gap-6">
-                <QRCodeSVG value={address} size={256} />
-                <Address address={address} format="long" disableAddressLink />
-              </div>
-            </div>
-          </label>
-        </label>
-      </div>
-    </>
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Address QR Code</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-6 py-6 break-all">
+          <QRCodeSVG value={address} size={256} />
+          <Address address={address} format="long" disableAddressLink />
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressQRCodeModal.tsx
@@ -12,7 +12,7 @@ export const AddressQRCodeModal = ({ address, children }: AddressQRCodeModalProp
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent>
+      <DialogContent onOpenAutoFocus={e => e.preventDefault()}>
         <DialogHeader>
           <DialogTitle>Address QR Code</DialogTitle>
         </DialogHeader>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
@@ -27,6 +27,7 @@ export const NetworkOptions = ({ hidden = false }: NetworkOptionsProps) => {
             <Button
               variant="ghost"
               size="sm"
+              className="w-full justify-start"
               onClick={() => {
                 switchChain?.({ chainId: allowedNetwork.id });
               }}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
@@ -23,9 +23,10 @@ export const NetworkOptions = ({ hidden = false }: NetworkOptionsProps) => {
       {allowedNetworks
         .filter(allowedNetwork => allowedNetwork.id !== chain?.id)
         .map(allowedNetwork => (
-          <DropdownMenuItem key={allowedNetwork.id} className={hidden ? "hidden" : ""}>
+          <DropdownMenuItem asChild key={allowedNetwork.id} className={hidden ? "hidden" : ""}>
             <Button
               variant="ghost"
+              size="sm"
               className="w-full justify-start"
               onClick={() => {
                 switchChain?.({ chainId: allowedNetwork.id });
@@ -48,3 +49,18 @@ export const NetworkOptions = ({ hidden = false }: NetworkOptionsProps) => {
     </>
   );
 };
+
+{
+  /* <DropdownMenuItem asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-destructive"
+            onClick={() => disconnect()}
+          >
+            <ArrowLeftOnRectangleIcon className="mr-2 h-4 w-4" />
+            <span>Disconnect</span>
+          </Button>
+        </DropdownMenuItem>
+      </DropdownMenuContent> */
+}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
@@ -27,7 +27,6 @@ export const NetworkOptions = ({ hidden = false }: NetworkOptionsProps) => {
             <Button
               variant="ghost"
               size="sm"
-              className="w-full justify-start"
               onClick={() => {
                 switchChain?.({ chainId: allowedNetwork.id });
               }}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
@@ -49,18 +49,3 @@ export const NetworkOptions = ({ hidden = false }: NetworkOptionsProps) => {
     </>
   );
 };
-
-{
-  /* <DropdownMenuItem asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start text-destructive"
-            onClick={() => disconnect()}
-          >
-            <ArrowLeftOnRectangleIcon className="mr-2 h-4 w-4" />
-            <span>Disconnect</span>
-          </Button>
-        </DropdownMenuItem>
-      </DropdownMenuContent> */
-}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkOptions.tsx
@@ -1,6 +1,8 @@
 import { useTheme } from "next-themes";
 import { useAccount, useSwitchChain } from "wagmi";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/solid";
+import { Button } from "~~/components/ui/button";
+import { DropdownMenuItem } from "~~/components/ui/dropdown-menu";
 import { getNetworkColor } from "~~/hooks/scaffold-eth";
 import { getTargetNetworks } from "~~/utils/scaffold-eth";
 
@@ -21,15 +23,15 @@ export const NetworkOptions = ({ hidden = false }: NetworkOptionsProps) => {
       {allowedNetworks
         .filter(allowedNetwork => allowedNetwork.id !== chain?.id)
         .map(allowedNetwork => (
-          <li key={allowedNetwork.id} className={hidden ? "hidden" : ""}>
-            <button
-              className="menu-item btn-sm !rounded-xl flex gap-3 py-3 whitespace-nowrap"
-              type="button"
+          <DropdownMenuItem key={allowedNetwork.id} className={hidden ? "hidden" : ""}>
+            <Button
+              variant="ghost"
+              className="w-full justify-start"
               onClick={() => {
                 switchChain?.({ chainId: allowedNetwork.id });
               }}
             >
-              <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
+              <ArrowsRightLeftIcon className="h-4 w-4 mr-2" />
               <span>
                 Switch to{" "}
                 <span
@@ -40,8 +42,8 @@ export const NetworkOptions = ({ hidden = false }: NetworkOptionsProps) => {
                   {allowedNetwork.name}
                 </span>
               </span>
-            </button>
-          </li>
+            </Button>
+          </DropdownMenuItem>
         ))}
     </>
   );

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
@@ -24,7 +24,7 @@ export const WrongNetworkDropdown = () => {
       <DropdownMenuContent align="end">
         <NetworkOptions />
         <DropdownMenuItem asChild>
-          <Button variant="ghost" size="sm" onClick={() => disconnect()}>
+          <Button variant="ghost" size="sm" className="w-full justify-start" onClick={() => disconnect()}>
             <ArrowLeftOnRectangleIcon className="mr-2 h-4 w-4" />
             <span>Disconnect</span>
           </Button>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
@@ -1,32 +1,27 @@
 import { NetworkOptions } from "./NetworkOptions";
+import { ChevronDown, LogOut } from "lucide-react";
 import { useDisconnect } from "wagmi";
-import { ArrowLeftOnRectangleIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
+import { Button } from "~~/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "~~/components/ui/dropdown-menu";
 
 export const WrongNetworkDropdown = () => {
   const { disconnect } = useDisconnect();
 
   return (
-    <div className="dropdown dropdown-end mr-2">
-      <label tabIndex={0} className="btn btn-error btn-sm dropdown-toggle gap-1">
-        <span>Wrong network</span>
-        <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
-      </label>
-      <ul
-        tabIndex={0}
-        className="dropdown-content menu p-2 mt-1 shadow-center shadow-accent bg-base-200 rounded-box gap-1"
-      >
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="destructive" size="sm" className="mr-2">
+          Wrong network
+          <ChevronDown className="h-4 w-4 ml-2" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
         <NetworkOptions />
-        <li>
-          <button
-            className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"
-            type="button"
-            onClick={() => disconnect()}
-          >
-            <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" />
-            <span>Disconnect</span>
-          </button>
-        </li>
-      </ul>
-    </div>
+        <Button variant="ghost" className="w-full justify-start text-destructive" onClick={() => disconnect()}>
+          <LogOut className="mr-2 h-4 w-4" />
+          Disconnect
+        </Button>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
@@ -1,8 +1,14 @@
 import { NetworkOptions } from "./NetworkOptions";
-import { ChevronDown, LogOut } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { useDisconnect } from "wagmi";
+import { ArrowLeftOnRectangleIcon } from "@heroicons/react/24/outline";
 import { Button } from "~~/components/ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "~~/components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "~~/components/ui/dropdown-menu";
 
 export const WrongNetworkDropdown = () => {
   const { disconnect } = useDisconnect();
@@ -15,12 +21,19 @@ export const WrongNetworkDropdown = () => {
           <ChevronDown className="h-4 w-4 ml-2" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-56">
+      <DropdownMenuContent align="end" className="border-none bg-base-200 rounded-2xl">
         <NetworkOptions />
-        <Button variant="ghost" className="w-full justify-start text-destructive" onClick={() => disconnect()}>
-          <LogOut className="mr-2 h-4 w-4" />
-          Disconnect
-        </Button>
+        <DropdownMenuItem asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start text-destructive"
+            onClick={() => disconnect()}
+          >
+            <ArrowLeftOnRectangleIcon className="mr-2 h-4 w-4" />
+            <span>Disconnect</span>
+          </Button>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
@@ -16,20 +16,15 @@ export const WrongNetworkDropdown = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="destructive" size="sm" className="mr-2">
+        <Button variant="destructive" size="sm">
           Wrong network
           <ChevronDown className="h-4 w-4 ml-2" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="border-none bg-base-200 rounded-2xl">
+      <DropdownMenuContent align="end">
         <NetworkOptions />
         <DropdownMenuItem asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="w-full justify-start text-destructive"
-            onClick={() => disconnect()}
-          >
+          <Button variant="ghost" size="sm" onClick={() => disconnect()}>
             <ArrowLeftOnRectangleIcon className="mr-2 h-4 w-4" />
             <span>Disconnect</span>
           </Button>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -7,6 +7,7 @@ import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { WrongNetworkDropdown } from "./WrongNetworkDropdown";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { Address } from "viem";
+import { Button } from "~~/components/ui/button";
 import { useNetworkColor } from "~~/hooks/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
@@ -31,9 +32,9 @@ export const RainbowKitCustomConnectButton = () => {
             {(() => {
               if (!connected) {
                 return (
-                  <button className="btn btn-primary btn-sm" onClick={openConnectModal} type="button">
+                  <Button variant="default" size="sm" onClick={openConnectModal}>
                     Connect Wallet
-                  </button>
+                  </Button>
                 );
               }
 
@@ -55,7 +56,7 @@ export const RainbowKitCustomConnectButton = () => {
                     ensAvatar={account.ensAvatar}
                     blockExplorerAddressLink={blockExplorerAddressLink}
                   />
-                  <AddressQRCodeModal address={account.address as Address} modalId="qrcode-modal" />
+                  <AddressQRCodeModal address={account.address as Address}>QR</AddressQRCodeModal>
                 </>
               );
             })()}

--- a/packages/nextjs/components/ui/button.tsx
+++ b/packages/nextjs/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { type VariantProps, cva } from "class-variance-authority";
 import { cn } from "~~/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 !ring-accent focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/packages/nextjs/components/ui/button.tsx
+++ b/packages/nextjs/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:!bg-muted",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/packages/nextjs/components/ui/button.tsx
+++ b/packages/nextjs/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { type VariantProps, cva } from "class-variance-authority";
 import { cn } from "~~/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 !ring-accent focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -12,13 +12,13 @@ const buttonVariants = cva(
         destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent",
+        ghost: "hover:bg-accent hover:bg-accent",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 px-3 text-xs",
-        lg: "h-10 px-8",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
         icon: "h-9 w-9",
       },
     },

--- a/packages/nextjs/components/ui/button.tsx
+++ b/packages/nextjs/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { type VariantProps, cva } from "class-variance-authority";
 import { cn } from "~~/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -12,13 +12,13 @@ const buttonVariants = cva(
         destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:!bg-muted",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
+        sm: "h-8 px-3 text-xs",
+        lg: "h-10 px-8",
         icon: "h-9 w-9",
       },
     },

--- a/packages/nextjs/components/ui/button.tsx
+++ b/packages/nextjs/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/packages/nextjs/components/ui/dialog.tsx
+++ b/packages/nextjs/components/ui/dialog.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Cross2Icon } from "@radix-ui/react-icons";
+import { cn } from "~~/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <Cross2Icon className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/packages/nextjs/components/ui/dropdown-menu.tsx
+++ b/packages/nextjs/components/ui/dropdown-menu.tsx
@@ -26,7 +26,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      "flex select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
       inset && "pl-8",
       className,
     )}
@@ -81,7 +81,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex select-none items-center px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}
@@ -97,7 +97,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
@@ -120,7 +120,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/packages/nextjs/components/ui/dropdown-menu.tsx
+++ b/packages/nextjs/components/ui/dropdown-menu.tsx
@@ -81,7 +81,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex select-none items-center px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}
@@ -97,7 +97,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     checked={checked}
@@ -120,7 +120,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.11",
+    "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slot": "^1.1.0",

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -29,8 +29,6 @@ module.exports = {
           warning: "#FFCF72",
           error: "#FF8863",
 
-          "--rounded-btn": "9999rem",
-
           ".tooltip": {
             "--tooltip-tail": "6px",
           },
@@ -60,8 +58,6 @@ module.exports = {
           success: "#34EEB6",
           warning: "#FFCF72",
           error: "#FF8863",
-
-          "--rounded-btn": "9999rem",
 
           ".tooltip": {
             "--tooltip-tail": "6px",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2104,6 +2104,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dialog@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-dialog@npm:1.1.1"
+  dependencies:
+    "@radix-ui/primitive": 1.1.0
+    "@radix-ui/react-compose-refs": 1.1.0
+    "@radix-ui/react-context": 1.1.0
+    "@radix-ui/react-dismissable-layer": 1.1.0
+    "@radix-ui/react-focus-guards": 1.1.0
+    "@radix-ui/react-focus-scope": 1.1.0
+    "@radix-ui/react-id": 1.1.0
+    "@radix-ui/react-portal": 1.1.1
+    "@radix-ui/react-presence": 1.1.0
+    "@radix-ui/react-primitive": 2.0.0
+    "@radix-ui/react-slot": 1.1.0
+    "@radix-ui/react-use-controllable-state": 1.1.0
+    aria-hidden: ^1.1.1
+    react-remove-scroll: 2.5.7
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 5f270518b61e0b570a321f1db09ed95939969e9bff71fad02bce02126f047f5305d74ff79bb4e763677062db881b1e4ecd297b1556a917fed3d7a77cc0a7c235
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-direction@npm:1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/react-direction@npm:1.1.0"
@@ -2714,6 +2746,7 @@ __metadata:
   resolution: "@se-2/nextjs@workspace:packages/nextjs"
   dependencies:
     "@heroicons/react": ^2.0.11
+    "@radix-ui/react-dialog": ^1.1.1
     "@radix-ui/react-dropdown-menu": ^2.1.1
     "@radix-ui/react-icons": ^1.3.0
     "@radix-ui/react-slot": ^1.1.0


### PR DESCRIPTION
## Description

Custom rainbowkit button + dropdown implemented with shadcn


See https://github.com/scaffold-eth/scaffold-eth-2/pull/937#discussion_r1760213449 and https://github.com/scaffold-eth/scaffold-eth-2/pull/937#discussion_r1760199979 first

Buttons functionality

https://github.com/user-attachments/assets/7d0ba4f7-7508-46c0-8b5f-ccc67f7000f2

---
With networks switch

https://github.com/user-attachments/assets/4d8693e2-df21-49b0-896e-3e270bea4c4e

---
Wrong network dropdown

https://github.com/user-attachments/assets/77ec7cb6-0074-40ee-ab7a-869b1a1aa74d

---
Dark theme

https://github.com/user-attachments/assets/2fd32a10-eb2f-4d4c-b8d5-8376eb83feeb
