### PR TITLE
yarn fork parameter number is incorrect

### DIFF
--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -12,11 +12,11 @@
     "compile": "make compile",
     "deploy": "node scripts-js/parseArgs.js",
     "flatten": "make flatten",
-    "fork": "make fork FORK_URL=${1:-mainnet}",
+    "fork": "make fork FORK_URL=${0:-mainnet}",
     "format": "make format",
     "lint": "make lint",
     "test": "forge test",
-    "verify": "make verify RPC_URL=${1:-localhost}",
+    "verify": "make verify RPC_URL=${0:-localhost}",
     "postinstall": "shx cp -n .env.example .env"
   },
   "dependencies": {


### PR DESCRIPTION


## Description

Correcting the parameter number. When trying:
`yarn fork "https://reth-ethereum.ithaca.xyz/rpc@23359458"` 
the script would not see the url+block. after correcting to 0, the script recognizes.

## Additional Information

After correcting
`yarn fork "https://reth-ethereum.ithaca.xyz/rpc@23359458"
shx rm ~/.foundry/keystores/scaffold-eth-default 2>/dev/null;   shx rm -rf broadcast/Deploy.s.sol/31337
cast wallet import --private-key 0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6 --unsafe-password 'localhost' scaffold-eth-default
`scaffold-eth-default` keystore was saved successfully. Address: 0xa0ee7a142d267c1f36714e4a8f75612f20a79720
anvil --fork-url https://reth-ethereum.ithaca.xyz/rpc@23359458 --chain-id 31337`

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: mlabab.eth 
