### PR TITLE
fix: correct typo 'harhdat-verify' to 'hardhat-verify' in config

### DIFF
--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -127,7 +127,7 @@ const config: HardhatUserConfig = {
       accounts: [deployerPrivateKey],
     },
   },
-  // Configuration for harhdat-verify plugin
+  // Configuration for hardhat-verify plugin
   etherscan: {
     apiKey: `${etherscanApiKey}`,
   },


### PR DESCRIPTION
## Summary
- Fixed typo in `packages/hardhat/hardhat.config.ts`
- Comment incorrectly said "harhdat-verify" instead of "hardhat-verify"

## Additional Information
- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: