### PR TITLE
Add contributing rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@ The project is under active development.
 
 You can view the open Issues, follow the development process and contribute to the project.
 
+### Rules
+
+1. All code contributions require an issue to be created and agreed upon by core contributors before submitting a Pull Request. This ensures proper discussion, alignment, and consensus on the proposed changes.
+2. Contributors must be humans, not bots.
+3. First time contributions must not contain only spelling or grammatical fixes.
+
 ## Getting started
 
 You can contribute to this repo in many ways:


### PR DESCRIPTION
Added a Rules section to the `CONTRIBUTING.md` to:

- Make the need of creating Issues before PRs a bit clearer
- Be able to prevent "sybil contributions" by fixing small spelling or grammatical errors, just for the sake of farming airdrops.

Got inspired by: https://github.com/wevm/viem/blob/main/.github/CONTRIBUTING.md