### PR TITLE
[Feature] Project Detail Consolidation

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -1,12 +1,13 @@
 import "@rainbow-me/rainbowkit/styles.css";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
+import scaffoldConfig from "~~/scaffold.config";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export const metadata = getMetadata({
-  title: "Scaffold-ETH 2 App",
-  description: "Built with 🏗 Scaffold-ETH 2",
+  title: scaffoldConfig.projectName,
+  description: scaffoldConfig.projectDescription,
 });
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -6,7 +6,7 @@ import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export const metadata = getMetadata({
-  title: scaffoldConfig.projectName,
+  title: `${scaffoldConfig.projectName} App`,
   description: scaffoldConfig.projectDescription,
 });
 

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -1,13 +1,13 @@
 import "@rainbow-me/rainbowkit/styles.css";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
-import scaffoldConfig from "~~/scaffold.config";
+import projectConfig from "~~/project.config";
 import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export const metadata = getMetadata({
-  title: `${scaffoldConfig.projectName} App`,
-  description: scaffoldConfig.projectDescription,
+  title: `${projectConfig.name} App`,
+  description: projectConfig.description,
 });
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -5,7 +5,7 @@ import type { NextPage } from "next";
 import { useAccount } from "wagmi";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { Address } from "~~/components/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
+import projectConfig from "~~/project.config";
 
 const Home: NextPage = () => {
   const { address: connectedAddress } = useAccount();
@@ -16,7 +16,7 @@ const Home: NextPage = () => {
         <div className="px-5">
           <h1 className="text-center">
             <span className="block text-2xl mb-2">Welcome to</span>
-            <span className="block text-4xl font-bold">{scaffoldConfig.projectName}</span>
+            <span className="block text-4xl font-bold">{projectConfig.name}</span>
           </h1>
           <div className="flex justify-center items-center space-x-2 flex-col sm:flex-row">
             <p className="my-2 font-medium">Connected Address:</p>

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -5,6 +5,7 @@ import type { NextPage } from "next";
 import { useAccount } from "wagmi";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { Address } from "~~/components/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 const Home: NextPage = () => {
   const { address: connectedAddress } = useAccount();
@@ -15,7 +16,7 @@ const Home: NextPage = () => {
         <div className="px-5">
           <h1 className="text-center">
             <span className="block text-2xl mb-2">Welcome to</span>
-            <span className="block text-4xl font-bold">Scaffold-ETH 2</span>
+            <span className="block text-4xl font-bold">{scaffoldConfig.projectName}</span>
           </h1>
           <div className="flex justify-center items-center space-x-2 flex-col sm:flex-row">
             <p className="my-2 font-medium">Connected Address:</p>

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -6,7 +6,7 @@ import { HeartIcon } from "@heroicons/react/24/outline";
 import { SwitchTheme } from "~~/components/SwitchTheme";
 import { Faucet } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
-import scaffoldConfig from "~~/scaffold.config";
+import projectConfig from "~~/project.config";
 import { useGlobalState } from "~~/services/store/store";
 
 /**
@@ -47,7 +47,7 @@ export const Footer = () => {
         <ul className="menu menu-horizontal w-full">
           <div className="flex justify-center items-center gap-2 text-sm w-full">
             <div className="text-center">
-              <a href={scaffoldConfig.projectRepoLink} target="_blank" rel="noreferrer" className="link">
+              <a href={projectConfig.repoLink} target="_blank" rel="noreferrer" className="link">
                 Fork me
               </a>
             </div>
@@ -58,17 +58,17 @@ export const Footer = () => {
               </p>
               <a
                 className="flex justify-center items-center gap-1"
-                href={scaffoldConfig.projectCreatorLink}
+                href={projectConfig.creatorLink}
                 target="_blank"
                 rel="noreferrer"
               >
-                <scaffoldConfig.projectCreatorSvg className="w-3 h-5 pb-1" />
-                <span className="link">{scaffoldConfig.projectCreator}</span>
+                <projectConfig.creatorSvg className="w-3 h-5 pb-1" />
+                <span className="link">{projectConfig.creator}</span>
               </a>
             </div>
             <span>·</span>
             <div className="text-center">
-              <a href={scaffoldConfig.projectSupportLink} target="_blank" rel="noreferrer" className="link">
+              <a href={projectConfig.supportLink} target="_blank" rel="noreferrer" className="link">
                 Support
               </a>
             </div>

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -4,10 +4,10 @@ import { hardhat } from "viem/chains";
 import { CurrencyDollarIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { HeartIcon } from "@heroicons/react/24/outline";
 import { SwitchTheme } from "~~/components/SwitchTheme";
-import { BuidlGuidlLogo } from "~~/components/assets/BuidlGuidlLogo";
 import { Faucet } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { useGlobalState } from "~~/services/store/store";
+import scaffoldConfig from "~~/scaffold.config";
 
 /**
  * Site footer
@@ -47,7 +47,7 @@ export const Footer = () => {
         <ul className="menu menu-horizontal w-full">
           <div className="flex justify-center items-center gap-2 text-sm w-full">
             <div className="text-center">
-              <a href="https://github.com/scaffold-eth/se-2" target="_blank" rel="noreferrer" className="link">
+              <a href={scaffoldConfig.projectRepoLink} target="_blank" rel="noreferrer" className="link">
                 Fork me
               </a>
             </div>
@@ -58,17 +58,17 @@ export const Footer = () => {
               </p>
               <a
                 className="flex justify-center items-center gap-1"
-                href="https://buidlguidl.com/"
+                href={scaffoldConfig.projectCreatorLink}
                 target="_blank"
                 rel="noreferrer"
               >
-                <BuidlGuidlLogo className="w-3 h-5 pb-1" />
-                <span className="link">BuidlGuidl</span>
+                <scaffoldConfig.projectCreatorSvg className="w-3 h-5 pb-1" />
+                <span className="link">{scaffoldConfig.projectCreator}</span>
               </a>
             </div>
             <span>·</span>
             <div className="text-center">
-              <a href="https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA" target="_blank" rel="noreferrer" className="link">
+              <a href={scaffoldConfig.projectSupportLink} target="_blank" rel="noreferrer" className="link">
                 Support
               </a>
             </div>

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -6,8 +6,8 @@ import { HeartIcon } from "@heroicons/react/24/outline";
 import { SwitchTheme } from "~~/components/SwitchTheme";
 import { Faucet } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
-import { useGlobalState } from "~~/services/store/store";
 import scaffoldConfig from "~~/scaffold.config";
+import { useGlobalState } from "~~/services/store/store";
 
 /**
  * Site footer

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 type HeaderMenuLink = {
   label: string;
@@ -90,11 +91,11 @@ export const Header = () => {
         </div>
         <Link href="/" passHref className="hidden lg:flex items-center gap-2 ml-4 mr-6 shrink-0">
           <div className="flex relative w-10 h-10">
-            <Image alt="SE2 logo" className="cursor-pointer" fill src="/logo.svg" />
+            <Image alt="SE2 logo" className="cursor-pointer" fill src={scaffoldConfig.projectIconPathHeader} />
           </div>
           <div className="flex flex-col">
-            <span className="font-bold leading-tight">Scaffold-ETH</span>
-            <span className="text-xs">Ethereum dev stack</span>
+            <span className="font-bold leading-tight">{scaffoldConfig.projectNameHeader}</span>
+            <span className="text-xs">{scaffoldConfig.projectDescriptionHeader}</span>
           </div>
         </Link>
         <ul className="hidden lg:flex lg:flex-nowrap menu menu-horizontal px-1 gap-2">

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -7,7 +7,7 @@ import { usePathname } from "next/navigation";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
+import projectConfig from "~~/project.config";
 
 type HeaderMenuLink = {
   label: string;
@@ -91,11 +91,11 @@ export const Header = () => {
         </div>
         <Link href="/" passHref className="hidden lg:flex items-center gap-2 ml-4 mr-6 shrink-0">
           <div className="flex relative w-10 h-10">
-            <Image alt="SE2 logo" className="cursor-pointer" fill src={scaffoldConfig.projectIconPathHeader} />
+            <Image alt="SE2 logo" className="cursor-pointer" fill src={projectConfig.iconPathHeader} />
           </div>
           <div className="flex flex-col">
-            <span className="font-bold leading-tight">{scaffoldConfig.projectNameHeader}</span>
-            <span className="text-xs">{scaffoldConfig.projectDescriptionHeader}</span>
+            <span className="font-bold leading-tight">{projectConfig.nameHeader}</span>
+            <span className="text-xs">{projectConfig.descriptionHeader}</span>
           </div>
         </Link>
         <ul className="hidden lg:flex lg:flex-nowrap menu menu-horizontal px-1 gap-2">

--- a/packages/nextjs/project.config.ts
+++ b/packages/nextjs/project.config.ts
@@ -1,0 +1,29 @@
+import { BuidlGuidlLogo } from "./components/assets/BuidlGuidlLogo";
+
+export type ProjectConfig = {
+  name: string;
+  description: string;
+  nameHeader: string;
+  descriptionHeader: string;
+  iconPathHeader: string;
+  creator: string;
+  creatorSvg: any;
+  creatorLink: string;
+  repoLink: string;
+  supportLink: string;
+};
+
+const projectConfig = {
+  nameHeader: "Scaffold-ETH",
+  descriptionHeader: "Ethereum dev stack",
+  iconPathHeader: "/logo.svg",
+  name: "Scaffold-ETH 2",
+  description: "Built with 🏗 Scaffold-ETH 2",
+  creator: "BuidlGuidl",
+  creatorSvg: BuidlGuidlLogo,
+  creatorLink: "https://buidlguidl.com/",
+  repoLink: "https://github.com/scaffold-eth/se-2",
+  supportLink: "https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA",
+} as const satisfies ProjectConfig;
+
+export default projectConfig;

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -1,4 +1,3 @@
-import { BuidlGuidlLogo } from "./components/assets/BuidlGuidlLogo";
 import * as chains from "viem/chains";
 
 export type ScaffoldConfig = {
@@ -7,16 +6,6 @@ export type ScaffoldConfig = {
   alchemyApiKey: string;
   walletConnectProjectId: string;
   onlyLocalBurnerWallet: boolean;
-  projectName: string;
-  projectDescription: string;
-  projectNameHeader: string;
-  projectDescriptionHeader: string;
-  projectIconPathHeader: string;
-  projectCreator: string;
-  projectCreatorSvg: any;
-  projectCreatorLink: string;
-  projectRepoLink: string;
-  projectSupportLink: string;
 };
 
 const scaffoldConfig = {
@@ -41,17 +30,6 @@ const scaffoldConfig = {
 
   // Only show the Burner Wallet when running on hardhat network
   onlyLocalBurnerWallet: true,
-
-  projectNameHeader: "Scaffold-ETH",
-  projectDescriptionHeader: "Ethereum dev stack",
-  projectIconPathHeader: "/logo.svg",
-  projectName: "Scaffold-ETH 2",
-  projectDescription: "Built with 🏗 Scaffold-ETH 2",
-  projectCreator: "BuidlGuidl",
-  projectCreatorSvg: BuidlGuidlLogo,
-  projectCreatorLink: "https://buidlguidl.com/",
-  projectRepoLink: "https://github.com/scaffold-eth/se-2",
-  projectSupportLink: "https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA",
 } as const satisfies ScaffoldConfig;
 
 export default scaffoldConfig;

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -1,3 +1,4 @@
+import { BuidlGuidlLogo } from "./components/assets/BuidlGuidlLogo";
 import * as chains from "viem/chains";
 
 export type ScaffoldConfig = {
@@ -6,6 +7,16 @@ export type ScaffoldConfig = {
   alchemyApiKey: string;
   walletConnectProjectId: string;
   onlyLocalBurnerWallet: boolean;
+  projectName: string;
+  projectDescription: string;
+  projectNameHeader: string;
+  projectDescriptionHeader: string;
+  projectIconPathHeader: string;
+  projectCreator: string;
+  projectCreatorSvg: any;
+  projectCreatorLink: string;
+  projectRepoLink: string;
+  projectSupportLink: string;
 };
 
 const scaffoldConfig = {
@@ -30,6 +41,17 @@ const scaffoldConfig = {
 
   // Only show the Burner Wallet when running on hardhat network
   onlyLocalBurnerWallet: true,
+
+  projectNameHeader: "Scaffold-ETH",
+  projectDescriptionHeader: "Ethereum dev stack",
+  projectIconPathHeader: "/logo.svg",
+  projectName: "Scaffold-ETH 2",
+  projectDescription: "Built with 🏗 Scaffold-ETH 2",
+  projectCreator: "BuidlGuidl",
+  projectCreatorSvg: BuidlGuidlLogo,
+  projectCreatorLink: "https://buidlguidl.com/",
+  projectRepoLink: "https://github.com/scaffold-eth/se-2",
+  projectSupportLink: "https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA",
 } as const satisfies ScaffoldConfig;
 
 export default scaffoldConfig;


### PR DESCRIPTION
## Description

Consolidates many of the project details into `scaffold.config.ts`.

SE-2 is cloned and forked for many purposes to create many unique applications. These unique applications of course have unique titles, descriptions, images, metadata, etc. There are currently a myriad of places where SE-2 metadata is spread throughout the project, which can make it a pain to update the metadata once a fork/clone becomes mature enough for its own branding. Easily leading to the possibility of complete applications to still have SE-2 branding present, which ends up feeling out of place.

This PR aims to alleviate these issues and remove the developer's need to scour the project to ensure they changed every single piece of SE-2 branding as possible to their own application's branding.

### Give credit where credit is due
Of course, none of this is possible without SE-2. Thus, maybe we could introduce a new section that gives SE-2 the proper plug space that it deserves?

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: JacobHomanics.eth
