### PR TITLE
fix(nextjs): stop excluding contracts/ from format script

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -7,7 +7,7 @@
     "lint": "yarn eslint .",
     "check-types": "tsc --noEmit --incremental",
     "dev": "next dev",
-    "format": "prettier --write . '!(node_modules|.next|contracts)/**/*'",
+    "format": "prettier --write . '!(node_modules|.next)/**/*'",
     "serve": "next start",
     "start": "next dev",
     "vercel": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env VERCEL_TELEMETRY_DISABLED=1",


### PR DESCRIPTION
Users paste ABIs into `externalContracts.ts` and expect prettier to format on save / `yarn format`. The `contracts/` exclusion in the format script was meant to skip auto-generated `deployedContracts.ts`, but it also caught `externalContracts.ts` which is user-pasted code that should be formatted.

This change removes `contracts` from the format-ignore pattern so `yarn format` formats `externalContracts.ts` as users expect.

This is also helpful for creat-eth, because if not https://github.com/scaffold-eth/create-eth/actions/runs/26504441866/job/78053025622?pr=430 