### PR TITLE
feat: add verify:sleep alias for rate-limited yarn verify (#1270)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo",
     "ipfs": "yarn workspace @se-2/nextjs ipfs",
     "vercel:login": "yarn workspace @se-2/nextjs vercel:login",
-    "verify": "yarn hardhat:verify"
+    "verify": "yarn hardhat:verify",
+    "verify:sleep": "yarn verify --sleep"
   },
   "packageManager": "yarn@3.2.3",
   "devDependencies": {


### PR DESCRIPTION
## Description

Adds a dedicated `yarn verify:sleep` alias to improve DX for users who run `yarn verify` on projects with multiple contracts and free Etherscan API keys. This makes the existing plugin-supported `--sleep` option easier to discover and use, reducing failures from Etherscan rate limits.

## Additional Information

- [x] I have read the contributing docs (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #1270_

Your ENS/address: _zalomea.eth_