### PR TITLE
change nextjs packageManager version

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -57,5 +57,5 @@
     "typescript": "^5.8.2",
     "vercel": "~51.2.1"
   },
-  "packageManager": "yarn@3.2.3"
+  "packageManager": "yarn@4.13.0"
 }


### PR DESCRIPTION
## Description

Forge to update the `packageManger` in `packages/nextjs/package.json` at #1211. 

I initially thought of just removing this field from the  `packages/nextjs/package.json` because any which ways while dong the `yarn install` the corepack looks only at the root package.json version but we actaully reqruire this because of `yarn vercel` because there we are just uploading the `nextjs` package to vercel so it doesn't have any context about the yarn version. 