### PR TITLE
Remove indexed event params

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -142,8 +142,7 @@ export const useScaffoldEventHistory = <
       return nextBlock;
     },
     select: data => {
-      const events = data.pages.flat();
-      const eventHistoryData = events?.map(addIndexedArgsToEvent) as UseScaffoldEventHistoryData<
+      const events = data.pages.flat() as unknown as UseScaffoldEventHistoryData<
         TContractName,
         TEventName,
         TBlockData,
@@ -152,7 +151,7 @@ export const useScaffoldEventHistory = <
       >;
 
       return {
-        pages: eventHistoryData?.reverse(),
+        pages: events?.reverse(),
         pageParams: data.pageParams,
       };
     },
@@ -179,12 +178,4 @@ export const useScaffoldEventHistory = <
     isFetchingNewEvent: query.isFetchingNextPage,
     refetch: query.refetch,
   };
-};
-
-export const addIndexedArgsToEvent = (event: any) => {
-  if (event.args && !Array.isArray(event.args)) {
-    return { ...event, args: { ...event.args, ...Object.values(event.args) } };
-  }
-
-  return event;
 };

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldWatchContractEvent.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldWatchContractEvent.ts
@@ -2,7 +2,7 @@ import { Abi, ExtractAbiEventNames } from "abitype";
 import { Log } from "viem";
 import { useWatchContractEvent } from "wagmi";
 import { useSelectedNetwork } from "~~/hooks/scaffold-eth";
-import { addIndexedArgsToEvent, useDeployedContractInfo } from "~~/hooks/scaffold-eth";
+import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
 import { AllowedChainIds } from "~~/utils/scaffold-eth";
 import { ContractAbi, ContractName, UseScaffoldEventConfig } from "~~/utils/scaffold-eth/contract";
 
@@ -30,14 +30,11 @@ export const useScaffoldWatchContractEvent = <
     chainId: selectedNetwork.id as AllowedChainIds,
   });
 
-  const addIndexedArgsToLogs = (logs: Log[]) => logs.map(addIndexedArgsToEvent);
-  const listenerWithIndexedArgs = (logs: Log[]) => onLogs(addIndexedArgsToLogs(logs) as Parameters<typeof onLogs>[0]);
-
   return useWatchContractEvent({
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,
     chainId: selectedNetwork.id,
-    onLogs: listenerWithIndexedArgs,
+    onLogs: (logs: Log[]) => onLogs(logs as Parameters<typeof onLogs>[0]),
     eventName,
   });
 };


### PR DESCRIPTION
Remove indexed events arguments for named event arguments

Updated Challenge 1 readme since it already has type errors if arguments are named https://github.com/scaffold-eth/se-2-challenges/commit/19b1c29c912f888796e64cff931c23772d9363f2

I think we don't need to update Se-2 docs for now since looks like not using indexed params is expected behavior

Fixes #1045 
