### PR TITLE
[Draft] Tinkering with AddressInput v2

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput2/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput2/index.tsx
@@ -1,3 +1,4 @@
+import { ComponentType, ReactNode } from "react";
 import { AddressInputPrefix } from "./_components/AddressInputPrefix";
 import { AddressInputSuffix } from "./_components/AddressInputSuffix";
 import { InputBase2 } from "./_components/InputBase2";
@@ -5,10 +6,45 @@ import { useAddressInput } from "./_hooks/useAddressInput";
 import { Address } from "viem";
 import { CommonInputProps } from "~~/components/scaffold-eth";
 
+type InputBaseProps<T> = CommonInputProps<T> & {
+  error?: boolean;
+  reFocus?: boolean;
+  prefix?: ReactNode;
+  suffix?: ReactNode;
+};
+
+type InputPrefixComponentProps = {
+  ensName?: string | null;
+  ensAvatar?: string | null;
+  isEnsAvatarLoading: boolean;
+  isEnsLoadingAddressOrName: boolean;
+  enteredEnsName?: string;
+  ensAddress?: Address;
+};
+
+type InputSuffixComponentProps = {
+  value: Address;
+};
+
+type AddressInput2Props = CommonInputProps<Address | string> & {
+  InputComponent?: ComponentType<InputBaseProps<Address>>;
+  InputPrefixComponent?: ComponentType<InputPrefixComponentProps>;
+  InputSuffixComponent?: ComponentType<InputSuffixComponentProps>;
+};
+
 /**
  * Address input with ENS name resolution
  */
-export const AddressInput2 = ({ value, name, placeholder, onChange, disabled }: CommonInputProps<Address | string>) => {
+export const AddressInput2 = ({
+  value,
+  name,
+  placeholder,
+  onChange,
+  disabled,
+  InputComponent = InputBase2,
+  InputPrefixComponent = AddressInputPrefix,
+  InputSuffixComponent = AddressInputSuffix,
+}: AddressInput2Props) => {
   const { ensAddress, ensName, ensAvatar, isEnsLoadingAddressOrName, reFocus, isEnsAvatarLoading, enteredEnsName } =
     useAddressInput({
       value,
@@ -16,7 +52,7 @@ export const AddressInput2 = ({ value, name, placeholder, onChange, disabled }: 
     });
 
   return (
-    <InputBase2<Address>
+    <InputComponent
       name={name}
       placeholder={placeholder}
       error={ensAddress === null}
@@ -25,7 +61,7 @@ export const AddressInput2 = ({ value, name, placeholder, onChange, disabled }: 
       disabled={isEnsLoadingAddressOrName || disabled}
       reFocus={reFocus}
       prefix={
-        <AddressInputPrefix
+        <InputPrefixComponent
           ensName={ensName}
           ensAvatar={ensAvatar}
           isEnsAvatarLoading={isEnsAvatarLoading}
@@ -33,7 +69,7 @@ export const AddressInput2 = ({ value, name, placeholder, onChange, disabled }: 
           enteredEnsName={enteredEnsName}
         />
       }
-      suffix={<AddressInputSuffix value={value as Address} />}
+      suffix={<InputSuffixComponent value={value as Address} />}
     />
   );
 };


### PR DESCRIPTION
Second version of `AddressInput`. See v1 here: https://github.com/scaffold-eth/scaffold-eth-2/pull/1054


Usage: 
```tsx
<AddressInput2
    placeholder="Destination Address"
    value={inputAddress ?? ""}
    onChange={value => setInputAddress(value as AddressType)}
    InputComponent={InputBase2}
    InputPrefixComponent={AddressInputPrefix}
    InputSuffixComponent={AddressInputSuffix}
/>
```

Main change: UI components moved to `AddressInput2` props. That UI components should have certain props. 

Comparing to v1
Pros:
1. `AddressInput` could be uploaded to NPM without default component props. In that case all the UI components (PropComponents) should be implemented from scratch by user. We could have examples at the docs though, or keep them in near folder but see [3]
2. Different `PropComponent`'s could be used for different `AddressInput`s. Not sure if it good or bad. On the one side it gives composability but on the other side it could add complexity to the project

Cons: 
3. If we use default components props, then that components should be accessible from `AddressInput` and hence distributed somehow together or just from the all components lib. So, component will become very similar to v1
4. A bit more complex