### PR TITLE
Add yarn fleek command to deploy on fleek

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test": "yarn hardhat:test",
     "vercel": "yarn workspace @se-2/nextjs vercel",
     "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo",
+    "fleek": "yarn workspace @se-2/nextjs fleek",
     "verify": "yarn hardhat:verify"
   },
   "packageManager": "yarn@3.2.3",

--- a/packages/nextjs/fleek.config.json
+++ b/packages/nextjs/fleek.config.json
@@ -1,0 +1,9 @@
+{
+  "sites": [
+    {
+      "slug": "",
+      "distDir": "out",
+      "buildCommand": "yarn build"
+    }
+  ]
+}

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -16,4 +16,14 @@ const nextConfig = {
   },
 };
 
+const isFleek = process.env.npm_lifecycle_event === "fleek";
+
+if (isFleek) {
+  nextConfig.output = "export";
+  nextConfig.trailingSlash = true;
+  nextConfig.images = {
+    unoptimized: true,
+  };
+}
+
 module.exports = nextConfig;

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,7 +11,8 @@
     "serve": "next start",
     "start": "next dev",
     "vercel": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env VERCEL_TELEMETRY_DISABLED=1",
-    "vercel:yolo": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true --build-env VERCEL_TELEMETRY_DISABLED=1"
+    "vercel:yolo": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true --build-env VERCEL_TELEMETRY_DISABLED=1",
+    "fleek": "fleek sites deploy"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.5",


### PR DESCRIPTION
### This PR:

-> Adds `yarn fleek` command to the package.json
-> Modifies `next.config.js` to populate `out` folder when `yarn fleek` is run
-> Adds a `fleek.config.json` file with an empty slug so that users know it should be there? (we might want to not include this file at all as it is going to be replaced anyways by yarn fleek

Here is a se-2 app i deployed using this branch:
https://limited-vulture-full.on-fleek.app/
Here is how it looks on ipfs:
https://ipfs.io/ipfs/QmdTSoHmQGYdLejyenRGw4K4M15FVWYWmsqkJBgsLWWig4/
One note here: the ipfs url looks the same as nifty ink ipfs so maybe if we could update the nifty ink ipfs gateway everything would work?

Here is the same app on vercel
https://delete-later-wheat.vercel.app/

### How to use it?
1. Clone se-2 and switch to feat/fleek branch
2. Install fleek with `npm install -g @fleek-platform/cli`
2. After installing fleek login to your fleek account, if you dont have one, create one
3. Then run yarn fleek which will walk you through creating a fleek.config.json file and connect your app to fleek
4. voila