### PR TITLE
fix: getting deployedOnBlock when no receipt

### DIFF
--- a/packages/hardhat/scripts/generateTsAbis.ts
+++ b/packages/hardhat/scripts/generateTsAbis.ts
@@ -88,7 +88,7 @@ function getContractDataFromDeployments() {
         fs.readFileSync(`${DEPLOYMENTS_DIR}/${chainName}/${contractName}.json`).toString(),
       );
       const inheritedFunctions = metadata ? getInheritedFunctions(JSON.parse(metadata).sources, contractName) : {};
-      contracts[contractName] = { address, abi, inheritedFunctions, deployedOnBlock: receipt.blockNumber };
+      contracts[contractName] = { address, abi, inheritedFunctions, deployedOnBlock: receipt?.blockNumber };
     }
     output[chainId] = contracts;
   }


### PR DESCRIPTION
## Description

Sometimes there is no receipt field in deployment file. It causes an error when `generateTsAbis.ts` script runs and tries to get `deployedOnBlock: receipt.blockNumber`. This PR fixes it

---

Where we met the issue:
If you install sre prediction market challenge with create-eth 1.0.2
```
npx create-eth@1.0.2 -e challenge-prediction-markets challenge-prediction-markets
```
and then try to run `yarn deploy` with solution contract, you'll get an error `TypeError: Cannot read properties of undefined (reading 'blockNumber')`



To test the fix you can try add the change to the prediction market instance and try to deploy again

---

Note: When `receipt` doesn't exist in hardhat-deploy deployments (claude answer)

<details><summary>When `receipt` doesn't exist in hardhat-deploy deployments:</summary>
<p>

## When `receipt` doesn't exist in hardhat-deploy deployments:

The `receipt` field in the deployment JSON files can be `undefined` in several scenarios:

### 1. **Failed or Pending Transactions**
- If a deployment transaction fails (reverts, runs out of gas, etc.)
- If a transaction is still pending and hasn't been mined yet
- If there's a network issue preventing the transaction from being processed

### 2. **Network-Specific Issues**
- **Local networks**: When using `autoMine: true` on local networks, sometimes the receipt might not be immediately available
- **External networks**: Network congestion, RPC issues, or temporary network problems can prevent receipt retrieval
- **Forked networks**: When using `MAINNET_FORKING_ENABLED=true`, there might be timing issues with receipt availability

### 3. **Hardhat-Deploy Configuration**
- When using certain deployment options that don't wait for transaction confirmation
- If the deployment script doesn't properly wait for the transaction to be mined
- When using `skipIfAlreadyDeployed: true` and the contract was already deployed previously

### 4. **Gas and Network Conditions**
- **Insufficient gas**: If the deployment runs out of gas, the transaction might fail without a proper receipt
- **Network congestion**: On busy networks, transactions might take longer to be mined, and the receipt might not be available immediately

### 5. **Manual Contract Deployment**
- When contracts are deployed manually outside of the hardhat-deploy framework
- When using external deployment tools that don't integrate with hardhat-deploy

### 6. **Development/Testing Scenarios**
- During testing when transactions are mocked or simulated
- When using hardhat's `impersonateAccount` or other testing utilities
- In scenarios where the deployment is interrupted or the process is killed

</p>
</details> 
