### PR TITLE
Add OP Retro Funding round 7 verification

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,5 @@
+{
+  "opRetro": {
+    "projectId": "0x154a42e5ca88d7c2732fda74d6eb611057fc88dbe6f0ff3aae7b89c2cd1666ab"
+  }
+}


### PR DESCRIPTION
## Description

Similar to what we did for RF4 in #860 we need to verify the repo for [Dev tooling RF7](https://atlas.optimism.io/missions/retro-funding-dev-tooling) in order to participate (we're creating Scaffold-ETH 2 project for RF7 round, so old generic BuidlGuidl RF4 verifications don't work for this).

Planning to verify these repos:

- [ ] Scaffold-ETH
- [ ] SE-2 docs
- [ ] SE-2 website
- [ ] Create-eth
- [ ] Create-eth extensions

