### PR TITLE
Fix shadowed variable naming in `useSelectedNetwork` hook

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useSelectedNetwork.ts
@@ -9,10 +9,10 @@ import { ChainWithAttributes, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth/
  */
 export function useSelectedNetwork(chainId?: AllowedChainIds): ChainWithAttributes {
   const globalTargetNetwork = useGlobalState(({ targetNetwork }) => targetNetwork);
-  const targetNetwork = scaffoldConfig.targetNetworks.find(targetNetwork => targetNetwork.id === chainId);
+  const selectedNetwork = scaffoldConfig.targetNetworks.find(network => network.id === chainId);
 
-  if (targetNetwork) {
-    return { ...targetNetwork, ...NETWORKS_EXTRA_DATA[targetNetwork.id] };
+  if (selectedNetwork) {
+    return { ...selectedNetwork, ...NETWORKS_EXTRA_DATA[selectedNetwork.id] };
   }
 
   return globalTargetNetwork;


### PR DESCRIPTION

This PR improves readability in `useSelectedNetwork` by removing variable shadowing and clarifying intent.

