### PR TITLE
make `useScaffoldWriteContract` & `useDeployedContractInfo` backward compatible

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
@@ -10,16 +10,34 @@ import {
   contracts,
 } from "~~/utils/scaffold-eth/contract";
 
+type DeployedContractData<TContractName extends ContractName> = {
+  data: Contract<TContractName> | undefined;
+  isLoading: boolean;
+};
+
 /**
  * Gets the matching contract info for the provided contract name from the contracts present in deployedContracts.ts
  * and externalContracts.ts corresponding to targetNetworks configured in scaffold.config.ts
  */
-export const useDeployedContractInfo = <TContractName extends ContractName>({
-  contractName,
-  chainId,
-}: UseDeployedContractConfig<TContractName>) => {
+export function useDeployedContractInfo<TContractName extends ContractName>(
+  config: UseDeployedContractConfig<TContractName>,
+): DeployedContractData<TContractName>;
+/**
+ * @deprecated Use object parameter version instead: useDeployedContractInfo({ contractName: "YourContract" })
+ */
+export function useDeployedContractInfo<TContractName extends ContractName>(
+  contractName: TContractName,
+): DeployedContractData<TContractName>;
+
+export function useDeployedContractInfo<TContractName extends ContractName>(
+  configOrName: UseDeployedContractConfig<TContractName> | TContractName,
+): DeployedContractData<TContractName> {
   const isMounted = useIsMounted();
 
+  const finalConfig: UseDeployedContractConfig<TContractName> =
+    typeof configOrName === "string" ? { contractName: configOrName } : (configOrName as any);
+
+  const { contractName, chainId } = finalConfig;
   const selectedNetwork = useSelectedNetwork(chainId);
   const deployedContract = contracts?.[selectedNetwork.id]?.[contractName as ContractName] as Contract<TContractName>;
   const [status, setStatus] = useState<ContractCodeStatus>(ContractCodeStatus.LOADING);
@@ -58,4 +76,4 @@ export const useDeployedContractInfo = <TContractName extends ContractName>({
     data: status === ContractCodeStatus.DEPLOYED ? deployedContract : undefined,
     isLoading: status === ContractCodeStatus.LOADING,
   };
-};
+}

--- a/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
@@ -37,6 +37,12 @@ export function useDeployedContractInfo<TContractName extends ContractName>(
   const finalConfig: UseDeployedContractConfig<TContractName> =
     typeof configOrName === "string" ? { contractName: configOrName } : (configOrName as any);
 
+  if (typeof configOrName === "string") {
+    console.warn(
+      "Using `useDeployedContractInfo` with a string parameter is deprecated. Please use the object parameter version instead.",
+    );
+  }
+
   const { contractName, chainId } = finalConfig;
   const selectedNetwork = useSelectedNetwork(chainId);
   const deployedContract = contracts?.[selectedNetwork.id]?.[contractName as ContractName] as Contract<TContractName>;

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts
@@ -54,10 +54,10 @@ export function useScaffoldWriteContract<TContractName extends ContractName>(
   configOrName: UseScaffoldWriteConfig<TContractName> | TContractName,
   writeContractParams?: UseWriteContractParameters,
 ): ScaffoldWriteContractReturnType<TContractName> {
-  const finalConfig: UseScaffoldWriteConfig<TContractName> =
+  const finalConfig =
     typeof configOrName === "string"
       ? { contractName: configOrName, writeContractParams, chainId: undefined }
-      : (configOrName as any);
+      : (configOrName as UseScaffoldWriteConfig<TContractName>);
   const { contractName, chainId, writeContractParams: finalWriteContractParams } = finalConfig;
 
   const { chain: accountChain } = useAccount();

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts
@@ -60,6 +60,12 @@ export function useScaffoldWriteContract<TContractName extends ContractName>(
       : (configOrName as UseScaffoldWriteConfig<TContractName>);
   const { contractName, chainId, writeContractParams: finalWriteContractParams } = finalConfig;
 
+  if (typeof configOrName === "string") {
+    console.warn(
+      "Using `useScaffoldWriteContract` with a string parameter is deprecated. Please use the object parameter version instead.",
+    );
+  }
+
   const { chain: accountChain } = useAccount();
   const writeTx = useTransactor();
   const [isMining, setIsMining] = useState(false);


### PR DESCRIPTION
### Description: 

This allows developers to consume `useScaffoldWriteContract` and `useDeployedContractInfo` hook in both ways until we make breaking changes release : 

Example of `useScaffoldWriteContract`

Old: 
```ts
  const { writeContractAsync: depeRecatedWriteAsync } = useScaffoldWriteContract("YourContract");
```

When using the Old way the IDE should give the warning : 

<img width="1241" alt="Screenshot 2024-12-17 at 2 12 08 PM" src="https://github.com/user-attachments/assets/8933608c-7399-4f6f-9d11-3dfd9aa7415f" />



New: 
```ts
  const { writeContractAsync: newWriteAsync } = useScaffoldWriteContract({
    contractName: "YourContract",
    chainId: 31337,
  });
```

### To test: 

<details>

<summary>
    Copy this in page.tsx
</summary>

```tsx
"use client";

import type { NextPage } from "next";
import { useAccount } from "wagmi";
import { Address } from "~~/components/scaffold-eth";
import { useDeployedContractInfo, useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";

const Home: NextPage = () => {
  const { address: connectedAddress } = useAccount();
  const { data: depecatedContractInfo } = useDeployedContractInfo("YourContract");
  const { data: newContractInfo } = useDeployedContractInfo({ contractName: "YourContract", chainId: 31337 });

  console.log({ depecatedContractInfo, newContractInfo });

  const { writeContractAsync: depeRecatedWriteAsync } = useScaffoldWriteContract("YourContract");

  const { writeContractAsync: newWriteAsync } = useScaffoldWriteContract({
    contractName: "YourContract",
    chainId: 31337,
  });

  const { data: currGreeting } = useScaffoldReadContract({
    contractName: "YourContract",
    functionName: "greeting",
  });

  const handleWriteWithDeperecated = async () => {
    try {
      await depeRecatedWriteAsync({
        functionName: "setGreeting",
        args: ["With deprecated write!"],
      });
    } catch {}
  };

  const handleNewWrite = async () => {
    try {
      await newWriteAsync({
        functionName: "setGreeting",
        args: ["With new write!"],
      });
    } catch {}
  };

  return (
    <>
      <div className="flex items-center flex-col flex-grow pt-10">
        <div className="px-5">
          <div className="flex justify-center items-center space-x-2 flex-col sm:flex-row">
            <p className="my-2 font-medium">Connected Address:</p>
            <Address address={connectedAddress} />
          </div>
        </div>
        <p>{currGreeting}</p>
        <div className="flex flex-col space-y-3">
          <button onClick={handleWriteWithDeperecated} className="btn btn-primary">
            Write with Deperecated
          </button>

          <button onClick={handleNewWrite} className="btn btn-primary">
            Write with New
          </button>
        </div>
      </div>
    </>
  );
};

export default Home;
```

</details>


### Question: 

Shall we also `console.warn("Warning: Using useScaffoldWriteContract with a string parameter is deprecated. Please use the object parameter version instead")` log this warning in browser? if people use string param? 

