### PR TITLE
docs: add production usage warning for useScaffoldEventHistory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@
 
 ![Debug Contracts tab](https://github.com/scaffold-eth/scaffold-eth-2/assets/55535804/b237af0c-5027-4849-a5c1-2e31495cccb1)
 
+---
+
+## ⚠️ Important Note about useScaffoldEventHistory
+
+> **Warning:** `useScaffoldEventHistory` is intended for local development only.  
+> This hook uses `getLogs` and can overload RPC endpoints, especially on production and L2 networks.  
+> **For production, please use a dedicated indexer (e.g., [Ponder](https://ponder.dev)) to query contract events efficiently.**
+
+---
+
 ## Requirements
 
 Before you begin, you need to install the following tools:

--- a/README.md
+++ b/README.md
@@ -17,16 +17,6 @@
 
 ![Debug Contracts tab](https://github.com/scaffold-eth/scaffold-eth-2/assets/55535804/b237af0c-5027-4849-a5c1-2e31495cccb1)
 
----
-
-## ⚠️ Important Note about useScaffoldEventHistory
-
-> **Warning:** `useScaffoldEventHistory` is intended for local development only.  
-> This hook uses `getLogs` and can overload RPC endpoints, especially on production and L2 networks.  
-> **For production, please use a dedicated indexer (e.g., [Ponder](https://ponder.dev)) to query contract events efficiently.**
-
----
-
 ## Requirements
 
 Before you begin, you need to install the following tools:

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -54,7 +54,12 @@ const getEvents = async (
 };
 
 /**
- * Reads events from a deployed contract
+ * @deprecated This hook is not optimized for production use.
+ * It uses getLogs which can overload RPC endpoints (especially on L2s with short block times).
+ * **Recommended only for local (hardhat/anvil) chains and development.**
+ * For production, use an indexer such as [Ponder](https://ponder.dev) or similar to query contract events efficiently.
+ *
+ * Reads events from a deployed contract.
  * @param config - The config settings
  * @param config.contractName - deployed contract name
  * @param config.eventName - name of the event to listen for

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Abi, AbiEvent, ExtractAbiEventNames } from "abitype";
 import { BlockNumber, GetLogsParameters } from "viem";
+import { hardhat } from "viem/chains";
 import { Config, UsePublicClientReturnType, useBlockNumber, usePublicClient } from "wagmi";
 import { useSelectedNetwork } from "~~/hooks/scaffold-eth";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
@@ -54,10 +55,9 @@ const getEvents = async (
 };
 
 /**
- * @deprecated This hook is not optimized for production use.
+ * @deprecated **Recommended only for local (hardhat/anvil) chains and development.**
  * It uses getLogs which can overload RPC endpoints (especially on L2s with short block times).
- * **Recommended only for local (hardhat/anvil) chains and development.**
- * For production, use an indexer such as [Ponder](https://ponder.dev) or similar to query contract events efficiently.
+ * For production, use an indexer such as ponder.sh or similar to query contract events efficiently.
  *
  * Reads events from a deployed contract.
  * @param config - The config settings
@@ -95,6 +95,15 @@ export const useScaffoldEventHistory = <
   blocksBatchSize = 500,
 }: UseScaffoldEventHistoryConfig<TContractName, TEventName, TBlockData, TTransactionData, TReceiptData>) => {
   const selectedNetwork = useSelectedNetwork(chainId);
+
+  // Runtime warning for non-local chains
+  useEffect(() => {
+    if (selectedNetwork.id !== hardhat.id) {
+      console.log(
+        "⚠️ useScaffoldEventHistory is not optimized for production use. It can overload RPC endpoints (especially on L2s)",
+      );
+    }
+  }, [selectedNetwork.id]);
 
   const publicClient = usePublicClient({
     chainId: selectedNetwork.id,


### PR DESCRIPTION
## Description
Addresses issue #1166 by adding documentation warnings about using `useScaffoldEventHistory` in production.

## Changes Made
- ✅ Added JSDoc deprecation warning to the hook
- ✅ Updated documentation to warn about RPC limitations
- ✅ Recommended indexer solutions for production use

## Why This Matters
The hook uses `getLogs` which can burn through RPC limits, especially on L2s with short block times. This change helps developers make informed decisions about when to use this hook.

## Testing
- [x] JSDoc warnings appear in IDE
- [x] Documentation renders correctly
- [x] No build errors

Closes #1166