### PR TITLE
Fix contract interactions error

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx
@@ -16,6 +16,7 @@ import {
 import { IntegerInput } from "~~/components/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
+import { AllowedChainIds } from "~~/utils/scaffold-eth";
 import { simulateContractWriteAndNotifyError } from "~~/utils/scaffold-eth/contract";
 
 type WriteOnlyFunctionFormProps = {
@@ -54,7 +55,11 @@ export const WriteOnlyFunctionForm = ({
           args: getParsedContractFunctionArgs(form),
           value: BigInt(txValue),
         };
-        await simulateContractWriteAndNotifyError({ wagmiConfig, writeContractParams: writeContractObj });
+        await simulateContractWriteAndNotifyError({
+          wagmiConfig,
+          writeContractParams: writeContractObj,
+          chainId: targetNetwork.id as AllowedChainIds,
+        });
 
         const makeWriteWithParams = () => writeContractAsync(writeContractObj);
         await writeTxn(makeWriteWithParams);

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts
@@ -116,7 +116,11 @@ export function useScaffoldWriteContract<TContractName extends ContractName>(
       } as WriteContractVariables<Abi, string, any[], Config, number>;
 
       if (!finalConfig?.disableSimulate) {
-        await simulateContractWriteAndNotifyError({ wagmiConfig, writeContractParams: writeContractObject });
+        await simulateContractWriteAndNotifyError({
+          wagmiConfig,
+          writeContractParams: writeContractObject,
+          chainId: selectedNetwork.id as AllowedChainIds,
+        });
       }
 
       const makeWriteWithParams = () =>

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -1,10 +1,11 @@
 import { Hash, SendTransactionParameters, TransactionReceipt, WalletClient } from "viem";
+import { hardhat } from "viem/chains";
 import { Config, useWalletClient } from "wagmi";
 import { getPublicClient } from "wagmi/actions";
 import { SendTransactionMutate } from "wagmi/query";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
-import { getBlockExplorerTxLink, getParsedError, notification } from "~~/utils/scaffold-eth";
-import { TransactorFuncOptions } from "~~/utils/scaffold-eth/contract";
+import { AllowedChainIds, getBlockExplorerTxLink, notification } from "~~/utils/scaffold-eth";
+import { TransactorFuncOptions, getParsedErrorWithAllAbis } from "~~/utils/scaffold-eth/contract";
 
 type TransactionFunc = (
   tx: (() => Promise<Hash>) | Parameters<SendTransactionMutate<Config, undefined>>[0],
@@ -50,8 +51,9 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
     let transactionHash: Hash | undefined = undefined;
     let transactionReceipt: TransactionReceipt | undefined;
     let blockExplorerTxURL = "";
+    let chainId: number = hardhat.id;
     try {
-      const network = await walletClient.getChainId();
+      chainId = await walletClient.getChainId();
       // Get full transaction from public client
       const publicClient = getPublicClient(wagmiConfig);
 
@@ -67,7 +69,7 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
       }
       notification.remove(notificationId);
 
-      blockExplorerTxURL = network ? getBlockExplorerTxLink(network, transactionHash) : "";
+      blockExplorerTxURL = chainId ? getBlockExplorerTxLink(chainId, transactionHash) : "";
 
       notificationId = notification.loading(
         <TxnNotification message="Waiting for transaction to complete." blockExplorerLink={blockExplorerTxURL} />,
@@ -94,7 +96,7 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
         notification.remove(notificationId);
       }
       console.error("⚡️ ~ file: useTransactor.ts ~ error", error);
-      const message = getParsedError(error);
+      const message = getParsedErrorWithAllAbis(error, chainId as AllowedChainIds);
 
       // if receipt was reverted, show notification with block explorer link and return error
       if (transactionReceipt?.status === "reverted") {

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -1,8 +1,8 @@
 import { Hash, SendTransactionParameters, TransactionReceipt, WalletClient } from "viem";
-import { hardhat } from "viem/chains";
 import { Config, useWalletClient } from "wagmi";
 import { getPublicClient } from "wagmi/actions";
 import { SendTransactionMutate } from "wagmi/query";
+import scaffoldConfig from "~~/scaffold.config";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 import { AllowedChainIds, getBlockExplorerTxLink, notification } from "~~/utils/scaffold-eth";
 import { TransactorFuncOptions, getParsedErrorWithAllAbis } from "~~/utils/scaffold-eth/contract";
@@ -51,7 +51,7 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
     let transactionHash: Hash | undefined = undefined;
     let transactionReceipt: TransactionReceipt | undefined;
     let blockExplorerTxURL = "";
-    let chainId: number = hardhat.id;
+    let chainId: number = scaffoldConfig.targetNetworks[0].id;
     try {
       chainId = await walletClient.getChainId();
       // Get full transaction from public client

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -355,7 +355,7 @@ const getParsedErrorWithAllAbis = (error: any, chainId: AllowedChainIds): string
 
     try {
       // Get all deployed contracts for the current chain
-      const chainContracts = deployedContractsData[chainId];
+      const chainContracts = deployedContractsData[chainId as keyof typeof deployedContractsData];
 
       if (!chainContracts) {
         return originalParsedError;

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -402,14 +402,15 @@ const getParsedErrorWithAllAbis = (error: any, chainId: AllowedChainIds): string
 export const simulateContractWriteAndNotifyError = async ({
   wagmiConfig,
   writeContractParams: params,
+  chainId,
 }: {
   wagmiConfig: Config;
   writeContractParams: WriteContractVariables<Abi, string, any[], Config, number>;
+  chainId: AllowedChainIds;
 }) => {
   try {
     await simulateContract(wagmiConfig, params);
   } catch (error) {
-    const chainId = wagmiConfig.chains[0]?.id as AllowedChainIds;
     const parsedError = getParsedErrorWithAllAbis(error, chainId);
 
     notification.error(parsedError);

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -23,6 +23,8 @@ import {
   Log,
   TransactionReceipt,
   WriteContractErrorType,
+  keccak256,
+  toHex,
 } from "viem";
 import { Config, UseReadContractParameters, UseWatchContractEventParameters, UseWriteContractParameters } from "wagmi";
 import { WriteContractParameters, WriteContractReturnType, simulateContract } from "wagmi/actions";
@@ -335,6 +337,68 @@ export type UseScaffoldEventHistoryData<
 
 export type AbiParameterTuple = Extract<AbiParameter, { type: "tuple" | `tuple[${string}]` }>;
 
+/**
+ * Enhanced error parsing that creates a lookup table from all deployed contracts
+ * to decode error signatures from any contract in the system
+ */
+const getParsedErrorWithAllAbis = (error: any, chainId: AllowedChainIds): string => {
+  const originalParsedError = getParsedError(error);
+
+  // Check if this is an unrecognized error signature
+  if (originalParsedError.includes("Encoded error signature") && originalParsedError.includes("not found on ABI")) {
+    const signatureMatch = originalParsedError.match(/0x[a-fA-F0-9]{8}/);
+    const signature = signatureMatch ? signatureMatch[0] : "";
+
+    if (signature) {
+      try {
+        // Get all deployed contracts for the current chain
+        const chainContracts = deployedContractsData[chainId];
+        if (chainContracts) {
+          // Build a lookup table of error signatures to error names
+          const errorLookup: Record<string, { name: string; contract: string; signature: string }> = {};
+
+          Object.entries(chainContracts).forEach(([contractName, contract]: [string, any]) => {
+            if (contract.abi) {
+              contract.abi.forEach((item: any) => {
+                if (item.type === "error") {
+                  // Create the proper error signature like Solidity does
+                  const errorName = item.name;
+                  const inputs = item.inputs || [];
+                  const inputTypes = inputs.map((input: any) => input.type).join(",");
+                  const errorSignature = `${errorName}(${inputTypes})`;
+
+                  // Hash the signature and take the first 4 bytes (8 hex chars)
+                  const hash = keccak256(toHex(errorSignature));
+                  const errorSelector = hash.slice(0, 10); // 0x + 8 chars = 10 total
+
+                  errorLookup[errorSelector] = {
+                    name: errorName,
+                    contract: contractName,
+                    signature: errorSignature,
+                  };
+                }
+              });
+            }
+          });
+
+          // Check if we can find the error in our lookup
+          const errorInfo = errorLookup[signature];
+          if (errorInfo) {
+            return `Contract function execution reverted with the following reason:\n${errorInfo.signature} from ${errorInfo.contract} contract`;
+          }
+
+          // If not found in simple lookup, provide a helpful message with context
+          return `${originalParsedError}\n\nThis error occurred when calling a function that internally calls another contract. Check the contract that your function calls internally for more details.`;
+        }
+      } catch (lookupError) {
+        console.log("Failed to create error lookup table:", lookupError);
+      }
+    }
+  }
+
+  return originalParsedError;
+};
+
 export const simulateContractWriteAndNotifyError = async ({
   wagmiConfig,
   writeContractParams: params,
@@ -345,7 +409,9 @@ export const simulateContractWriteAndNotifyError = async ({
   try {
     await simulateContract(wagmiConfig, params);
   } catch (error) {
-    const parsedError = getParsedError(error);
+    const chainId = wagmiConfig.chains[0]?.id as AllowedChainIds;
+    const parsedError = getParsedErrorWithAllAbis(error, chainId);
+
     notification.error(parsedError);
     throw error;
   }

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -341,7 +341,7 @@ export type AbiParameterTuple = Extract<AbiParameter, { type: "tuple" | `tuple[$
  * Enhanced error parsing that creates a lookup table from all deployed contracts
  * to decode error signatures from any contract in the system
  */
-const getParsedErrorWithAllAbis = (error: any, chainId: AllowedChainIds): string => {
+export const getParsedErrorWithAllAbis = (error: any, chainId: AllowedChainIds): string => {
   const originalParsedError = getParsedError(error);
 
   // Check if this is an unrecognized error signature

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -345,54 +345,59 @@ const getParsedErrorWithAllAbis = (error: any, chainId: AllowedChainIds): string
   const originalParsedError = getParsedError(error);
 
   // Check if this is an unrecognized error signature
-  if (originalParsedError.includes("Encoded error signature") && originalParsedError.includes("not found on ABI")) {
+  if (/Encoded error signature.*not found on ABI/i.test(originalParsedError)) {
     const signatureMatch = originalParsedError.match(/0x[a-fA-F0-9]{8}/);
     const signature = signatureMatch ? signatureMatch[0] : "";
 
-    if (signature) {
-      try {
-        // Get all deployed contracts for the current chain
-        const chainContracts = deployedContractsData[chainId];
-        if (chainContracts) {
-          // Build a lookup table of error signatures to error names
-          const errorLookup: Record<string, { name: string; contract: string; signature: string }> = {};
+    if (!signature) {
+      return originalParsedError;
+    }
 
-          Object.entries(chainContracts).forEach(([contractName, contract]: [string, any]) => {
-            if (contract.abi) {
-              contract.abi.forEach((item: any) => {
-                if (item.type === "error") {
-                  // Create the proper error signature like Solidity does
-                  const errorName = item.name;
-                  const inputs = item.inputs || [];
-                  const inputTypes = inputs.map((input: any) => input.type).join(",");
-                  const errorSignature = `${errorName}(${inputTypes})`;
+    try {
+      // Get all deployed contracts for the current chain
+      const chainContracts = deployedContractsData[chainId];
 
-                  // Hash the signature and take the first 4 bytes (8 hex chars)
-                  const hash = keccak256(toHex(errorSignature));
-                  const errorSelector = hash.slice(0, 10); // 0x + 8 chars = 10 total
+      if (!chainContracts) {
+        return originalParsedError;
+      }
 
-                  errorLookup[errorSelector] = {
-                    name: errorName,
-                    contract: contractName,
-                    signature: errorSignature,
-                  };
-                }
-              });
+      // Build a lookup table of error signatures to error names
+      const errorLookup: Record<string, { name: string; contract: string; signature: string }> = {};
+
+      Object.entries(chainContracts).forEach(([contractName, contract]: [string, any]) => {
+        if (contract.abi) {
+          contract.abi.forEach((item: any) => {
+            if (item.type === "error") {
+              // Create the proper error signature like Solidity does
+              const errorName = item.name;
+              const inputs = item.inputs || [];
+              const inputTypes = inputs.map((input: any) => input.type).join(",");
+              const errorSignature = `${errorName}(${inputTypes})`;
+
+              // Hash the signature and take the first 4 bytes (8 hex chars)
+              const hash = keccak256(toHex(errorSignature));
+              const errorSelector = hash.slice(0, 10); // 0x + 8 chars = 10 total
+
+              errorLookup[errorSelector] = {
+                name: errorName,
+                contract: contractName,
+                signature: errorSignature,
+              };
             }
           });
-
-          // Check if we can find the error in our lookup
-          const errorInfo = errorLookup[signature];
-          if (errorInfo) {
-            return `Contract function execution reverted with the following reason:\n${errorInfo.signature} from ${errorInfo.contract} contract`;
-          }
-
-          // If not found in simple lookup, provide a helpful message with context
-          return `${originalParsedError}\n\nThis error occurred when calling a function that internally calls another contract. Check the contract that your function calls internally for more details.`;
         }
-      } catch (lookupError) {
-        console.log("Failed to create error lookup table:", lookupError);
+      });
+
+      // Check if we can find the error in our lookup
+      const errorInfo = errorLookup[signature];
+      if (errorInfo) {
+        return `Contract function execution reverted with the following reason:\n${errorInfo.signature} from ${errorInfo.contract} contract`;
       }
+
+      // If not found in simple lookup, provide a helpful message with context
+      return `${originalParsedError}\n\nThis error occurred when calling a function that internally calls another contract. Check the contract that your function calls internally for more details.`;
+    } catch (lookupError) {
+      console.log("Failed to create error lookup table:", lookupError);
     }
   }
 


### PR DESCRIPTION
See the bug and how to reproduce in #1145 

It can't parse the error because it checks only abi of the ContractA. This PR fixes it, now when trying to find error it parses abi's of all the deployed contracts.

Error after fix
<img width="444" height="127" alt="image" src="https://github.com/user-attachments/assets/ad4b5373-7844-47f8-8e06-046b57b55832" />


Fixes #1145 
