### PR TITLE
Update default Alchemy key

### DIFF
--- a/packages/foundry/.env.example
+++ b/packages/foundry/.env.example
@@ -6,7 +6,7 @@
 # but we recommend getting your own API Keys for Production Apps.
 
 # Alchemy rpc URL is used while deploying the contracts to some testnets/mainnets, checkout `foundry.toml` for it's use.
-ALCHEMY_API_KEY=oKxs-03sij-U_N0iOlrSsZFr29-IqbuF
+ALCHEMY_API_KEY=cR4WnXePioePZ5fFrnSiR
 
 # Etherscan API key is used to verify the contract on etherscan.
 ETHERSCAN_API_KEY=DNXJA8RX2Q3VZ4URQIWP7Z68CJXQZSC6AW

--- a/packages/foundry/scripts-js/checkAccountBalance.js
+++ b/packages/foundry/scripts-js/checkAccountBalance.js
@@ -9,7 +9,7 @@ import { parse } from "toml";
 import { ethers } from "ethers";
 
 const ALCHEMY_API_KEY =
-  process.env.ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF";
+  process.env.ALCHEMY_API_KEY || "cR4WnXePioePZ5fFrnSiR";
 
 // Load environment variables
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Description

Update default key for Alchemy, old one got deprecated a few days ago. New one is the same as the one we're using in hardhat version

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
