### PR TITLE
Add chain metadata to `useSelectedNetwork` hook

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,4 +1,3 @@
-import { useTargetNetwork } from "./useTargetNetwork";
 import { useTheme } from "next-themes";
 import { useSelectedNetwork } from "~~/hooks/scaffold-eth";
 import { AllowedChainIds, ChainWithAttributes } from "~~/utils/scaffold-eth";

--- a/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
@@ -3,6 +3,10 @@ import { useGlobalState } from "~~/services/store/store";
 import { AllowedChainIds } from "~~/utils/scaffold-eth";
 import { NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth/networks";
 
+/**
+ * Given a chainId, retrives the network object from `scaffold.config`,
+ * if not found default to network set by `useTargetNetwork` hook
+ */
 export function useSelectedNetwork(chainId?: AllowedChainIds) {
   const globalTargetNetwork = useGlobalState(({ targetNetwork }) => targetNetwork);
   const targetNetwork =

--- a/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
@@ -1,16 +1,19 @@
 import scaffoldConfig from "~~/scaffold.config";
 import { useGlobalState } from "~~/services/store/store";
 import { AllowedChainIds } from "~~/utils/scaffold-eth";
-import { NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth/networks";
+import { ChainWithAttributes, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth/networks";
 
 /**
  * Given a chainId, retrives the network object from `scaffold.config`,
  * if not found default to network set by `useTargetNetwork` hook
  */
-export function useSelectedNetwork(chainId?: AllowedChainIds) {
+export function useSelectedNetwork(chainId?: AllowedChainIds): ChainWithAttributes {
   const globalTargetNetwork = useGlobalState(({ targetNetwork }) => targetNetwork);
-  const targetNetwork =
-    scaffoldConfig.targetNetworks.find(targetNetwork => targetNetwork.id === chainId) ?? globalTargetNetwork;
+  const targetNetwork = scaffoldConfig.targetNetworks.find(targetNetwork => targetNetwork.id === chainId);
 
-  return targetNetwork ? { ...targetNetwork, ...NETWORKS_EXTRA_DATA[targetNetwork.id] } : targetNetwork;
+  if (targetNetwork) {
+    return { ...targetNetwork, ...NETWORKS_EXTRA_DATA[targetNetwork.id] };
+  }
+
+  return globalTargetNetwork;
 }

--- a/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
@@ -1,8 +1,12 @@
 import scaffoldConfig from "~~/scaffold.config";
 import { useGlobalState } from "~~/services/store/store";
 import { AllowedChainIds } from "~~/utils/scaffold-eth";
+import { NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth/networks";
 
 export function useSelectedNetwork(chainId?: AllowedChainIds) {
-  const targetNetwork = useGlobalState(({ targetNetwork }) => targetNetwork);
-  return scaffoldConfig.targetNetworks.find(targetNetwork => targetNetwork.id === chainId) ?? targetNetwork;
+  const globalTargetNetwork = useGlobalState(({ targetNetwork }) => targetNetwork);
+  const targetNetwork =
+    scaffoldConfig.targetNetworks.find(targetNetwork => targetNetwork.id === chainId) ?? globalTargetNetwork;
+
+  return targetNetwork ? { ...targetNetwork, ...NETWORKS_EXTRA_DATA[targetNetwork.id] } : targetNetwork;
 }

--- a/packages/nextjs/hooks/scaffold-eth/useTargetNetwork.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useTargetNetwork.ts
@@ -16,7 +16,7 @@ export function useTargetNetwork(): { targetNetwork: ChainWithAttributes } {
   useEffect(() => {
     const newSelectedNetwork = scaffoldConfig.targetNetworks.find(targetNetwork => targetNetwork.id === chain?.id);
     if (newSelectedNetwork && newSelectedNetwork.id !== targetNetwork.id) {
-      setTargetNetwork(newSelectedNetwork);
+      setTargetNetwork({ ...newSelectedNetwork, ...NETWORKS_EXTRA_DATA[newSelectedNetwork.id] });
     }
   }, [chain?.id, setTargetNetwork, targetNetwork.id]);
 

--- a/packages/nextjs/hooks/scaffold-eth/useTargetNetwork.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useTargetNetwork.ts
@@ -20,13 +20,5 @@ export function useTargetNetwork(): { targetNetwork: ChainWithAttributes } {
     }
   }, [chain?.id, setTargetNetwork, targetNetwork.id]);
 
-  return useMemo(
-    () => ({
-      targetNetwork: {
-        ...targetNetwork,
-        ...NETWORKS_EXTRA_DATA[targetNetwork.id],
-      },
-    }),
-    [targetNetwork],
-  );
+  return useMemo(() => ({ targetNetwork }), [targetNetwork]);
 }

--- a/packages/nextjs/services/store/store.ts
+++ b/packages/nextjs/services/store/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import scaffoldConfig from "~~/scaffold.config";
-import { ChainWithAttributes } from "~~/utils/scaffold-eth";
+import { ChainWithAttributes, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
 
 /**
  * Zustand Store
@@ -31,6 +31,9 @@ export const useGlobalState = create<GlobalState>(set => ({
     set(state => ({ nativeCurrency: { ...state.nativeCurrency, price: newValue } })),
   setIsNativeCurrencyFetching: (newValue: boolean): void =>
     set(state => ({ nativeCurrency: { ...state.nativeCurrency, isFetching: newValue } })),
-  targetNetwork: scaffoldConfig.targetNetworks[0],
+  targetNetwork: {
+    ...scaffoldConfig.targetNetworks[0],
+    ...NETWORKS_EXTRA_DATA[scaffoldConfig.targetNetworks[0].id],
+  },
   setTargetNetwork: (newTargetNetwork: ChainWithAttributes) => set(() => ({ targetNetwork: newTargetNetwork })),
 }));


### PR DESCRIPTION
## Description

Adds chain metadata to  `useSelectedNetwork` response, so other hooks like `useNetworkColor` have the color metadata from the chain to work as intended.

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #1092 
