### PR TITLE
🚀 Network Updates: Out with the Old, In with the New!

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -96,16 +96,16 @@ const config: HardhatUserConfig = {
       url: `https://polygon-mainnet.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
-    polygonMumbai: {
-      url: `https://polygon-mumbai.g.alchemy.com/v2/${providerApiKey}`,
+    polygonAmoy: {
+      url: `https://polygon-amoy.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     polygonZkEvm: {
       url: `https://polygonzkevm-mainnet.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
-    polygonZkEvmTestnet: {
-      url: `https://polygonzkevm-testnet.g.alchemy.com/v2/${providerApiKey}`,
+    polygonZkEvmCardona: {
+      url: `https://polygonzkevm-cardona.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     gnosis: {
@@ -142,14 +142,6 @@ const config: HardhatUserConfig = {
     },
     scroll: {
       url: "https://rpc.scroll.io",
-      accounts: [deployerPrivateKey],
-    },
-    pgn: {
-      url: "https://rpc.publicgoods.network",
-      accounts: [deployerPrivateKey],
-    },
-    pgnTestnet: {
-      url: "https://sepolia.publicgoods.network",
       accounts: [deployerPrivateKey],
     },
     celo: {


### PR DESCRIPTION



## 🌉 What's This PR About?

Hello fellow builders! 👋 This PR gives our network configuration a much-needed refresh, saying goodbye to deprecated networks and welcoming their shiny new replacements.

## 🔄 Changes Made

- 🔴 **Removed Deprecated Networks**:
  - Bid farewell to Polygon Mumbai (it served us well, RIP 🪦)
  - PGN and PGN Testnet have left the chat (they've gone to the great blockchain in the sky ☁️)

- 🟢 **Added New Networks**:
  - Welcomed Polygon Amoy as Mumbai's successor (the torch has been passed! 🔥)
  - Introduced Polygon zkEVM Cardona as the replacement for the previous zkEVM testnet

- 🛠️ **Updated Configuration**:
  - Updated RPC endpoints to point to the new networks
  - Kept all account configurations consistent

## ✅ Testing

Both new networks have been thoroughly tested:
- `yarn deploy --network polygonAmoy` ✓
- `yarn deploy --network polygonZkEvmCardona` ✓

Contracts deploy smoothly on both networks, like a hot knife through butter! 🧈

## 🔍 Technical Details

This PR addresses the issues outlined in #1068:
- Mumbai has been deprecated and is now replaced by Amoy
- PGN has been discontinued and is completely removed
- Polygon zkEVM testnet has transitioned to Cardona

## 🙏 Acknowledgements

Thanks to the team for flagging these necessary updates! Keeping our testnets current ensures developers have the best experience building on scaffold-eth-2.

As they say in blockchain land: Stay updated or get deprecated! 😄
