### PR TITLE
Update Celo Testnet from Celo Alfajores to Celo Sepolia 

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -122,8 +122,8 @@ const config: HardhatUserConfig = {
       url: "https://forno.celo.org",
       accounts: [deployerPrivateKey],
     },
-    celoAlfajores: {
-      url: "https://alfajores-forno.celo-testnet.org",
+    celoSepolia: {
+      url: "https://forno.celo-sepolia.celo-testnet.org/",
       accounts: [deployerPrivateKey],
     },
   },

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -33,7 +33,7 @@ export const RPC_CHAIN_NAMES: Record<number, string> = {
   [chains.baseGoerli.id]: "base-goerli",
   [chains.baseSepolia.id]: "base-sepolia",
   [chains.celo.id]: "celo-mainnet",
-  [chains.celoAlfajores.id]: "celo-alfajores",
+  [chains.celoSepolia.id]: "celo-sepolia",
 };
 
 export const getAlchemyHttpUrl = (chainId: number) => {
@@ -87,7 +87,7 @@ export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
   [chains.celo.id]: {
     color: "#FCFF52",
   },
-  [chains.celoAlfajores.id]: {
+  [chains.celoSepolia.id]: {
     color: "#476520",
   },
 };


### PR DESCRIPTION
## Description

Celo Alfajores Testnet will sunset on the 30th of September, aligned with Holseky. Celo Sepolia was officially announced on the 13th of August 2025. 

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
