### PR TITLE
feat: allow optional contractAddress parameter in useScaffoldReadCont…

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -12,8 +12,6 @@ import {
   ExtractAbiFunction,
 } from "abitype";
 import type { ExtractAbiFunctionNames } from "abitype";
-import type { Simplify } from "type-fest";
-import type { MergeDeepRecord } from "type-fest/source/merge-deep";
 import {
   Address,
   Block,
@@ -32,6 +30,9 @@ import { WriteContractVariables } from "wagmi/query";
 import deployedContractsData from "~~/contracts/deployedContracts";
 import externalContractsData from "~~/contracts/externalContracts";
 import scaffoldConfig from "~~/scaffold.config";
+
+type MergeDeepRecord<L, R, O extends Record<string, any> = Record<string, never>> = L & R & O;
+type Simplify<T> = { [K in keyof T]: T[K] } & {};
 
 type AddExternalFlag<T> = {
   [ChainId in keyof T]: {
@@ -191,6 +192,7 @@ export type UseScaffoldReadConfig<
   contractName: TContractName;
   chainId?: AllowedChainIds;
   watch?: boolean;
+  contractAddress?: Address;
 } & IsContractDeclarationMissing<
   Partial<UseReadContractParameters>,
   {


### PR DESCRIPTION
Fixes #1208

Hey! This PR adds an optional `contractAddress` param to 
`useScaffoldReadContract` so you can pass any address instead 
of always being locked to the deployed contract address.

Really useful when playing around with proxy contracts or 
testing against different deployments without changing config.

What changed:
- Added `contractAddress?: Address` to `UseScaffoldReadConfig` type
- Destructured it in the hook
- Used `contractAddress ?? deployedContract?.address` so it falls 
  back to deployed address if nothing is passed (no breaking change)

Usage:
// works exactly as before
useScaffoldReadContract({ contractName: "YourContract", functionName: "getBalance" })

// now you can also pass a custom address
useScaffoldReadContract({ contractName: "YourContract", functionName: "getBalance", contractAddress: "0x1234..." })

Let me know if anything needs tweaking!