### PR TITLE
remove duplicate events from end 

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -254,7 +254,13 @@ export const useScaffoldEventHistory = <
 
   // Combine historical data from infinite query with live events from watch hook
   const historicalEvents = query.data?.pages || [];
-  const combinedEvents = [...liveEvents, ...historicalEvents] as typeof historicalEvents;
+  const allEvents = [...liveEvents, ...historicalEvents] as typeof historicalEvents;
+
+  // remove duplicates
+  const combinedEvents = allEvents.filter((event, index, self) => {
+    const eventKey = `${event?.transactionHash}-${event?.logIndex}-${event?.blockHash}`;
+    return index === self.findIndex(e => `${e?.transactionHash}-${e?.logIndex}-${e?.blockHash}` === eventKey);
+  }) as typeof historicalEvents;
 
   return {
     data: combinedEvents,


### PR DESCRIPTION
## Description

Not the best way, but a simple way. I tried tinkering hard at https://github.com/technophile-04/test-arb-history, but its hard to get it properly working because the sometime the interval at which block are mined + some times due to the blockBatchSize goes there are some overlaps in `getNextParams` and because of which this issue might be causing. 

Tried lot of approach, but then thought maybe lets go with simple approach only. 

Also I think the `useScaffoldEventHistory` isn't good for l2s because it will burn rpcs calls alot even with batching.

For example if you look at this contract: 

https://sepolia.arbiscan.io/tx/0x8fc14b8dda901d6beaa929a4e4528b6eaddb2109ad8bd96f5bdd61978e65558f it was deployed at block : [181594184](https://sepolia.arbiscan.io/block/181594184) 

And current blocknumber is : 183246630

So there are total of 16,52,446 block minned in b/w and useScaffoldEvenHistory need to query all of them, even if we query in batches of 500 (default) or 1000 it's still almost 1.5k request (getLogs). 