### PR TITLE
Disable vercel telemetry

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -10,8 +10,8 @@
     "lint": "next lint",
     "serve": "next start",
     "start": "next dev",
-    "vercel": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1",
-    "vercel:yolo": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true"
+    "vercel": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env VERCEL_TELEMETRY_DISABLED=1",
+    "vercel:yolo": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true --build-env VERCEL_TELEMETRY_DISABLED=1"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.5",


### PR DESCRIPTION
Context: https://github.com/scaffold-eth/se-2-challenges/pull/245#pullrequestreview-2503416298

I think we need to disable telemetry by default, because
- vercel cli asks to do additional actions to approve telemetry before deploy
- I am not sure people want to vercel to collect their data

Vercel telemetry [docs](https://vercel.com/docs/cli/about-telemetry)