### PR TITLE
[Draft] Tinkering with AddressInput hook/ui

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_components/AddressInputPrefix.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_components/AddressInputPrefix.tsx
@@ -1,0 +1,40 @@
+import { Address, GetEnsNameReturnType } from "viem";
+import { GetEnsAvatarReturnType } from "wagmi/actions";
+
+export const AddressInputPrefix = ({
+  ensName,
+  ensAvatar,
+  isEnsAvatarLoading,
+  isEnsLoadingAddressOrName,
+  enteredEnsName,
+  ensAddress,
+}: {
+  ensName?: GetEnsNameReturnType;
+  ensAvatar?: GetEnsAvatarReturnType;
+  ensAddress?: Address;
+  isEnsAvatarLoading: boolean;
+  isEnsLoadingAddressOrName: boolean;
+  enteredEnsName?: string;
+}) => {
+  return ensName ? (
+    <div className="flex bg-base-300 rounded-l-full items-center">
+      {isEnsAvatarLoading && <div className="skeleton bg-base-200 w-[35px] h-[35px] rounded-full shrink-0"></div>}
+      {ensAvatar ? (
+        <span className="w-[35px]">
+          {
+            // eslint-disable-next-line
+            <img className="w-full rounded-full" src={ensAvatar} alt={`${ensAddress} avatar`} />
+          }
+        </span>
+      ) : null}
+      <span className="text-accent px-2">{enteredEnsName ?? ensName}</span>
+    </div>
+  ) : (
+    isEnsLoadingAddressOrName && (
+      <div className="flex bg-base-300 rounded-l-full items-center gap-2 pr-2">
+        <div className="skeleton bg-base-200 w-[35px] h-[35px] rounded-full shrink-0"></div>
+        <div className="skeleton bg-base-200 h-3 w-20"></div>
+      </div>
+    )
+  );
+};

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_components/AddressInputSuffix.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_components/AddressInputSuffix.tsx
@@ -1,0 +1,8 @@
+import { blo } from "blo";
+import { Address } from "viem";
+
+export const AddressInputSuffix = ({ value }: { value: Address }) => {
+  // Don't want to use nextJS Image here (and adding remote patterns for the URL)
+  // eslint-disable-next-line @next/next/no-img-element
+  return value && <img alt="" className="!rounded-full" src={blo(value as `0x${string}`)} width="35" height="35" />;
+};

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_components/InputBase2/_hooks/useInputBase.ts
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_components/InputBase2/_hooks/useInputBase.ts
@@ -1,0 +1,29 @@
+import { ChangeEvent, FocusEvent, useCallback, useEffect, useRef } from "react";
+
+export const useInputBase = <T>({ onChange, reFocus }: { onChange: (newValue: T) => void; reFocus?: boolean }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value as unknown as T);
+    },
+    [onChange],
+  );
+
+  // Runs only when reFocus prop is passed, useful for setting the cursor
+  // at the end of the input. Example AddressInput
+  const onFocus = (e: FocusEvent<HTMLInputElement, Element>) => {
+    if (reFocus !== undefined) {
+      e.currentTarget.setSelectionRange(e.currentTarget.value.length, e.currentTarget.value.length);
+    }
+  };
+  useEffect(() => {
+    if (reFocus !== undefined && reFocus === true) inputRef.current?.focus();
+  }, [reFocus]);
+
+  return {
+    inputRef,
+    handleChange,
+    onFocus,
+  };
+};

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_components/InputBase2/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_components/InputBase2/index.tsx
@@ -1,0 +1,49 @@
+import { ReactNode } from "react";
+import { useInputBase } from "./_hooks/useInputBase";
+import { CommonInputProps } from "~~/components/scaffold-eth";
+
+type InputBaseProps<T> = CommonInputProps<T> & {
+  error?: boolean;
+  prefix?: ReactNode;
+  suffix?: ReactNode;
+  reFocus?: boolean;
+};
+
+export const InputBase2 = <T extends { toString: () => string } | undefined = string>({
+  name,
+  value,
+  onChange,
+  placeholder,
+  error,
+  disabled,
+  prefix,
+  suffix,
+  reFocus,
+}: InputBaseProps<T>) => {
+  const { handleChange, onFocus, inputRef } = useInputBase<T>({ onChange, reFocus });
+
+  let modifier = "";
+  if (error) {
+    modifier = "border-error";
+  } else if (disabled) {
+    modifier = "border-disabled bg-base-300";
+  }
+
+  return (
+    <div className={`flex border-2 border-base-300 bg-base-200 rounded-full text-accent ${modifier}`}>
+      {prefix}
+      <input
+        className="input input-ghost focus-within:border-transparent focus:outline-none focus:bg-transparent h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium placeholder:text-accent/70 text-base-content/70 focus:text-base-content/70"
+        placeholder={placeholder}
+        name={name}
+        value={value?.toString()}
+        onChange={handleChange}
+        disabled={disabled}
+        autoComplete="off"
+        ref={inputRef}
+        onFocus={onFocus}
+      />
+      {suffix}
+    </div>
+  );
+};

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_hooks/useAddressInput.ts
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput2/_hooks/useAddressInput.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { useDebounceValue } from "usehooks-ts";
+import { Address, isAddress } from "viem";
+import { normalize } from "viem/ens";
+import { useEnsAddress, useEnsAvatar, useEnsName } from "wagmi";
+import { isENS } from "~~/components/scaffold-eth";
+import { CommonInputProps } from "~~/components/scaffold-eth";
+
+export const useAddressInput = ({ value, onChange }: CommonInputProps<Address | string>) => {
+  // Debounce the input to keep clean RPC calls when resolving ENS names
+  // If the input is an address, we don't need to debounce it
+  const [_debouncedValue] = useDebounceValue(value, 500);
+  const debouncedValue = isAddress(value) ? value : _debouncedValue;
+  const isDebouncedValueLive = debouncedValue === value;
+
+  // If the user changes the input after an ENS name is already resolved, we want to remove the stale result
+  const settledValue = isDebouncedValueLive ? debouncedValue : undefined;
+
+  const {
+    data: ensAddress,
+    isLoading: isEnsAddressLoading,
+    isError: isEnsAddressError,
+    isSuccess: isEnsAddressSuccess,
+  } = useEnsAddress({
+    name: settledValue,
+    chainId: 1,
+    query: {
+      gcTime: 30_000,
+      enabled: isDebouncedValueLive && isENS(debouncedValue),
+    },
+  });
+
+  const [enteredEnsName, setEnteredEnsName] = useState<string>();
+  const {
+    data: ensName,
+    isLoading: isEnsNameLoading,
+    isError: isEnsNameError,
+    isSuccess: isEnsNameSuccess,
+  } = useEnsName({
+    address: settledValue as Address,
+    chainId: 1,
+    query: {
+      enabled: isAddress(debouncedValue),
+      gcTime: 30_000,
+    },
+  });
+
+  const { data: ensAvatar, isLoading: isEnsAvatarLoading } = useEnsAvatar({
+    name: ensName ? normalize(ensName) : undefined,
+    chainId: 1,
+    query: {
+      enabled: Boolean(ensName),
+      gcTime: 30_000,
+    },
+  });
+
+  // ens => address
+  useEffect(() => {
+    if (!ensAddress) return;
+
+    // ENS resolved successfully
+    setEnteredEnsName(debouncedValue);
+    onChange(ensAddress);
+  }, [ensAddress, onChange, debouncedValue]);
+
+  useEffect(() => {
+    setEnteredEnsName(undefined);
+  }, [value]);
+
+  const reFocus =
+    isEnsAddressError ||
+    isEnsNameError ||
+    isEnsNameSuccess ||
+    isEnsAddressSuccess ||
+    ensName === null ||
+    ensAddress === null;
+
+  return {
+    ensAddress,
+    ensName,
+    enteredEnsName,
+    ensAvatar,
+    isEnsAvatarLoading,
+    isEnsLoadingAddressOrName: isEnsAddressLoading || isEnsNameLoading,
+    reFocus,
+  };
+};

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput2/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput2/index.tsx
@@ -1,0 +1,39 @@
+import { AddressInputPrefix } from "./_components/AddressInputPrefix";
+import { AddressInputSuffix } from "./_components/AddressInputSuffix";
+import { InputBase2 } from "./_components/InputBase2";
+import { useAddressInput } from "./_hooks/useAddressInput";
+import { Address } from "viem";
+import { CommonInputProps } from "~~/components/scaffold-eth";
+
+/**
+ * Address input with ENS name resolution
+ */
+export const AddressInput2 = ({ value, name, placeholder, onChange, disabled }: CommonInputProps<Address | string>) => {
+  const { ensAddress, ensName, ensAvatar, isEnsLoadingAddressOrName, reFocus, isEnsAvatarLoading, enteredEnsName } =
+    useAddressInput({
+      value,
+      onChange,
+    });
+
+  return (
+    <InputBase2<Address>
+      name={name}
+      placeholder={placeholder}
+      error={ensAddress === null}
+      value={value as Address}
+      onChange={onChange}
+      disabled={isEnsLoadingAddressOrName || disabled}
+      reFocus={reFocus}
+      prefix={
+        <AddressInputPrefix
+          ensName={ensName}
+          ensAvatar={ensAvatar}
+          isEnsAvatarLoading={isEnsAvatarLoading}
+          isEnsLoadingAddressOrName={isEnsLoadingAddressOrName}
+          enteredEnsName={enteredEnsName}
+        />
+      }
+      suffix={<AddressInputSuffix value={value as Address} />}
+    />
+  );
+};


### PR DESCRIPTION
Created `AddressInput2` component, which is absolutely similary to `AddressInput`, but
- all the logic now lives in `useAddressInput` hook
- prefix and suffix now UI components
- since `AddressInput2` depends of `InputBase`, I copied it to `InputBase2` component too and moved it's logic to `useInputBase`.

So, to change UI of AddressInput, user needs to change UI parts of it: components `InputBase`, `AddressInputPrefix` and `AddressInputSuffix`

----

In this `AddressInput` component we already have predefined UI (our current default). I'll create another PR soon with different option