### PR TITLE
RPC Overrides

### DIFF
--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -4,6 +4,7 @@ export type ScaffoldConfig = {
   targetNetworks: readonly chains.Chain[];
   pollingInterval: number;
   alchemyApiKey: string;
+  rpcOverrides: Record<number, string>;
   walletConnectProjectId: string;
   onlyLocalBurnerWallet: boolean;
 };
@@ -23,6 +24,13 @@ const scaffoldConfig = {
   // It's recommended to store it in an env variable:
   // .env.local for local testing, and in the Vercel/system env config for live apps.
   alchemyApiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || DEFAULT_ALCHEMY_API_KEY,
+
+  // If you want to use a different RPC for a specific network, you can add it here.
+  // The key is the chain ID, and the value is the RPC URL.
+  // (this should be commented)
+  rpcOverrides: {
+    [chains.mainnet.id]: "https://mainnet.buidlguidl.com",
+  },
 
   // This is ours WalletConnect's default project ID.
   // You can get your own at https://cloud.walletconnect.com

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -4,7 +4,7 @@ export type ScaffoldConfig = {
   targetNetworks: readonly chains.Chain[];
   pollingInterval: number;
   alchemyApiKey: string;
-  rpcOverrides: Record<number, string>;
+  rpcOverrides?: Record<number, string>;
   walletConnectProjectId: string;
   onlyLocalBurnerWallet: boolean;
 };
@@ -26,10 +26,10 @@ const scaffoldConfig = {
   alchemyApiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || DEFAULT_ALCHEMY_API_KEY,
 
   // If you want to use a different RPC for a specific network, you can add it here.
-  // The key is the chain ID, and the value is the RPC URL.
-  // (this should be commented)
+  // The key is the chain ID, and the value is the HTTP RPC URL
   rpcOverrides: {
-    [chains.mainnet.id]: "https://mainnet.buidlguidl.com",
+    // Example:
+    // [chains.mainnet.id]: "https://mainnet.buidlguidl.com",
   },
 
   // This is ours WalletConnect's default project ID.

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -2,8 +2,8 @@ import { wagmiConnectors } from "./wagmiConnectors";
 import { Chain, createClient, fallback, http } from "viem";
 import { hardhat, mainnet } from "viem/chains";
 import { createConfig } from "wagmi";
-import scaffoldConfig, { DEFAULT_ALCHEMY_API_KEY } from "~~/scaffold.config";
-import { getAlchemyHttpUrl, getRpcOverrideHttpUrl } from "~~/utils/scaffold-eth";
+import scaffoldConfig, { DEFAULT_ALCHEMY_API_KEY, ScaffoldConfig } from "~~/scaffold.config";
+import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth";
 
 const { targetNetworks } = scaffoldConfig;
 
@@ -19,7 +19,7 @@ export const wagmiConfig = createConfig({
   client({ chain }) {
     let rpcFallbacks = [http()];
 
-    const rpcOverrideUrl = getRpcOverrideHttpUrl(chain.id);
+    const rpcOverrideUrl = (scaffoldConfig.rpcOverrides as ScaffoldConfig["rpcOverrides"])?.[chain.id];
     if (rpcOverrideUrl) {
       rpcFallbacks = [http(rpcOverrideUrl), http()];
     } else {

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -3,7 +3,7 @@ import { Chain, createClient, fallback, http } from "viem";
 import { hardhat, mainnet } from "viem/chains";
 import { createConfig } from "wagmi";
 import scaffoldConfig, { DEFAULT_ALCHEMY_API_KEY } from "~~/scaffold.config";
-import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth";
+import { getAlchemyHttpUrl, getRpcOverrideHttpUrl } from "~~/utils/scaffold-eth";
 
 const { targetNetworks } = scaffoldConfig;
 
@@ -19,11 +19,16 @@ export const wagmiConfig = createConfig({
   client({ chain }) {
     let rpcFallbacks = [http()];
 
-    const alchemyHttpUrl = getAlchemyHttpUrl(chain.id);
-    if (alchemyHttpUrl) {
-      const isUsingDefaultKey = scaffoldConfig.alchemyApiKey === DEFAULT_ALCHEMY_API_KEY;
-      // If using default Scaffold-ETH 2 API key, we prioritize the default RPC
-      rpcFallbacks = isUsingDefaultKey ? [http(), http(alchemyHttpUrl)] : [http(alchemyHttpUrl), http()];
+    const rpcOverrideUrl = getRpcOverrideHttpUrl(chain.id);
+    if (rpcOverrideUrl) {
+      rpcFallbacks = [http(rpcOverrideUrl), http()];
+    } else {
+      const alchemyHttpUrl = getAlchemyHttpUrl(chain.id);
+      if (alchemyHttpUrl) {
+        const isUsingDefaultKey = scaffoldConfig.alchemyApiKey === DEFAULT_ALCHEMY_API_KEY;
+        // If using default Scaffold-ETH 2 API key, we prioritize the default RPC
+        rpcFallbacks = isUsingDefaultKey ? [http(), http(alchemyHttpUrl)] : [http(alchemyHttpUrl), http()];
+      }
     }
 
     return createClient({

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -36,6 +36,11 @@ export const RPC_CHAIN_NAMES: Record<number, string> = {
   [chains.celoAlfajores.id]: "celo-alfajores",
 };
 
+export const getRpcOverrideHttpUrl = (chainId: number) => {
+  const rpcOverride = scaffoldConfig.rpcOverrides[chainId as keyof typeof scaffoldConfig.rpcOverrides];
+  return rpcOverride;
+};
+
 export const getAlchemyHttpUrl = (chainId: number) => {
   return scaffoldConfig.alchemyApiKey && RPC_CHAIN_NAMES[chainId]
     ? `https://${RPC_CHAIN_NAMES[chainId]}.g.alchemy.com/v2/${scaffoldConfig.alchemyApiKey}`

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -36,11 +36,6 @@ export const RPC_CHAIN_NAMES: Record<number, string> = {
   [chains.celoAlfajores.id]: "celo-alfajores",
 };
 
-export const getRpcOverrideHttpUrl = (chainId: number) => {
-  const rpcOverride = scaffoldConfig.rpcOverrides[chainId as keyof typeof scaffoldConfig.rpcOverrides];
-  return rpcOverride;
-};
-
 export const getAlchemyHttpUrl = (chainId: number) => {
   return scaffoldConfig.alchemyApiKey && RPC_CHAIN_NAMES[chainId]
     ? `https://${RPC_CHAIN_NAMES[chainId]}.g.alchemy.com/v2/${scaffoldConfig.alchemyApiKey}`


### PR DESCRIPTION
 ## Problem

Currently, changing the RPCs for the frontend is a bit tricky since SE-2 assumes that you are going to use Alchemy, and tweaking it requires you to tweak `wagmiConfig` and it's not very extract forward (we area  bit vendor-locked with Alchemy)

## Solution

Let the builders define the `rpcOverrides` in `scaffold.config.ts`. We don't want to pollute the config file, but RPC config seems like a top-level kind of config.

Tried to come up with the simplest way that respect the current functionality.

Really open!!
- Should we do this?
- Naming
- Logic
