### PR TITLE
fix: removed unecessary logs for decoding tx in block-explorer

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
@@ -38,11 +38,11 @@ export const decodeTransactionData = (tx: TransactionWithFunction) => {
         foundInterface = true;
         break;
       } catch (e) {
-        // NOTE: do nothing
+        // do nothing
       }
     }
     if (!foundInterface) {
-      tx.functionName = "Unknown ABI";
+      tx.functionName = "⚠️ Unknown";
     }
   }
   return tx;

--- a/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
@@ -37,7 +37,7 @@ export const decodeTransactionData = (tx: TransactionWithFunction) => {
         })?.inputs.map((input: any) => input.type);
         foundInterface = true;
         break;
-      } catch (e) {
+      } catch {
         // do nothing
       }
     }

--- a/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
@@ -18,6 +18,7 @@ const interfaces = chainMetaData
 
 export const decodeTransactionData = (tx: TransactionWithFunction) => {
   if (tx.input.length >= 10 && !tx.input.startsWith("0x60e06040")) {
+    let foundInterface = false;
     for (const [, contractAbi] of Object.entries(interfaces)) {
       try {
         const { functionName, args } = decodeFunctionData({
@@ -34,11 +35,14 @@ export const decodeTransactionData = (tx: TransactionWithFunction) => {
           abi: contractAbi as AbiFunction[],
           name: functionName,
         })?.inputs.map((input: any) => input.type);
-
+        foundInterface = true;
         break;
       } catch (e) {
-        console.error(`Parsing failed: ${e}`);
+        // NOTE: do nothing
       }
+    }
+    if (!foundInterface) {
+      tx.functionName = "Unknown ABI";
     }
   }
   return tx;


### PR DESCRIPTION
## Description

Instead of logging errors for expected behavior it adds 'Unknown ABI' to function name.

Before
![Screenshot from 2024-11-15 11-42-04](https://github.com/user-attachments/assets/4c755c73-ede6-48e6-a2b0-be9be0eb842a)

After
![Screenshot from 2024-11-15 11-42-37](https://github.com/user-attachments/assets/59d3ced9-2c6a-43cc-bf40-fc400f553c87)

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #984_

Your ENS/address: harmont.eth
