### PR TITLE
fix typo CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Here are some tips for a high-quality pull request:
 - Create a title for the PR that accurately defines the work done.
 - Structure the description neatly to make it easy to consume by the readers. For example, you can include bullet points and screenshots instead of having one large paragraph.
 - Add the link to the issue if applicable.
-- Have a good commit message that summarises the work done.
+- Have a good commit message that summarizes the work done.
 
 Once you submit your PR:
 


### PR DESCRIPTION
## Description

This pull request fixes a spelling error in the documentation. The word "summarises" was used, which is the British English variant. It has been corrected to "summarizes," as American English is typically used in technical documentation. This change ensures consistency in language style across the project.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_No related issues._

Your ENS/address: 0x0aeb922fe731e0c455c9d1decc9e6fbc792ef98c
