### PR TITLE
fix: correct bytecode prefix check for contract creation detection

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
@@ -17,7 +17,7 @@ const interfaces = chainMetaData
   : {};
 
 export const decodeTransactionData = (tx: TransactionWithFunction) => {
-  if (tx.input.length >= 10 && !tx.input.startsWith("0x60e06040")) {
+  if (tx.input.length >= 10 && !tx.input.startsWith("0x6080604")) {
     let foundInterface = false;
     for (const [, contractAbi] of Object.entries(interfaces)) {
       try {


### PR DESCRIPTION
## Bug Fix

Fixed the contract creation bytecode prefix check in `decodeTxData.ts`.

**Before:** `0x60e06040` (incorrect)
**After:** `0x6080604` (matches standard Solidity init code)

Standard Solidity init code starts with `PUSH1 0x80 PUSH1 0x40 MSTORE` (0x60806040), not 0x60e06040.

## Impact

Contract creation transactions are now properly detected and won't appear as "Unknown" in the block explorer.

## Testing

- Verified the prefix matches standard Solidity compiler output
- Covers all standard Solidity init code versions (0x6080604*)

Closes #1246