### PR TITLE
Allow CREATE2 transaction type in abi generation

### DIFF
--- a/packages/foundry/scripts-js/generateTsAbis.js
+++ b/packages/foundry/scripts-js/generateTsAbis.js
@@ -73,7 +73,7 @@ function getDeploymentHistory(broadcastPath) {
     );
 
     for (const tx of transactions) {
-      if (tx.transactionType === "CREATE") {
+      if (tx.transactionType === "CREATE" || tx.transactionType === "CREATE2") {
         // Store or update contract deployment info
         deploymentHistory.set(tx.contractAddress, {
           contractName: tx.contractName,


### PR DESCRIPTION
## Description

Allow CREATE2 transaction type in abi generation. If deployment code uses CREATE2 (like uniswap hooks) then the abi is not generated.
## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: mlabab.eth
