### PR TITLE
Forward user to creating a keystore if none exist

### DIFF
--- a/packages/foundry/scripts-js/selectOrCreateKeystore.js
+++ b/packages/foundry/scripts-js/selectOrCreateKeystore.js
@@ -1,35 +1,36 @@
-import { readdirSync, existsSync } from "fs";
+import { readdirSync } from "fs";
 import { join } from "path";
 import { spawnSync, spawn } from "child_process";
 import readline from "readline";
 import { fileURLToPath } from "url";
 
 async function selectOrCreateKeystore() {
+  // Create readline interface only when function is called
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   const keystorePath = join(process.env.HOME, ".foundry", "keystores");
-  let keystores = [];
 
   try {
-    if (existsSync(keystorePath)) {
-      keystores = readdirSync(keystorePath).filter(
-        (keystore) => keystore !== "scaffold-eth-default"
-      );
-    }
+    const keystores = readdirSync(keystorePath).filter(
+      (keystore) => keystore !== "scaffold-eth-default"
+    );
 
     if (keystores.length === 0) {
-      console.log("\n📁 No keystores found. Creating a new wallet...");
-      return await createWallet(rl);
+      console.log(
+        "\n❌ No keystores found in ~/.foundry/keystores, please select 0 to create a new keystore"
+      );
     }
 
     console.log("\n🔑 Available keystores:");
     console.log("0. Create new keystore");
 
-    keystores.forEach((keystore, index) => {
+    keystores.map((keystore, index) => {
       console.log(`${index + 1}. ${keystore}`);
+
+      return { keystore };
     });
 
     const answer = await new Promise((resolve) => {
@@ -42,7 +43,60 @@ async function selectOrCreateKeystore() {
     const selection = parseInt(answer);
 
     if (selection === 0) {
-      return await createWallet(rl);
+      const newWalletResult = spawnSync("cast", ["wallet", "new"], {
+        encoding: "utf-8",
+      });
+
+      if (newWalletResult.error || newWalletResult.status !== 0) {
+        console.error(
+          "\n❌ Error generating new wallet:",
+          newWalletResult.stderr || newWalletResult.error
+        );
+        process.exit(1);
+      }
+
+      const privateKey = newWalletResult.stdout
+        .split("\n")
+        .find((line) => line.includes("Private key:"))
+        ?.split(":")[1]
+        ?.trim();
+
+      if (!privateKey) {
+        console.error("\n❌ Could not extract private key from output");
+        process.exit(1);
+      }
+
+      const keystoreName = await new Promise((resolve) => {
+        rl.question("\nEnter name for new keystore: ", resolve);
+      });
+
+      // Close readline before spawning process with inherited stdio
+      rl.close();
+
+      return new Promise((resolve, reject) => {
+        const importProcess = spawn(
+          "cast",
+          ["wallet", "import", keystoreName, "--private-key", privateKey],
+          {
+            stdio: "inherit",
+          }
+        );
+
+        importProcess.on("close", (code) => {
+          if (code === 0) {
+            console.log(
+              "\n💰 Fund the address and re-run the deploy command to use this keystore."
+            );
+            console.log(
+              `\nTIP: Use \`yarn account\` and select \`${keystoreName}\` keystore to check if the address is funded.`
+            );
+            process.exit(0);
+          } else {
+            console.error("\n❌ Error importing keystore");
+            reject(new Error("Import failed"));
+          }
+        });
+      });
     }
 
     if (isNaN(selection) || selection < 1 || selection > keystores.length) {
@@ -51,77 +105,23 @@ async function selectOrCreateKeystore() {
     }
 
     const selectedKeystore = keystores[selection - 1];
+    // Close readline before returning
     rl.close();
     return selectedKeystore;
   } catch (error) {
     console.error("\n❌ Error reading keystores:", error);
     process.exit(1);
   } finally {
+    // Ensure readline is closed
     rl.close();
   }
 }
 
-async function createWallet(rl) {
-  const newWalletResult = spawnSync("cast", ["wallet", "new"], {
-    encoding: "utf-8",
-  });
-
-  if (newWalletResult.error || newWalletResult.status !== 0) {
-    console.error(
-      "\n❌ Error generating new wallet:",
-      newWalletResult.stderr || newWalletResult.error
-    );
-    process.exit(1);
-  }
-
-  const privateKey = newWalletResult.stdout
-    .split("\n")
-    .find((line) => line.includes("Private key:"))
-    ?.split(":")[1]
-    ?.trim();
-
-  if (!privateKey) {
-    console.error("\n❌ Could not extract private key from output");
-    process.exit(1);
-  }
-
-  const keystoreName = await new Promise((resolve) => {
-    rl.question("\nEnter name for new keystore: ", resolve);
-  });
-
-  rl.close();
-
-  return new Promise((resolve, reject) => {
-    const importProcess = spawn(
-      "cast",
-      ["wallet", "import", keystoreName, "--private-key", privateKey],
-      {
-        stdio: "inherit",
-      }
-    );
-
-    importProcess.on("close", (code) => {
-      if (code === 0) {
-        console.log(
-          "\n💰 Fund the address and re-run the deploy command to use this keystore."
-        );
-        console.log(
-          `\nTIP: Use \`yarn account\` and select \`${keystoreName}\` keystore to check if the address is funded.`
-        );
-        process.exit(0);
-      } else {
-        console.error("\n❌ Error importing keystore");
-        reject(new Error("Import failed"));
-      }
-    });
-  });
-}
-
+// Run the selection if this script is called directly
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  selectOrCreateKeystore()
+  selectKeystore()
     .then((keystore) => {
       console.log("\n🔑 Selected keystore:", keystore);
-      process.exit(0);
     })
     .catch((error) => {
       console.error(error);

--- a/packages/foundry/scripts-js/selectOrCreateKeystore.js
+++ b/packages/foundry/scripts-js/selectOrCreateKeystore.js
@@ -1,36 +1,35 @@
-import { readdirSync } from "fs";
+import { readdirSync, existsSync } from "fs";
 import { join } from "path";
 import { spawnSync, spawn } from "child_process";
 import readline from "readline";
 import { fileURLToPath } from "url";
 
 async function selectOrCreateKeystore() {
-  // Create readline interface only when function is called
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
   const keystorePath = join(process.env.HOME, ".foundry", "keystores");
+  let keystores = [];
 
   try {
-    const keystores = readdirSync(keystorePath).filter(
-      (keystore) => keystore !== "scaffold-eth-default"
-    );
+    if (existsSync(keystorePath)) {
+      keystores = readdirSync(keystorePath).filter(
+        (keystore) => keystore !== "scaffold-eth-default"
+      );
+    }
 
     if (keystores.length === 0) {
-      console.log(
-        "\n❌ No keystores found in ~/.foundry/keystores, please select 0 to create a new keystore"
-      );
+      console.log("\n📁 No keystores found. Creating a new wallet...");
+      return await createWallet(rl);
     }
 
     console.log("\n🔑 Available keystores:");
     console.log("0. Create new keystore");
 
-    keystores.map((keystore, index) => {
+    keystores.forEach((keystore, index) => {
       console.log(`${index + 1}. ${keystore}`);
-
-      return { keystore };
     });
 
     const answer = await new Promise((resolve) => {
@@ -43,60 +42,7 @@ async function selectOrCreateKeystore() {
     const selection = parseInt(answer);
 
     if (selection === 0) {
-      const newWalletResult = spawnSync("cast", ["wallet", "new"], {
-        encoding: "utf-8",
-      });
-
-      if (newWalletResult.error || newWalletResult.status !== 0) {
-        console.error(
-          "\n❌ Error generating new wallet:",
-          newWalletResult.stderr || newWalletResult.error
-        );
-        process.exit(1);
-      }
-
-      const privateKey = newWalletResult.stdout
-        .split("\n")
-        .find((line) => line.includes("Private key:"))
-        ?.split(":")[1]
-        ?.trim();
-
-      if (!privateKey) {
-        console.error("\n❌ Could not extract private key from output");
-        process.exit(1);
-      }
-
-      const keystoreName = await new Promise((resolve) => {
-        rl.question("\nEnter name for new keystore: ", resolve);
-      });
-
-      // Close readline before spawning process with inherited stdio
-      rl.close();
-
-      return new Promise((resolve, reject) => {
-        const importProcess = spawn(
-          "cast",
-          ["wallet", "import", keystoreName, "--private-key", privateKey],
-          {
-            stdio: "inherit",
-          }
-        );
-
-        importProcess.on("close", (code) => {
-          if (code === 0) {
-            console.log(
-              "\n💰 Fund the address and re-run the deploy command to use this keystore."
-            );
-            console.log(
-              `\nTIP: Use \`yarn account\` and select \`${keystoreName}\` keystore to check if the address is funded.`
-            );
-            process.exit(0);
-          } else {
-            console.error("\n❌ Error importing keystore");
-            reject(new Error("Import failed"));
-          }
-        });
-      });
+      return await createWallet(rl);
     }
 
     if (isNaN(selection) || selection < 1 || selection > keystores.length) {
@@ -105,23 +51,77 @@ async function selectOrCreateKeystore() {
     }
 
     const selectedKeystore = keystores[selection - 1];
-    // Close readline before returning
     rl.close();
     return selectedKeystore;
   } catch (error) {
     console.error("\n❌ Error reading keystores:", error);
     process.exit(1);
   } finally {
-    // Ensure readline is closed
     rl.close();
   }
 }
 
-// Run the selection if this script is called directly
+async function createWallet(rl) {
+  const newWalletResult = spawnSync("cast", ["wallet", "new"], {
+    encoding: "utf-8",
+  });
+
+  if (newWalletResult.error || newWalletResult.status !== 0) {
+    console.error(
+      "\n❌ Error generating new wallet:",
+      newWalletResult.stderr || newWalletResult.error
+    );
+    process.exit(1);
+  }
+
+  const privateKey = newWalletResult.stdout
+    .split("\n")
+    .find((line) => line.includes("Private key:"))
+    ?.split(":")[1]
+    ?.trim();
+
+  if (!privateKey) {
+    console.error("\n❌ Could not extract private key from output");
+    process.exit(1);
+  }
+
+  const keystoreName = await new Promise((resolve) => {
+    rl.question("\nEnter name for new keystore: ", resolve);
+  });
+
+  rl.close();
+
+  return new Promise((resolve, reject) => {
+    const importProcess = spawn(
+      "cast",
+      ["wallet", "import", keystoreName, "--private-key", privateKey],
+      {
+        stdio: "inherit",
+      }
+    );
+
+    importProcess.on("close", (code) => {
+      if (code === 0) {
+        console.log(
+          "\n💰 Fund the address and re-run the deploy command to use this keystore."
+        );
+        console.log(
+          `\nTIP: Use \`yarn account\` and select \`${keystoreName}\` keystore to check if the address is funded.`
+        );
+        process.exit(0);
+      } else {
+        console.error("\n❌ Error importing keystore");
+        reject(new Error("Import failed"));
+      }
+    });
+  });
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  selectKeystore()
+  selectOrCreateKeystore()
     .then((keystore) => {
       console.log("\n🔑 Selected keystore:", keystore);
+      process.exit(0);
     })
     .catch((error) => {
       console.error(error);

--- a/packages/foundry/scripts-js/selectOrCreateKeystore.js
+++ b/packages/foundry/scripts-js/selectOrCreateKeystore.js
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { readdirSync, existsSync } from "fs";
 import { join } from "path";
 import { spawnSync, spawn } from "child_process";
 import readline from "readline";
@@ -14,9 +14,11 @@ async function selectOrCreateKeystore() {
   const keystorePath = join(process.env.HOME, ".foundry", "keystores");
 
   try {
-    const keystores = readdirSync(keystorePath).filter(
-      (keystore) => keystore !== "scaffold-eth-default"
-    );
+    const keystores = existsSync(keystorePath)
+    ? readdirSync(keystorePath).filter(
+        (keystore) => keystore !== "scaffold-eth-default"
+      )
+    : [];
 
     if (keystores.length === 0) {
       console.log(


### PR DESCRIPTION
When the user has no keystores yet, the `yarn deploy --network network_name` just fails.
This PR prevents that by showing the users the menu instead of giving the user an error message. 
I think we can definitely improve this but this should be a good start!

Before:
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/c7ac3e27-aaf2-456b-9f9f-eb40aa7bd766" />


After:
<img width="583" alt="image" src="https://github.com/user-attachments/assets/d2715f9a-48b5-45af-9643-891bb192d83d" />



Fixes #1072 