### PR TITLE
Keystore Randomization

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ Visit your app on: `http://localhost:3000`. You can interact with your smart con
 yarn generate
 ```
 
-This creates a `scaffold-eth-custom` [keystore](https://book.getfoundry.sh/reference/cli/cast/wallet#cast-wallet) in `~/.foundry/keystores/scaffold-eth-custom` account.
+This creates a `scaffold-eth-${}` [keystore](https://book.getfoundry.sh/reference/cli/cast/wallet#cast-wallet) in `~/.foundry/keystores/scaffold-eth-${}` account.
 
 Update `.env` in `packages/foundry`:
 
 ```
-ETH_KEYSTORE_ACCOUNT=scaffold-eth-custom
+ETH_KEYSTORE_ACCOUNT=scaffold-eth-${}
 ```
 
 </details>
@@ -85,15 +85,15 @@ ETH_KEYSTORE_ACCOUNT=scaffold-eth-custom
 <summary>Option 2: Import existing private key</summary>
 
 ```
-yarn account:import
+yarn account:import -- ${ACCOUNT_NAME}
 ```
 
-This imports your key as `scaffold-eth-custom`.
+This imports your key as `${ACCOUNT_NAME}`.
 
 Update `.env`:
 
 ```
-ETH_KEYSTORE_ACCOUNT=scaffold-eth-custom
+ETH_KEYSTORE_ACCOUNT=${ACCOUNT_NAME}
 ```
 
 </details>

--- a/packages/foundry/.env.example
+++ b/packages/foundry/.env.example
@@ -15,5 +15,5 @@
 ALCHEMY_API_KEY=oKxs-03sij-U_N0iOlrSsZFr29-IqbuF
 # Etherscan API key is used to verify the contract on etherscan.
 ETHERSCAN_API_KEY=DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW
-# Default account for localhost / use "scaffold-eth-custom" if you wish to use a generated account or imported account
+# Default account for localhost / use "scaffold-eth-${}" if you wish to use a generated account or imported account
 ETH_KEYSTORE_ACCOUNT=scaffold-eth-default

--- a/packages/foundry/Makefile
+++ b/packages/foundry/Makefile
@@ -54,10 +54,18 @@ verify-keystore:
 account:
 	@node scripts-js/ListAccount.js $$(make verify-keystore)
 
+RANDOM_STRING := $(shell openssl rand -base64 12 | tr -dc A-Za-z0-9 | head -c 12)
+
 # Generate a new account
 account-generate:
-	@cast wallet import $(ACCOUNT_NAME) --private-key $$(cast wallet new | grep 'Private key:' | awk '{print $$3}')
-	@echo "Please update .env file with ETH_KEYSTORE_ACCOUNT=$(ACCOUNT_NAME)"
+	@if [ "$(ACCOUNT_NAME)" = "scaffold-eth-custom" ]; then \
+		ACCOUNT_NAME="scaffold-eth-$(RANDOM_STRING)"; \
+	else \
+		ACCOUNT_NAME=$(ACCOUNT_NAME); \
+	fi; \
+	cast wallet import $$ACCOUNT_NAME --private-key $$(cast wallet new | grep 'Private key:' | awk '{print $$3}'); \
+	echo "Please update .env file with ETH_KEYSTORE_ACCOUNT=$$ACCOUNT_NAME"
+
 
 # Import an existing account
 account-import:

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -6,7 +6,7 @@
     "verify-keystore": "make verify-keystore",
     "account": "make account",
     "account:generate": "make account-generate ACCOUNT_NAME=${1:-scaffold-eth-custom}",
-    "account:import": "make account-import ACCOUNT_NAME=${1:-scaffold-eth-custom}",
+    "account:import": "make account-import ACCOUNT_NAME=${1}",
     "chain": "make chain",
     "compile": "make compile",
     "deploy": "node scripts-js/parseArgs.js",

--- a/packages/foundry/script/DeployYourContract.s.sol
+++ b/packages/foundry/script/DeployYourContract.s.sol
@@ -18,7 +18,7 @@ contract DeployYourContract is ScaffoldETHDeploy {
     /**
      * @dev Deployer setup based on `ETH_KEYSTORE_ACCOUNT` in `.env`:
      *      - "scaffold-eth-default": Uses Anvil's account #9 (0xa0Ee7A142d267C1f36714E4a8F75612F20a79720), no password prompt
-     *      - "scaffold-eth-custom": requires password used while creating keystore
+     *      - "scaffold-eth-${}": requires password used while creating keystore
      *
      * Note: Must use ScaffoldEthDeployerRunner modifier to:
      *      - Setup correct `deployer` account and fund it

--- a/packages/foundry/scripts-js/ListAccount.js
+++ b/packages/foundry/scripts-js/ListAccount.js
@@ -81,12 +81,12 @@ async function main() {
 
     if (isDefaultAccount) {
       console.log(
-        "\n🏠 It seems you are trying to access the localhost account. Did you forget to update ETH_KEYSTORE_ACCOUNT=scaffold-eth-custom in the .env file?\n"
+        "\n🏠 It seems you are trying to access the localhost account. Did you forget to update ETH_KEYSTORE_ACCOUNT to your generated wallet in the .env file?\n"
       );
     }
 
     console.log(
-      "\n💡 If you haven't generated a deployer keystore account yet, please run `yarn account:generate`. Then update the `.env` file with `ETH_KEYSTORE_ACCOUNT=scaffold-eth-custom`"
+      "\n💡 If you haven't generated a deployer keystore account yet, please run `yarn account:generate`. Then update the `ETH_KEYSTORE_ACCOUNT` value in the `.env` file"
     );
     return;
   }
@@ -94,7 +94,7 @@ async function main() {
   if (isValidAddress && isDefaultAccount) {
     console.log("\n⚠️ Displaying balance for default account");
     console.log(
-      "\n❓ Did you forget to update ETH_KEYSTORE_ACCOUNT=scaffold-eth-custom in the .env file?\n"
+      "\n❓ Did you forget to update ETH_KEYSTORE_ACCOUNT's value in the .env file?\n"
     );
   }
 

--- a/packages/foundry/scripts-js/parseArgs.js
+++ b/packages/foundry/scripts-js/parseArgs.js
@@ -73,7 +73,7 @@ To deploy to ${network}, please follow these steps:
    $ yarn generate
 
 2. Update your .env file:
-   ETH_KEYSTORE_ACCOUNT='scaffold-eth-custom'
+   ETH_KEYSTORE_ACCOUNT set to the generated account's name.
 
 The default account (scaffold-eth-default) can only be used for localhost deployments.
 `);


### PR DESCRIPTION
## Description

We can improve keystore security by generating a unique one in every SE-2 application. 

When `yarn-generate` is called, it will create a unique name and private key for the user.

I will try to improve the documentation but would appreciate help with updating it!

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: JacobHomanics.eth
