### PR TITLE
Update Makefile to have --via-ir on verify command

### DIFF
--- a/packages/foundry/Makefile
+++ b/packages/foundry/Makefile
@@ -77,4 +77,4 @@ lint:
 
 # Verify contracts
 verify:
-	forge script script/VerifyAll.s.sol --ffi --rpc-url $(RPC_URL)
+	forge script script/VerifyAll.s.sol --ffi --via-ir --rpc-url $(RPC_URL)


### PR DESCRIPTION
## Description
When we use `--via-ir` on the deploy command then (at least in some cases) it needs to be in the verify command. We should rigorously test this and perhaps also consider just removing `--via-ir` from the deploy command.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: gnole.eth
