### PR TITLE
fix: correct bytecode prefix in decodeTxData for contract creation detection

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
@@ -17,7 +17,7 @@ const interfaces = chainMetaData
   : {};
 
 export const decodeTransactionData = (tx: TransactionWithFunction) => {
-  if (tx.input.length >= 10 && !tx.input.startsWith("0x60e06040")) {
+  if (tx.input.length >= 10 && tx.to !== null && !tx.input.startsWith("0x6080604")) {
     let foundInterface = false;
     for (const [, contractAbi] of Object.entries(interfaces)) {
       try {


### PR DESCRIPTION
## Summary

- Fixes the bytecode prefix check in `decodeTxData.ts` from `0x60e06040` to `0x6080604` to match standard Solidity init code (`PUSH1 0x80 PUSH1 0x40 MSTORE`)
- Adds `tx.to === null` check as the canonical way to detect contract creation transactions (per EIP-2718)
- Contract creation transactions were incorrectly falling through to the function decoder and being labeled as `⚠️ Unknown` in the block explorer

## Test plan

- [ ] Deploy a contract on local Hardhat network and verify it no longer shows as "Unknown" in the block explorer
- [ ] Verify normal function calls still decode correctly
- [ ] Verify contract creation transactions are properly skipped

Fixes #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)