### PR TITLE
Add deployedOnBlock to deployedContracts on Hardhat

### DIFF
--- a/packages/hardhat/scripts/generateTsAbis.ts
+++ b/packages/hardhat/scripts/generateTsAbis.ts
@@ -84,11 +84,11 @@ function getContractDataFromDeployments() {
     const chainId = fs.readFileSync(`${DEPLOYMENTS_DIR}/${chainName}/.chainId`).toString();
     const contracts = {} as Record<string, any>;
     for (const contractName of getContractNames(`${DEPLOYMENTS_DIR}/${chainName}`)) {
-      const { abi, address, metadata } = JSON.parse(
+      const { abi, address, metadata, receipt } = JSON.parse(
         fs.readFileSync(`${DEPLOYMENTS_DIR}/${chainName}/${contractName}.json`).toString(),
       );
       const inheritedFunctions = metadata ? getInheritedFunctions(JSON.parse(metadata).sources, contractName) : {};
-      contracts[contractName] = { address, abi, inheritedFunctions };
+      contracts[contractName] = { address, abi, inheritedFunctions, deployedOnBlock: receipt.blockNumber };
     }
     output[chainId] = contracts;
   }

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -68,6 +68,7 @@ export type GenericContract = {
   abi: Abi;
   inheritedFunctions?: InheritedFunctions;
   external?: true;
+  deployedOnBlock?: number;
 };
 
 export type GenericContractsDeclaration = {


### PR DESCRIPTION
generateTsAbis adds the blockNumber from the transaction receipt from the deployment transaction, and you can get this information using useDeployedContractInfo hook.

Only implemented on Hardhat for now.

To test it, just deploy the default contract and use the useDeployedContractInfo hook, you will get the new deployedOnBlock attribute.

Feature from the discussion https://github.com/scaffold-eth/scaffold-eth-2/discussions/1129

I can implement this on Foundry too and then I can change the Ponder extension to use this new attribute by default.