### PR TITLE
Fix typos

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/getParsedError.ts
+++ b/packages/nextjs/utils/scaffold-eth/getParsedError.ts
@@ -1,7 +1,7 @@
 import { BaseError as BaseViemError, ContractFunctionRevertedError } from "viem";
 
 /**
- * Parses an viem/wagmi error to get a displayable string
+ * Parses a viem/wagmi error to get a displayable string
  * @param e - error object
  * @returns parsed error string
  */

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -12,7 +12,7 @@ type ChainAttributes = {
 export type ChainWithAttributes = chains.Chain & Partial<ChainAttributes>;
 export type AllowedChainIds = (typeof scaffoldConfig.targetNetworks)[number]["id"];
 
-// Mapping of chainId to RPC chain name an format followed by alchemy and infura
+// Mapping of chainId to RPC chain name a format followed by alchemy and infura
 export const RPC_CHAIN_NAMES: Record<number, string> = {
   [chains.mainnet.id]: "eth-mainnet",
   [chains.goerli.id]: "eth-goerli",


### PR DESCRIPTION
This pull request corrects grammatical errors in comments within two utility files:

1. **`getParsedError.ts`**
   - Corrected grammar in the comment from "an viem/wagmi error" to "a viem/wagmi error."

2. **`networks.ts`**
   - Corrected grammar in the comment from "an format" to "a format."