### PR TITLE
fix blockexplorer address page when contract is empty

### DIFF
--- a/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
+++ b/packages/nextjs/app/blockexplorer/address/[address]/page.tsx
@@ -40,6 +40,11 @@ async function fetchByteCodeAndAssembly(buildInfoDirectory: string, contractPath
 const getContractData = async (address: Address) => {
   const contracts = deployedContracts as GenericContractsDeclaration | null;
   const chainId = hardhat.id;
+
+  if (!contracts || !contracts[chainId] || Object.keys(contracts[chainId]).length === 0) {
+    return null;
+  }
+
   let contractPath = "";
 
   const buildInfoDirectory = path.join(
@@ -60,7 +65,7 @@ const getContractData = async (address: Address) => {
     throw new Error(`Directory ${buildInfoDirectory} not found.`);
   }
 
-  const deployedContractsOnChain = contracts ? contracts[chainId] : {};
+  const deployedContractsOnChain = contracts[chainId];
   for (const [contractName, contractInfo] of Object.entries(deployedContractsOnChain)) {
     if (contractInfo.address.toLowerCase() === address.toLowerCase()) {
       contractPath = `contracts/${contractName}.sol`;


### PR DESCRIPTION
## To reproduce: 

On the main branch, do `yarn chain` and `yarn start` without `yarn deploy `. Go to blockeplorer and click one of the addresses. That page will be broken. 

The problem was that the `contracts` variable was an empty object, and JS gives `Boolean({})` as `true`, and hence it broke up. 

We now do `Object.keys(contracts[chainId]).length === 0` which checks if the object is empty or not. 