### PR TITLE
Small fixes to homepage layout

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -17,7 +17,7 @@ const Home: NextPage = () => {
             <span className="block text-2xl mb-2">Welcome to</span>
             <span className="block text-4xl font-bold">Scaffold-ETH 2</span>
           </h1>
-          <div className="flex justify-center items-center space-x-2 flex-col sm:flex-row">
+          <div className="flex justify-center items-center space-x-2 flex-col">
             <p className="my-2 font-medium">Connected Address:</p>
             <Address address={connectedAddress} />
           </div>
@@ -40,7 +40,7 @@ const Home: NextPage = () => {
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">
-          <div className="flex justify-center items-center gap-12 flex-col sm:flex-row">
+          <div className="flex justify-center items-center gap-12 flex-col md:flex-row">
             <div className="flex flex-col bg-base-100 px-10 py-10 text-center items-center max-w-xs rounded-3xl">
               <BugAntIcon className="h-8 w-8 fill-secondary" />
               <p>


### PR DESCRIPTION
## Description

The layout wasn't working as expected due to incorrect flex-col/flex-row setup, especially on different screen sizes. The proposed changes provide a clean layout for all screen sizes.

## Additional Information

Tailwind follows a mobile-first approach, meanwhile the SE-2 homepage seemed to have been following a desktop-first approach: https://tailwindcss.com/docs/responsive-design#working-mobile-first which led to unexpected behaviour.

Because of this, the example: `flex-col sm:flex-row` does not work as expected. On small screens, it actually defaults to `flex-col`. Since when tailwind sees `flex-col`, it actually interprets it as `sm:flex-col`.

## Proposed Changes

The `Connected Addresses` section now simply is a `flex-col`, since with the (now removed) `sm:flex-row`, mobile screens would have content displaying horizontally off-screen.

The `Call To Action` section inhibits the mobile first approach by defaulting to a `flex-col` and on screens medium or larger it turns into a `flex-row`.

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: jacobhomanics.eth
