### PR TITLE
Error on yarn lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "hardhat:lint-staged": "yarn workspace @se-2/hardhat lint-staged",
     "hardhat:test": "yarn workspace @se-2/hardhat test",
     "hardhat:verify": "yarn workspace @se-2/hardhat verify",
-    "lint": "yarn nextjs:lint && yarn hardhat:lint",
+    "lint": "yarn next:lint && yarn hardhat:lint",
     "next:build": "yarn workspace @se-2/nextjs build",
     "next:check-types": "yarn workspace @se-2/nextjs check-types",
     "next:format": "yarn workspace @se-2/nextjs format",


### PR DESCRIPTION
Solved error on using old nextjs:lint by next:lint command

## Description

_Failing when running `yarn lint` due to using `yarn nextjs:lint` old command. We must use `yarn next:lint` one._

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{1040}_


Your ENS/address: meketom.eth
