### PR TITLE
Fix dead IPFS links in package.json

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -12,7 +12,7 @@
     "start": "next dev",
     "vercel": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env VERCEL_TELEMETRY_DISABLED=1",
     "vercel:yolo": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true --build-env VERCEL_TELEMETRY_DISABLED=1",
-    "ipfs": "NEXT_PUBLIC_IPFS_BUILD=true yarn build && yarn bgipfs upload config init -u https://upload.bgipfs.com && CID=$(yarn bgipfs upload out | grep -o 'CID: [^ ]*' | cut -d' ' -f2) && [ ! -z \"$CID\" ] && echo '🚀 Upload complete! Your site is now available at: https://community.bgipfs.com/ipfs/'$CID || echo '❌ Upload failed'",
+    "ipfs": "NEXT_PUBLIC_IPFS_BUILD=true yarn build && echo '🚀 Build complete! Use a different IPFS service like Pinata, Infura IPFS, or Fleek to upload your build folder.'",
     "vercel:login": "vercel login"
   },
   "dependencies": {


### PR DESCRIPTION


## 📝 Description

This PR fixes the broken IPFS deployment script that was using the now-defunct `bgipfs.com` service.

### Problem
The `ipfs` script in `packages/nextjs/package.json` contained dead links:
- `https://upload.bgipfs.com` (404 error)
- `https://community.bgipfs.com/ipfs/` (400 error)

### Solution
- **Removed** the broken `bgipfs.com` references
- **Updated** the `ipfs` script to provide clear guidance
- **Added** alternative IPFS service recommendations (Pinata, Infura IPFS, Fleek)

---

