### PR TITLE
refactor: lazy load wallet connectors to prevent indexedDb not founf errors

### DIFF
--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -14,7 +14,7 @@ export const enabledChains = targetNetworks.find((network: Chain) => network.id 
 
 export const wagmiConfig = createConfig({
   chains: enabledChains,
-  connectors: wagmiConnectors,
+  connectors: wagmiConnectors(),
   ssr: true,
   client({ chain }) {
     let rpcFallbacks = [http()];

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -28,16 +28,24 @@ const wallets = [
 /**
  * wagmi connectors for the wagmi context
  */
-export const wagmiConnectors = connectorsForWallets(
-  [
-    {
-      groupName: "Supported Wallets",
-      wallets,
-    },
-  ],
+export const wagmiConnectors = () => {
+  // Only create connectors on client-side to avoid SSR issues
+  // TODO: update when https://github.com/rainbow-me/rainbowkit/issues/2476 is resolved
+  if (typeof window === "undefined") {
+    return [];
+  }
 
-  {
-    appName: "scaffold-eth-2",
-    projectId: scaffoldConfig.walletConnectProjectId,
-  },
-);
+  return connectorsForWallets(
+    [
+      {
+        groupName: "Supported Wallets",
+        wallets,
+      },
+    ],
+
+    {
+      appName: "scaffold-eth-2",
+      projectId: scaffoldConfig.walletConnectProjectId,
+    },
+  );
+};


### PR DESCRIPTION
## Description

- Refactored wallet connection to be available when window is available (client side), to silence IndexedDB Errors

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #1109 _

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: zmsrick.eth
