### PR TITLE
Update Viem Package 2.23.0 -> 2.30.0

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.4.0",
     "usehooks-ts": "^3.1.0",
-    "viem": "2.23.0",
+    "viem": "2.30.0",
     "wagmi": "2.14.11",
     "zustand": "^5.0.0"
   },


### PR DESCRIPTION
- Encountered Missing Zircuit Garfield Testnet Config During Development

Before:
![Screenshot From 2025-05-20 21-10-39](https://github.com/user-attachments/assets/496919e8-086f-45b5-873a-2fb2c7e1a3e4)

After:
![Screenshot From 2025-05-20 21-11-38](https://github.com/user-attachments/assets/ca1cbb63-3025-4b29-8603-cf5b6d33e904)

In principle ZircuitTestnet is deprecated and not use anymore, but that's a contribution that should be done on Viem side.