### PR TITLE
Fix debug page contracts view

### DIFF
--- a/packages/nextjs/app/debug/_components/DebugContracts.tsx
+++ b/packages/nextjs/app/debug/_components/DebugContracts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo } from "react";
-import { useLocalStorage } from "usehooks-ts";
+import { useSessionStorage } from "usehooks-ts";
 import { BarsArrowUpIcon } from "@heroicons/react/20/solid";
 import { ContractUI } from "~~/app/debug/_components/contract";
 import { ContractName, GenericContract } from "~~/utils/scaffold-eth/contract";
@@ -13,7 +13,7 @@ export function DebugContracts() {
   const contractsData = useAllContracts();
   const contractNames = useMemo(() => Object.keys(contractsData) as ContractName[], [contractsData]);
 
-  const [selectedContract, setSelectedContract] = useLocalStorage<ContractName>(
+  const [selectedContract, setSelectedContract] = useSessionStorage<ContractName>(
     selectedContractStorageKey,
     contractNames[0],
     { initializeWithValue: false },


### PR DESCRIPTION
## Description

Fixes https://github.com/scaffold-eth/scaffold-eth-2/issues/939

One of the possible (and simple) solutions is to use sessionStorage instead of localStorage. As I understand it doesn't change anything except one case: 
User worked with debug page where he chose some non-first contract. User closes browser tab with his debug page and open debug page in another browser tab. With localStorage, last chosen contract will be selected. With sessionStorage first contract will be selected. I believe it's not a problem at all

Additionally, using sessionStorage adds possibility to view different contracts of debug page in different browser tabs

----

What I also tried to do:
- use simple hash function depending on contractNames
```
const [selectedContract, setSelectedContract] = useLocalStorage<ContractName>(
    ${selectedContractStorageKey}-${hash},
    contractNames[0],
    { initializeWithValue: false },
  );
```
it works great, but adds new entry to localstorage for every hash
- use one localStorage for `selectedContract` and one for `hash`. But in this case I needed to use `useEffects` to handle logic and again it didn't work for multiple tabs, same as https://github.com/scaffold-eth/scaffold-eth-2/issues/939

