### PR TITLE
Fix deployments chainId error

### DIFF
--- a/packages/hardhat/scripts/generateTsAbis.ts
+++ b/packages/hardhat/scripts/generateTsAbis.ts
@@ -80,8 +80,17 @@ function getContractDataFromDeployments() {
     throw Error("At least one other deployment script should exist to generate an actual contract.");
   }
   const output = {} as Record<string, any>;
-  for (const chainName of getDirectories(DEPLOYMENTS_DIR)) {
-    const chainId = fs.readFileSync(`${DEPLOYMENTS_DIR}/${chainName}/.chainId`).toString();
+  const chainDirectories = getDirectories(DEPLOYMENTS_DIR);
+  for (const chainName of chainDirectories) {
+    let chainId;
+    try {
+      chainId = fs.readFileSync(`${DEPLOYMENTS_DIR}/${chainName}/.chainId`).toString();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      console.log(`No chainId file found for ${chainName}`);
+      continue;
+    }
+
     const contracts = {} as Record<string, any>;
     for (const contractName of getContractNames(`${DEPLOYMENTS_DIR}/${chainName}`)) {
       const { abi, address, metadata, receipt } = JSON.parse(


### PR DESCRIPTION
How to reproduce:
1. Deploy your contract to any chain except localhost. Let's assume the chain is sepolia. During deployment new folder will be created: `packages/hardhat/deployments/sepolia`. The folder includes ` .chainId`, `*.json` files and `solcInputs` folder
2. Switch to some other branch. Files from `packages/hardhat/deployments/sepolia` folder will disappear but folder still exist
3. Run `yarn deploy` from new branch. `generateTsAbi.ts` script will try to find `.chainId` file inside the folder and fail, which cause the error, something like this

<details><summary>Error</summary>
<p>

```
$ yarn deploy
Generating typings for: 1 artifacts in dir: typechain-types for target: ethers-v6
Successfully generated 34 typings!
Compiled 1 Solidity file successfully (evm target: paris).
deploying "YourContract" (tx: 0xf91cbfe7e8880e13af9b80cc76c71e30ca5cb2b002cefa6d99f9665701c47dbf)...: deployed at 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9 with 532743 gas
👋 Initial greeting: Building Unstoppable Apps!!!
An unexpected error occurred:

Error: ENOENT: no such file or directory, open './deployments/sepolia/.chainId'
    at Object.openSync (node:fs:561:18)
    at Object.readFileSync (node:fs:445:35)
    at getContractDataFromDeployments (/Users/liana/Documents/prog/buidl-guidl/se-2/packages/hardhat/scripts/generateTsAbis.ts:84:24)
    at generateTsAbis (/Users/liana/Documents/prog/buidl-guidl/se-2/packages/hardhat/scripts/generateTsAbis.ts:104:28)
    at OverriddenTaskDefinition._action (/Users/liana/Documents/prog/buidl-guidl/se-2/packages/hardhat/hardhat.config.ts:150:23)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Environment._runTaskDefinition (/Users/liana/Documents/prog/buidl-guidl/se-2/packages/hardhat/node_modules/hardhat/src/internal/core/runtime-environment.ts:351:14)
    at async Environment.run (/Users/liana/Documents/prog/buidl-guidl/se-2/packages/hardhat/node_modules/hardhat/src/internal/core/runtime-environment.ts:184:14)
    at async main (/Users/liana/Documents/prog/buidl-guidl/se-2/packages/hardhat/node_modules/hardhat/src/internal/cli/cli.ts:322:7) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: './deployments/sepolia/.chainId'
}
```


</p>
</details> 


This PR fixes it