### PR TITLE
update hardhat mainnet rpc url

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -55,8 +55,7 @@ const config: HardhatUserConfig = {
       },
     },
     mainnet: {
-      // url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
-      url: "https://mainnet.rpc.buidlguidl.com/",
+      url: "https://eth.drpc.org",
       accounts: [deployerPrivateKey],
     },
     sepolia: {

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -55,7 +55,8 @@ const config: HardhatUserConfig = {
       },
     },
     mainnet: {
-      url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
+      // url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
+      url: "https://mainnet.rpc.buidlguidl.com/",
       accounts: [deployerPrivateKey],
     },
     sepolia: {


### PR DESCRIPTION
## Description

Hot fix for #1126. 

--- 

### Issue encountered with BG RPC: 

For some reason, we are not able to connect to BG RPC via ethers `JSONRpcProvider` while running `yarn accoun`, it errors out saying: 

<img width="1502" height="598" alt="Screenshot 2025-07-15 at 11 12 22 AM" src="https://github.com/user-attachments/assets/e9889f51-7928-495b-b261-87c791e065d5" />

Seems like ethers is first making a request with an empty request body / payload. Not sure why this is happening only with BG RPC maybe we are not following some standard for `/` route like for now its return `400` maybe it should return something different? I tried reading about sepc but there is not specific instruction on `/` route.  But RPC is not down and it works great you can try at https://ethereum-json-rpc.com/ by inputting custom URL with BG endpoint 

Another issue which I saw was is when you do `yarn deploy --network mainnet` its get stuck: 

<img width="1236" height="227" alt="Screenshot 2025-07-15 at 10 06 46 AM" src="https://github.com/user-attachments/assets/b67b6834-dc5c-43a5-ae5d-3681c0fb6f20" />
 
 
 Although transaction happened and there were 6 block confirmation it was still stuck there 
 
 So, for now, went with the DRPC URL 