### PR TITLE
Remove  unnecessary RPC call on Faucet Button

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -4,9 +4,10 @@ import React, { useCallback, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { hardhat } from "viem/chains";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
-import { useOutsideClick } from "~~/hooks/scaffold-eth";
+import { useOutsideClick, useTargetNetwork } from "~~/hooks/scaffold-eth";
 
 type HeaderMenuLink = {
   label: string;
@@ -56,6 +57,9 @@ export const HeaderMenuLinks = () => {
  * Site header
  */
 export const Header = () => {
+  const { targetNetwork } = useTargetNetwork();
+  const isLocalNetwork = targetNetwork.id === hardhat.id;
+
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const burgerMenuRef = useRef<HTMLDivElement>(null);
   useOutsideClick(
@@ -103,7 +107,7 @@ export const Header = () => {
       </div>
       <div className="navbar-end flex-grow mr-4">
         <RainbowKitCustomConnectButton />
-        <FaucetButton />
+        {isLocalNetwork && <FaucetButton />}
       </div>
     </div>
   );


### PR DESCRIPTION
While testing the [BG RPC](https://client.buidlguidl.com/) I did a SE-2 build where I wanted to remove all the "automatic" RPC calls and only trigger them when doing an action (e.g. clicking a button).

After deleting all the obvious (getting the ETH price, the Balance from the connected wallet, etc) I realized that a RPC call for getting the connected address balance was still happening. 

Digging a bit, this was coming from the `FaucetButton` component: even if the component doesn't show (it returns `null` if not in localhost) the `useWatchBalance` hook is still being called.

This PR adds a check so we don't render/execute the FaucetButton at all (following the same logic as the block explorer link in the footer)

You can test by pulling down https://github.com/scaffold-eth/scaffold-eth-2/tree/faucet-button--test, where all the RPC calls are removed (except the FaucetButton one), so you can add the fix from this PR and check.

PS. It might be a bit nitpicky (just saving an RPC call every X seconds) but since the fix is straight forward decided to go for it. 

What do y'all think?

