### PR TITLE
fix: correct grammar 'ours' to 'our' in config comments

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -19,7 +19,7 @@ const deployerPrivateKey =
 // If not set, it uses our block explorers default API keys.
 const etherscanApiKey = process.env.ETHERSCAN_V2_API_KEY || "DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW";
 
-// If not set, it uses ours Alchemy's default API key.
+// If not set, it uses our Alchemy's default API key.
 // You can get your own at https://dashboard.alchemyapi.io
 const providerApiKey = process.env.ALCHEMY_API_KEY || "cR4WnXePioePZ5fFrnSiR";
 

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -19,7 +19,7 @@ const scaffoldConfig = {
   // it has no effect if you only target the local network (default is 4000)
   pollingInterval: 3000,
 
-  // This is ours Alchemy's default API key.
+  // This is our Alchemy's default API key.
   // You can get your own at https://dashboard.alchemyapi.io
   // It's recommended to store it in an env variable:
   // .env.local for local testing, and in the Vercel/system env config for live apps.
@@ -32,7 +32,7 @@ const scaffoldConfig = {
     // [chains.mainnet.id]: "https://mainnet.rpc.buidlguidl.com",
   },
 
-  // This is ours WalletConnect's default project ID.
+  // This is our WalletConnect's default project ID.
   // You can get your own at https://cloud.walletconnect.com
   // It's recommended to store it in an env variable:
   // .env.local for local testing, and in the Vercel/system env config for live apps.


### PR DESCRIPTION
## Summary
- Fixed grammatically incorrect "ours" to "our" in configuration comments
- `packages/nextjs/scaffold.config.ts`: Alchemy and WalletConnect API key comments
- `packages/hardhat/hardhat.config.ts`: Alchemy API key comment

## Additional Information
- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: