### PR TITLE
update contract sort order in numberic way

### DIFF
--- a/packages/nextjs/app/debug/_components/DebugContracts.tsx
+++ b/packages/nextjs/app/debug/_components/DebugContracts.tsx
@@ -11,7 +11,13 @@ const selectedContractStorageKey = "scaffoldEth2.selectedContract";
 
 export function DebugContracts() {
   const contractsData = useAllContracts();
-  const contractNames = useMemo(() => Object.keys(contractsData) as ContractName[], [contractsData]);
+  const contractNames = useMemo(
+    () =>
+      Object.keys(contractsData).sort((a, b) => {
+        return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+      }) as ContractName[],
+    [contractsData],
+  );
 
   const [selectedContract, setSelectedContract] = useSessionStorage<ContractName>(
     selectedContractStorageKey,


### PR DESCRIPTION
### Description: 

This sorts in natural number order. 

In main branch: Contract1, Contract11 and then Contract2 will appear in debug page

We implemented this logic in https://github.com/BuidlGuidl/ctf.buidlguidl.com/blob/e5f418f7bd1ac942f99f49e689101c53ae6b5f78/packages/nextjs/app/debug/_components/DebugContracts.tsx#L12-L14



## To test: 

1. Create this files: 

<details>

<summary>
    Contract1.sol
</summary>

```solidity
      // SPDX-License-Identifier: MIT
      pragma solidity ^0.8.0;
      
      contract Contract1 {
          // State variable
          uint256 public counter;
      
          // Event declaration
          event CounterIncremented(uint256 newValue);
          event CounterReset();
      
          // Increment the counter
          function increment() public {
              counter += 1;
              emit CounterIncremented(counter);
          }
      
          // Get the current counter value
          function getCounter() public view returns (uint256) {
              return counter;
          }
      
          // Reset the counter to zero
          function reset() public {
              counter = 0;
              emit CounterReset();
          }
      }
```

</details>

<details>

<summary>
    Contract2.sol
</summary>

```solidity
       // SPDX-License-Identifier: MIT
    pragma solidity ^0.8.0;
    
    contract Contract2 {
        // State variables
        string public message;
        address public lastSender;
        uint256 public lastUpdated;
    
        // Events
        event MessageUpdated(address sender, string newMessage);
    
        // Store a new message
        function setMessage(string memory _newMessage) public {
            message = _newMessage;
            lastSender = msg.sender;
            lastUpdated = block.timestamp;
            
            emit MessageUpdated(msg.sender, _newMessage);
        }
    
        // Get the current message details
        function getMessageDetails() public view returns (
            string memory currentMessage,
            address messageSender,
            uint256 timestamp
        ) {
            return (message, lastSender, lastUpdated);
        }
    
        // Check if an address has ever sent a message
        function hasUserSetMessage(address user) public view returns (bool) {
            return user == lastSender;
        }
    }
 ```

</details>


<details>

<summary>
    Contract11.sol
</summary>

```solidity
      // SPDX-License-Identifier: MIT
  pragma solidity ^0.8.0;
  
  contract Contract11 {
      // State variable
      uint256 public counter;
  
      // Event declaration
      event CounterIncremented(uint256 newValue);
      event CounterReset();
  
      // Increment the counter
      function increment() public {
          counter += 1;
          emit CounterIncremented(counter);
      }
  
      // Get the current counter value
      function getCounter() public view returns (uint256) {
          return counter;
      }
  
      // Reset the counter to zero
      function reset() public {
          counter = 0;
          emit CounterReset();
      }
  }
```

</details>

2. Copy this in `00_deploy_your_contracts.ts`

<details>

<summary>
    00_deploy_your_contract.ts
</summary>

```ts
import { HardhatRuntimeEnvironment } from "hardhat/types";
import { DeployFunction } from "hardhat-deploy/types";
import { Contract } from "ethers";

/**
 * Deploys a contract named "YourContract" using the deployer account and
 * constructor arguments set to the deployer address
 *
 * @param hre HardhatRuntimeEnvironment object.
 */
const deployYourContract: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
  /*
    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.

    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
    should have sufficient balance to pay for the gas fees for contract creation.

    You can generate a random account with `yarn generate` or `yarn account:import` to import your
    existing PK which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED in the .env file (then used on hardhat.config.ts)
    You can run the `yarn account` command to check your balance in every network.
  */
  const { deployer } = await hre.getNamedAccounts();
  const { deploy } = hre.deployments;

  await deploy("YourContract", {
    from: deployer,
    // Contract constructor arguments
    args: [deployer],
    log: true,
    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
    // automatically mining the contract deployment transaction. There is no effect on live networks.
    autoMine: true,
  });

  await deploy("Contract1", {
    from: deployer,
    log: true,
    autoMine: true,
  });

  await deploy("Contract11", {
    from: deployer,
    log: true,
    autoMine: true,
  });

  await deploy("Contract2", {
    from: deployer,
    log: true,
    autoMine: true,
  });

  // Get the deployed contract to interact with it after deploying.
  const yourContract = await hre.ethers.getContract<Contract>("YourContract", deployer);
  console.log("👋 Initial greeting:", await yourContract.greeting());
};

export default deployYourContract;

// Tags are useful if you have multiple deploy files and only want to run one of them.
// e.g. yarn deploy --tags YourContract
deployYourContract.tags = ["YourContract"];
```

</details>