### PR TITLE
fix: correct contract creation bytecode prefix in decodeTxData (#1246)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "precommit": "lint-staged",
     "start": "yarn workspace @se-2/nextjs dev",
     "test": "yarn hardhat:test",
+    "next:test": "yarn workspace @se-2/nextjs test",
     "vercel": "yarn workspace @se-2/nextjs vercel",
     "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo",
     "ipfs": "yarn workspace @se-2/nextjs ipfs",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -8,6 +8,7 @@
     "dev": "next dev",
     "format": "prettier --write . '!(node_modules|.next|contracts)/**/*'",
     "lint": "next lint",
+    "test": "node --experimental-strip-types --test utils/scaffold-eth/decodeTxData.test.ts",
     "serve": "next start",
     "start": "next dev",
     "vercel": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env VERCEL_TELEMETRY_DISABLED=1",

--- a/packages/nextjs/utils/scaffold-eth/decodeTxData.test.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxData.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { isContractCreationBytecode } from "./decodeTxDataUtils.ts";
+
+describe("isContractCreationBytecode", () => {
+  it("returns true for standard Solidity init bytecode (0x60806040...)", () => {
+    assert.strictEqual(isContractCreationBytecode("0x6080604052604051600055"), true);
+    assert.strictEqual(isContractCreationBytecode("0x6080604052"), true);
+    assert.strictEqual(isContractCreationBytecode("0x60806041"), true);
+  });
+
+  it("returns false for function call data (4-byte selector)", () => {
+    assert.strictEqual(isContractCreationBytecode("0xa9059cbb000000000000000000000000"), false);
+    assert.strictEqual(isContractCreationBytecode("0x60e06040"), false);
+  });
+
+  it("returns false for input shorter than 10 chars", () => {
+    assert.strictEqual(isContractCreationBytecode("0x608060"), false);
+  });
+});

--- a/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
@@ -16,8 +16,11 @@ const interfaces = chainMetaData
     }, {} as ContractsInterfaces)
   : {};
 
+export { isContractCreationBytecode } from "./decodeTxDataUtils";
+import { isContractCreationBytecode } from "./decodeTxDataUtils";
+
 export const decodeTransactionData = (tx: TransactionWithFunction) => {
-  if (tx.input.length >= 10 && !tx.input.startsWith("0x60e06040")) {
+  if (tx.input.length >= 10 && !isContractCreationBytecode(tx.input)) {
     let foundInterface = false;
     for (const [, contractAbi] of Object.entries(interfaces)) {
       try {

--- a/packages/nextjs/utils/scaffold-eth/decodeTxDataUtils.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxDataUtils.ts
@@ -1,0 +1,3 @@
+/** Standard Solidity contract creation bytecode starts with PUSH1 0x80 PUSH1 0x40 (0x6080604...). */
+export const isContractCreationBytecode = (input: string): boolean =>
+  input.length >= 10 && input.startsWith("0x6080604");


### PR DESCRIPTION
## Summary

Fixes #1246.

**Root cause:** The check used `0x60e06040` but standard Solidity contract creation bytecode starts with `0x60806040` (PUSH1 0x80 PUSH1 0x40 MSTORE). Contract creation transactions were not excluded and fell through to the function decoder, which failed to match any ABI and labeled them as "⚠️ Unknown" in the block explorer.

**Fix:** Changed the prefix check from `0x60e06040` to `0x6080604` (without trailing digit) to cover all standard Solidity init code variants.

## Changes

- `packages/nextjs/utils/scaffold-eth/decodeTxData.ts`: Use correct bytecode prefix for contract creation detection
- `packages/nextjs/utils/scaffold-eth/decodeTxDataUtils.ts`: Extracted `isContractCreationBytecode` helper for testability
- `packages/nextjs/utils/scaffold-eth/decodeTxData.test.ts`: Unit tests for contract creation detection
- `packages/nextjs/package.json`: Added test script
- `package.json`: Added next:test script

## Testing

- Verified the fix addresses the reported scenario in #1246
- Added 3 tests covering: standard Solidity init bytecode, function call data, short input edge case
- Change is minimal and follows existing code patterns
- No unrelated changes included

Made with [Cursor](https://cursor.com)