### PR TITLE
fix: correct typo writeContactAsync to writeContractAsync in comment

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts
@@ -186,7 +186,7 @@ export function useScaffoldWriteContract<TContractName extends ContractName>(
   return {
     ...wagmiContractWrite,
     isMining,
-    // Overwrite wagmi's writeContactAsync
+    // Overwrite wagmi's writeContractAsync
     writeContractAsync: sendContractWriteAsyncTx,
     // Overwrite wagmi's writeContract
     writeContract: sendContractWriteTx,


### PR DESCRIPTION
## Summary
- Fixed typo in `packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts`
- Comment incorrectly said "writeContactAsync" instead of "writeContractAsync" (missing 'r' in Contract)

## Additional Information
- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: