### PR TITLE
fix: prevent text overflow in inheritance tooltip

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/InheritanceTooltip.tsx
+++ b/packages/nextjs/app/debug/_components/contract/InheritanceTooltip.tsx
@@ -4,7 +4,7 @@ export const InheritanceTooltip = ({ inheritedFrom }: { inheritedFrom?: string }
   <>
     {inheritedFrom && (
       <span
-        className="tooltip tooltip-top tooltip-accent px-2 md:break-normal"
+        className="tooltip tooltip-top tooltip-accent px-2 md:break-words"
         data-tip={`Inherited from: ${inheritedFrom}`}
       >
         <InformationCircleIcon className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
## Description

  - Changed md:break-normal to md:break-words
  - Fixes tooltip overflow for long contract names"

## Related Issues

_Closes #1159 _

Your ENS/address: 0x56596b38790E1D385DA9376C54647604f878acBb
![bug](https://github.com/user-attachments/assets/dc2a74bc-b9e4-4626-ab7e-9451398868b4)
![fix](https://github.com/user-attachments/assets/f6a35306-6c1b-456c-9e28-39bf6a058fe4)
