### PR TITLE
fix: import on wagmi package

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -1,6 +1,6 @@
-import { getPublicClient } from "@wagmi/core";
 import { Hash, SendTransactionParameters, TransactionReceipt, WalletClient } from "viem";
 import { Config, useWalletClient } from "wagmi";
+import { getPublicClient } from "wagmi/actions";
 import { SendTransactionMutate } from "wagmi/query";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 import { getBlockExplorerTxLink, getParsedError, notification } from "~~/utils/scaffold-eth";


### PR DESCRIPTION
## Description
Creating production build using `npm run build` causes build errors:
![image](https://github.com/user-attachments/assets/a940ec7d-c8ed-4a42-be2e-114cce4a3dfe)
- Reference of `getPublicClient` should be changed from import `@wagmi/core` to `wagmi/actions`
- Also fixes the issue `publicClient` is possibly undefined in:
```ts
      //useTransactor.tsx
     //`publicClient` is possibly undefined
      transactionReceipt = await publicClient.waitForTransactionReceipt({
        hash: transactionHash,
        confirmations: options?.blockConfirmations,
      });
      notification.remove(notificationId);
```
## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address:
`0xBa9Da840bA7B5d0F227716f2e7266675cE697e9D`