### PR TITLE
move 99_deployScript as hardhat task

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -9,6 +9,8 @@ import "solidity-coverage";
 import "@nomicfoundation/hardhat-verify";
 import "hardhat-deploy";
 import "hardhat-deploy-ethers";
+import { task } from "hardhat/config";
+import generateTsAbis from "./scripts/generateTsAbis";
 
 // If not set, it uses the hardhat account 0 private key.
 const deployerPrivateKey =
@@ -146,5 +148,13 @@ const config: HardhatUserConfig = {
     enabled: false,
   },
 };
+
+// Extend the deploy task
+task("deploy").setAction(async (args, hre, runSuper) => {
+  // Run the original deploy task
+  await runSuper(args);
+  // Force run the generateTsAbis script
+  await generateTsAbis(hre);
+});
 
 export default config;

--- a/packages/hardhat/scripts/generateTsAbis.ts
+++ b/packages/hardhat/scripts/generateTsAbis.ts
@@ -87,7 +87,7 @@ function getContractDataFromDeployments() {
       const { abi, address, metadata } = JSON.parse(
         fs.readFileSync(`${DEPLOYMENTS_DIR}/${chainName}/${contractName}.json`).toString(),
       );
-      const inheritedFunctions = getInheritedFunctions(JSON.parse(metadata).sources, contractName);
+      const inheritedFunctions = metadata ? getInheritedFunctions(JSON.parse(metadata).sources, contractName) : {};
       contracts[contractName] = { address, abi, inheritedFunctions };
     }
     output[chainId] = contracts;
@@ -125,9 +125,3 @@ const generateTsAbis: DeployFunction = async function () {
 };
 
 export default generateTsAbis;
-
-// Tags are useful if you have multiple deploy files and only want to run one of them.
-// e.g. yarn deploy --tags generateTsAbis
-generateTsAbis.tags = ["generateTsAbis"];
-
-generateTsAbis.runAtTheEnd = true;


### PR DESCRIPTION
### Description: 

This is something which we did at CTF repo. Doing this no more requires `99_deployScript` to be present and also avoids the problem people deleting it by mistake