### PR TITLE
Remove hardcoded colors

### DIFF
--- a/packages/nextjs/app/blockexplorer/_components/PaginationButton.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/PaginationButton.tsx
@@ -12,8 +12,8 @@ export const PaginationButton = ({ currentPage, totalItems, setCurrentPage }: Pa
   const isPrevButtonDisabled = currentPage === 0;
   const isNextButtonDisabled = currentPage + 1 >= Math.ceil(totalItems / ITEMS_PER_PAGE);
 
-  const prevButtonClass = isPrevButtonDisabled ? "bg-gray-200 cursor-default" : "btn btn-primary";
-  const nextButtonClass = isNextButtonDisabled ? "bg-gray-200 cursor-default" : "btn btn-primary";
+  const prevButtonClass = isPrevButtonDisabled ? "btn-disabled cursor-default" : "btn-primary";
+  const nextButtonClass = isNextButtonDisabled ? "btn-disabled cursor-default" : "btn-primary";
 
   if (isNextButtonDisabled && isPrevButtonDisabled) return null;
 

--- a/packages/nextjs/app/blockexplorer/_components/SearchBar.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/SearchBar.tsx
@@ -35,7 +35,7 @@ export const SearchBar = () => {
   return (
     <form onSubmit={handleSearch} className="flex items-center justify-end mb-5 space-x-3 mx-5">
       <input
-        className="border-primary bg-base-100 text-base-content p-2 mr-2 w-full md:w-1/2 lg:w-1/3 rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-accent"
+        className="border-primary bg-base-100 text-base-content placeholder:text-base-content/50 p-2 mr-2 w-full md:w-1/2 lg:w-1/3 rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-accent"
         type="text"
         value={searchInput}
         placeholder="Search by hash or address"

--- a/packages/nextjs/app/blockexplorer/_components/TransactionHash.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/TransactionHash.tsx
@@ -28,10 +28,7 @@ export const TransactionHash = ({ hash }: { hash: string }) => {
             }, 800);
           }}
         >
-          <DocumentDuplicateIcon
-            className="ml-1.5 text-xl font-normal text-base-content h-5 w-5 cursor-pointer"
-            aria-hidden="true"
-          />
+          <DocumentDuplicateIcon className="ml-1.5 text-xl font-normal h-5 w-5 cursor-pointer" aria-hidden="true" />
         </CopyToClipboard>
       )}
     </div>

