### PR TITLE
Fix network synchronization in TransactionComp

### DIFF
--- a/packages/nextjs/app/blockexplorer/transaction/_components/TransactionComp.tsx
+++ b/packages/nextjs/app/blockexplorer/transaction/_components/TransactionComp.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Hash, Transaction, TransactionReceipt, formatEther, formatUnits } from "viem";
-import { hardhat } from "viem/chains";
 import { usePublicClient } from "wagmi";
 import { Address } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
@@ -11,13 +10,12 @@ import { decodeTransactionData, getFunctionDetails } from "~~/utils/scaffold-eth
 import { replacer } from "~~/utils/scaffold-eth/common";
 
 const TransactionComp = ({ txHash }: { txHash: Hash }) => {
-  const client = usePublicClient({ chainId: hardhat.id });
+  const { targetNetwork } = useTargetNetwork();
+  const client = usePublicClient({ chainId: targetNetwork.id });
   const router = useRouter();
   const [transaction, setTransaction] = useState<Transaction>();
   const [receipt, setReceipt] = useState<TransactionReceipt>();
   const [functionCalled, setFunctionCalled] = useState<string>();
-
-  const { targetNetwork } = useTargetNetwork();
 
   useEffect(() => {
     if (txHash && client) {


### PR DESCRIPTION
The `TransactionComp` component was hardcoded to use Hardhat network (`hardhat.id`) for fetching transaction data, while the UI displayed information based on the selected `targetNetwork`. This caused data inconsistencies when users switched networks.

**Solution:** 
- Updated `usePublicClient` to use `targetNetwork.id` instead of hardcoded `hardhat.id`
- Removed unused `hardhat` import from `viem/chains`
- Ensured transaction data is fetched from the correct RPC endpoint matching the selected network
