### PR TITLE
feat: add ConnectWalletButton component

### DIFF
--- a/packages/nextjs/components/scaffold-eth/ConnectWalletButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/ConnectWalletButton.tsx
@@ -1,0 +1,50 @@
+import { ButtonHTMLAttributes } from "react";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { useAccount } from "wagmi";
+
+interface ConnectWalletButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  connectText?: string;
+  disabled?: boolean;
+}
+
+export const ConnectWalletButton = ({
+  children,
+  connectText = "Connect Wallet",
+  disabled = false,
+  onClick,
+  className,
+  ...props
+}: ConnectWalletButtonProps) => {
+  const { isConnected } = useAccount();
+  const { openConnectModal, connectModalOpen } = useConnectModal();
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    if (isConnected) {
+      onClick?.(e);
+    } else {
+      openConnectModal?.();
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className={className}
+      disabled={disabled || (!isConnected && !openConnectModal) || connectModalOpen}
+      {...props}
+    >
+      {isConnected ? (
+        children
+      ) : connectModalOpen ? (
+        <>
+          <div className="loading" />
+          Connecting...
+        </>
+      ) : (
+        connectText
+      )}
+    </button>
+  );
+};


### PR DESCRIPTION
## Description

This component makes it easier to have a button that does something that requires the user to connect their wallet. If the wallet is not connected, instead of rendering the `children`, it instead opens the connection modal. I find that this is a surprisingly common use case.

I would consider this a "simple" PR. If it is accepted, I'm down to write the docs for it too.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: `byteatatime.eth`