--- a/packages/nextjs/app/blockexplorer/_components/TransactionHash.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/TransactionHash.tsx
@@ -15,7 +15,7 @@ export const TransactionHash = ({ hash }: { hash: string }) => {
       </Link>
       {addressCopied ? (
         <CheckCircleIcon
-          className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+          className="ml-1.5 text-xl font-normal text-base-content h-5 w-5 cursor-pointer"
           aria-hidden="true"
         />
       ) : (
@@ -29,7 +29,7 @@ export const TransactionHash = ({ hash }: { hash: string }) => {
           }}
         >
           <DocumentDuplicateIcon
-            className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+            className="ml-1.5 text-xl font-normal text-base-content h-5 w-5 cursor-pointer"
             aria-hidden="true"
           />
         </CopyToClipboard>

--- a/packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx
+++ b/packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx
@@ -69,7 +69,7 @@ export const DisplayVariable = ({
         </button>
         <InheritanceTooltip inheritedFrom={inheritedFrom} />
       </div>
-      <div className="text-gray-500 font-medium flex flex-col items-start">
+      <div className="text-base-content/80 flex flex-col items-start">
         <div>
           <div
             className={`break-all block transition bg-transparent ${

--- a/packages/nextjs/app/debug/_components/contract/TxReceipt.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TxReceipt.tsx
@@ -26,10 +26,7 @@ export const TxReceipt = ({ txResult }: { txResult: TransactionReceipt }) => {
               }, 800);
             }}
           >
-            <DocumentDuplicateIcon
-              className="ml-1.5 text-xl font-normal text-base-content h-5 w-5 cursor-pointer"
-              aria-hidden="true"
-            />
+            <DocumentDuplicateIcon className="ml-1.5 text-xl font-normal h-5 w-5 cursor-pointer" aria-hidden="true" />
           </CopyToClipboard>
         )}
       </div>

--- a/packages/nextjs/app/debug/_components/contract/TxReceipt.tsx
+++ b/packages/nextjs/app/debug/_components/contract/TxReceipt.tsx
@@ -13,7 +13,7 @@ export const TxReceipt = ({ txResult }: { txResult: TransactionReceipt }) => {
       <div className="mt-1 pl-2">
         {txResultCopied ? (
           <CheckCircleIcon
-            className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+            className="ml-1.5 text-xl font-normal text-base-content h-5 w-5 cursor-pointer"
             aria-hidden="true"
           />
         ) : (
@@ -27,7 +27,7 @@ export const TxReceipt = ({ txResult }: { txResult: TransactionReceipt }) => {
             }}
           >
             <DocumentDuplicateIcon
-              className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
+              className="ml-1.5 text-xl font-normal text-base-content h-5 w-5 cursor-pointer"
               aria-hidden="true"
             />
           </CopyToClipboard>

--- a/packages/nextjs/app/debug/_components/contract/utilsDisplay.tsx
+++ b/packages/nextjs/app/debug/_components/contract/utilsDisplay.tsx
@@ -85,7 +85,7 @@ export const ObjectFieldDisplay = ({
 }) => {
   return (
     <div className={`flex flex-row items-baseline ${leftPad ? "ml-4" : ""}`}>
-      <span className="text-gray-500 dark:text-gray-400 mr-2">{name}:</span>
+      <span className="text-base-content/60 mr-2">{name}:</span>
       <span className="text-base-content">{displayTxResult(value, size)}</span>
     </div>
   );

--- a/packages/nextjs/components/SwitchTheme.tsx
+++ b/packages/nextjs/components/SwitchTheme.tsx
@@ -29,7 +29,7 @@ export const SwitchTheme = ({ className }: { className?: string }) => {
       <input
         id="theme-toggle"
         type="checkbox"
-        className="toggle toggle-primary bg-primary hover:bg-primary border-primary"
+        className="toggle bg-base-content focus:bg-base-content border-base-content"
         onChange={handleToggle}
         checked={isDarkMode}
       />

--- a/packages/nextjs/components/SwitchTheme.tsx
+++ b/packages/nextjs/components/SwitchTheme.tsx
@@ -29,7 +29,7 @@ export const SwitchTheme = ({ className }: { className?: string }) => {
       <input
         id="theme-toggle"
         type="checkbox"
-        className="toggle bg-base-content focus:bg-base-content border-base-content"
+        className="toggle toggle-primary bg-primary hover:bg-primary border-primary"
         onChange={handleToggle}
         checked={isDarkMode}
       />

--- a/packages/nextjs/components/scaffold-eth/Address/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address/Address.tsx
@@ -177,7 +177,7 @@ export const Address = ({
             </AddressLinkWrapper>
           </span>
           <AddressCopyIcon
-            className={`ml-1 text-base-content ${copyIconSizeMap[addressSize]} cursor-pointer`}
+            className={`ml-1 ${copyIconSizeMap[addressSize]} cursor-pointer`}
             address={checkSumAddress}
           />
         </div>

--- a/packages/nextjs/components/scaffold-eth/Address/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address/Address.tsx
@@ -177,7 +177,7 @@ export const Address = ({
             </AddressLinkWrapper>
           </span>
           <AddressCopyIcon
-            className={`ml-1 text-sky-600 ${copyIconSizeMap[addressSize]} cursor-pointer`}
+            className={`ml-1 text-base-content ${copyIconSizeMap[addressSize]} cursor-pointer`}
             address={checkSumAddress}
           />
         </div>

--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -43,7 +43,7 @@ export const Balance = ({ address, className = "", usdMode }: BalanceProps) => {
 
   if (isError) {
     return (
-      <div className={`border-2 border-gray-400 rounded-md px-2 flex flex-col items-center max-w-fit cursor-pointer`}>
+      <div className="border-2 border-base-content/30 rounded-md px-2 flex flex-col items-center max-w-fit cursor-pointer">
         <div className="text-warning">Error</div>
       </div>
     );

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -50,7 +50,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
     <div className={`flex border-2 border-base-300 bg-base-200 rounded-full text-accent ${modifier}`}>
       {prefix}
       <input
-        className="input input-ghost focus-within:border-transparent focus:outline-none focus:bg-transparent h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium placeholder:text-accent/80 text-base-content/90 focus:text-base-content/90"
+        className="input input-ghost focus-within:border-transparent focus:outline-none focus:bg-transparent h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium placeholder:text-accent/70 text-base-content/70 focus:text-base-content/70"
         placeholder={placeholder}
         name={name}
         value={value?.toString()}

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -50,7 +50,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
     <div className={`flex border-2 border-base-300 bg-base-200 rounded-full text-accent ${modifier}`}>
       {prefix}
       <input
-        className="input input-ghost focus-within:border-transparent focus:outline-none focus:bg-transparent focus:text-gray-400 h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium placeholder:text-accent/50 text-gray-400"
+        className="input input-ghost focus-within:border-transparent focus:outline-none focus:bg-transparent h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium placeholder:text-accent/80 text-base-content/90 focus:text-base-content/90"
         placeholder={placeholder}
         name={name}
         value={value?.toString()}


### PR DESCRIPTION
## Description

Removed hardcoded colors so colors will be better for extensions.

Changes:

general:
- copy button near address and transactions is the same color as default text
- changed input content and placeholder colors
- switch theme toggle color is now `text-base-content`, so it has the same color as switch icon, has better contrast and also is better for extensions, for example sre-challenges light theme
- changed balance error border color
- changed receipt object keys colors

debug page:
- display variable is now `text-base-content/80` and also normal font-weight so it has better contrast with var title

blockexplorer:
- changed color of searchbar placeholder
- changed hardcoded color of pagination button to `btn-disabled`

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
