### PR TITLE
remove hardcoded string and use AddressType

### DIFF
--- a/packages/nextjs/app/blockexplorer/_components/AddressComponent.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/AddressComponent.tsx
@@ -1,12 +1,13 @@
 import { BackButton } from "./BackButton";
 import { ContractTabs } from "./ContractTabs";
+import { Address as AddressType } from "viem";
 import { Address, Balance } from "~~/components/scaffold-eth";
 
 export const AddressComponent = ({
   address,
   contractData,
 }: {
-  address: string;
+  address: AddressType;
   contractData: { bytecode: string; assembly: string } | null;
 }) => {
   return (

--- a/packages/nextjs/app/blockexplorer/_components/ContractTabs.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/ContractTabs.tsx
@@ -6,7 +6,7 @@ import { AddressLogsTab } from "./AddressLogsTab";
 import { AddressStorageTab } from "./AddressStorageTab";
 import { PaginationButton } from "./PaginationButton";
 import { TransactionsTable } from "./TransactionsTable";
-import { createPublicClient, http } from "viem";
+import { Address, createPublicClient, http } from "viem";
 import { hardhat } from "viem/chains";
 import { useFetchBlocks } from "~~/hooks/scaffold-eth";
 
@@ -16,7 +16,7 @@ type AddressCodeTabProps = {
 };
 
 type PageProps = {
-  address: string;
+  address: Address;
   contractData: AddressCodeTabProps | null;
 };
 

--- a/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { Address } from "viem";
 import { hardhat } from "viem/chains";
 import { AddressComponent } from "~~/app/blockexplorer/_components/AddressComponent";
 import deployedContracts from "~~/contracts/deployedContracts";
@@ -7,7 +8,7 @@ import { isZeroAddress } from "~~/utils/scaffold-eth/common";
 import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 
 type PageProps = {
-  params: Promise<{ address: string }>;
+  params: Promise<{ address: Address }>;
 };
 
 async function fetchByteCodeAndAssembly(buildInfoDirectory: string, contractPath: string) {
@@ -36,7 +37,7 @@ async function fetchByteCodeAndAssembly(buildInfoDirectory: string, contractPath
   return { bytecode, assembly };
 }
 
-const getContractData = async (address: string) => {
+const getContractData = async (address: Address) => {
   const contracts = deployedContracts as GenericContractsDeclaration | null;
   const chainId = hardhat.id;
   let contractPath = "";
@@ -84,7 +85,7 @@ export function generateStaticParams() {
 
 const AddressPage = async (props: PageProps) => {
   const params = await props.params;
-  const address = params?.address as string;
+  const address = params?.address as Address;
 
   if (isZeroAddress(address)) return null;
 


### PR DESCRIPTION
## Description

Remove hardcoding for `address: string` and instead use `Address` type from viem so that if users switches: 

```ts
// abi.d.ts
type AddressType = string;
```
