### PR TITLE
better default for border radius

### DIFF
--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -106,6 +106,7 @@
 
 .btn {
   @apply shadow-md;
+  border-radius: 9999rem;
 }
 
 .btn.btn-ghost {

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -33,7 +33,7 @@
   --color-warning: #ffcf72;
   --color-error: #ff8863;
 
-  --radius-field: 9999rem;
+  --radius-field: 1rem;
   --radius-box: 1rem;
   --tt-tailw: 6px;
 }
@@ -58,7 +58,7 @@
   --color-warning: #ffcf72;
   --color-error: #ff8863;
 
-  --radius-field: 9999rem;
+  --radius-field: 1rem;
   --radius-box: 1rem;
 
   --tt-tailw: 6px;


### PR DESCRIPTION
Fixes #1264 

Changedradius default from 9999rem to 1rem.. which fixes the pill-shaped textarea issue, and it's unnoticeable for shorter elements like buttons and inputs since the browser caps border-radius at half the element's height anyway (and some of them are hardcoded already)

I think nothing changed visually (just textareas), but please take a look!


Before
<img width="479" height="242" alt="image" src="https://github.com/user-attachments/assets/982afc9c-f90b-4550-b45a-9993e17c644b" />

After
<img width="433" height="188" alt="image" src="https://github.com/user-attachments/assets/698b35b9-cd80-426d-a298-47af9ae5fcc3" />
