### PR TITLE
Fix fromBlockValue type

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -111,7 +111,12 @@ export const useScaffoldEventHistory = <
 
   const isContractAddressAndClientReady = Boolean(deployedContractData?.address) && Boolean(publicClient);
 
-  const fromBlockValue = fromBlock !== undefined ? fromBlock : BigInt(deployedContractData?.deployedOnBlock || 0);
+  const fromBlockValue =
+    fromBlock !== undefined
+      ? fromBlock
+      : BigInt(
+          deployedContractData && "deployedOnBlock" in deployedContractData ? deployedContractData.deployedOnBlock : 0,
+        );
 
   const query = useInfiniteQuery({
     queryKey: [


### PR DESCRIPTION
After https://github.com/scaffold-eth/scaffold-eth-2/pull/1143 `yarn next:check-types` fails if there's no `deployedOnContract` field in `deployedContractData`. 

This PR fixes it
