### PR TITLE
Fix Typo in Documentation Comment

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
@@ -4,7 +4,7 @@ import { AllowedChainIds } from "~~/utils/scaffold-eth";
 import { ChainWithAttributes, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth/networks";
 
 /**
- * Given a chainId, retrives the network object from `scaffold.config`,
+ * Given a chainId, retrieves the network object from `scaffold.config`,
  * if not found default to network set by `useTargetNetwork` hook
  */
 export function useSelectedNetwork(chainId?: AllowedChainIds): ChainWithAttributes {


### PR DESCRIPTION



---


## Description
- Changed "retrives" to "retrieves" for improved clarity and professionalism.

Your ENS/address:`leopardracer.eth`

---


