### PR TITLE
Fix blockexplorer pagination when auto mining is set

### DIFF
--- a/packages/nextjs/app/blockexplorer/_components/ContractTabs.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/ContractTabs.tsx
@@ -26,7 +26,7 @@ const publicClient = createPublicClient({
 });
 
 export const ContractTabs = ({ address, contractData }: PageProps) => {
-  const { blocks, transactionReceipts, currentPage, totalBlocks, setCurrentPage } = useFetchBlocks();
+  const { blocks, transactionReceipts, currentPage, totalTransactions, setCurrentPage } = useFetchBlocks();
   const [activeTab, setActiveTab] = useState("transactions");
   const [isContract, setIsContract] = useState(false);
 
@@ -85,11 +85,7 @@ export const ContractTabs = ({ address, contractData }: PageProps) => {
       {activeTab === "transactions" && (
         <div className="pt-4">
           <TransactionsTable blocks={filteredBlocks} transactionReceipts={transactionReceipts} />
-          <PaginationButton
-            currentPage={currentPage}
-            totalItems={Number(totalBlocks)}
-            setCurrentPage={setCurrentPage}
-          />
+          <PaginationButton currentPage={currentPage} totalItems={totalTransactions} setCurrentPage={setCurrentPage} />
         </div>
       )}
       {activeTab === "code" && contractData && (

--- a/packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx
@@ -7,64 +7,76 @@ import { TransactionsTableProps } from "~~/utils/scaffold-eth/";
 
 export const TransactionsTable = ({ blocks, transactionReceipts }: TransactionsTableProps) => {
   const { targetNetwork } = useTargetNetwork();
+  const hasTransactions = blocks.some(block => block.transactions.length > 0);
 
   return (
     <div className="flex justify-center px-4 md:px-0">
       <div className="overflow-x-auto w-full shadow-2xl rounded-xl">
-        <table className="table text-xl bg-base-100 table-zebra w-full md:table-md table-sm">
-          <thead>
-            <tr className="rounded-xl text-sm text-base-content">
-              <th className="bg-primary">Transaction Hash</th>
-              <th className="bg-primary">Function Called</th>
-              <th className="bg-primary">Block Number</th>
-              <th className="bg-primary">Time Mined</th>
-              <th className="bg-primary">From</th>
-              <th className="bg-primary">To</th>
-              <th className="bg-primary text-end">Value ({targetNetwork.nativeCurrency.symbol})</th>
-            </tr>
-          </thead>
-          <tbody>
-            {blocks.map(block =>
-              (block.transactions as TransactionWithFunction[]).map(tx => {
-                const receipt = transactionReceipts[tx.hash];
-                const timeMined = new Date(Number(block.timestamp) * 1000).toLocaleString();
-                const functionCalled = tx.input.substring(0, 10);
+        {!hasTransactions ? (
+          <div className="bg-base-100 rounded-xl p-8 text-center text-base-content/70">
+            No transactions found on this page.
+          </div>
+        ) : (
+          <table className="table text-xl bg-base-100 table-zebra w-full md:table-md table-sm">
+            <thead>
+              <tr className="rounded-xl text-sm text-base-content">
+                <th className="bg-primary">Transaction Hash</th>
+                <th className="bg-primary">Function Called</th>
+                <th className="bg-primary">Block Number</th>
+                <th className="bg-primary">Time Mined</th>
+                <th className="bg-primary">From</th>
+                <th className="bg-primary">To</th>
+                <th className="bg-primary text-end">Value ({targetNetwork.nativeCurrency.symbol})</th>
+              </tr>
+            </thead>
+            <tbody>
+              {blocks.map(block =>
+                (block.transactions as TransactionWithFunction[]).map(tx => {
+                  const receipt = transactionReceipts[tx.hash];
+                  const timeMined = new Date(Number(block.timestamp) * 1000).toLocaleString();
+                  const functionCalled = tx.input.substring(0, 10);
 
-                return (
-                  <tr key={tx.hash} className="hover text-sm">
-                    <td className="w-1/12 md:py-4">
-                      <TransactionHash hash={tx.hash} />
-                    </td>
-                    <td className="w-2/12 md:py-4">
-                      {tx.functionName === "0x" ? "" : <span className="mr-1">{tx.functionName}</span>}
-                      {functionCalled !== "0x" && (
-                        <span className="badge badge-primary font-bold text-xs">{functionCalled}</span>
-                      )}
-                    </td>
-                    <td className="w-1/12 md:py-4">{block.number?.toString()}</td>
-                    <td className="w-2/12 md:py-4">{timeMined}</td>
-                    <td className="w-2/12 md:py-4">
-                      <Address address={tx.from} size="sm" onlyEnsOrAddress chain={targetNetwork} />
-                    </td>
-                    <td className="w-2/12 md:py-4">
-                      {!receipt?.contractAddress ? (
-                        tx.to && <Address address={tx.to} size="sm" onlyEnsOrAddress chain={targetNetwork} />
-                      ) : (
-                        <div className="relative">
-                          <Address address={receipt.contractAddress} size="sm" onlyEnsOrAddress chain={targetNetwork} />
-                          <small className="absolute top-4 left-4">(Contract Creation)</small>
-                        </div>
-                      )}
-                    </td>
-                    <td className="text-right md:py-4">
-                      {formatEther(tx.value)} {targetNetwork.nativeCurrency.symbol}
-                    </td>
-                  </tr>
-                );
-              }),
-            )}
-          </tbody>
-        </table>
+                  return (
+                    <tr key={tx.hash} className="hover text-sm">
+                      <td className="w-1/12 md:py-4">
+                        <TransactionHash hash={tx.hash} />
+                      </td>
+                      <td className="w-2/12 md:py-4">
+                        {tx.functionName === "0x" ? "" : <span className="mr-1">{tx.functionName}</span>}
+                        {functionCalled !== "0x" && (
+                          <span className="badge badge-primary font-bold text-xs">{functionCalled}</span>
+                        )}
+                      </td>
+                      <td className="w-1/12 md:py-4">{block.number?.toString()}</td>
+                      <td className="w-2/12 md:py-4">{timeMined}</td>
+                      <td className="w-2/12 md:py-4">
+                        <Address address={tx.from} size="sm" onlyEnsOrAddress chain={targetNetwork} />
+                      </td>
+                      <td className="w-2/12 md:py-4">
+                        {!receipt?.contractAddress ? (
+                          tx.to && <Address address={tx.to} size="sm" onlyEnsOrAddress chain={targetNetwork} />
+                        ) : (
+                          <div className="relative">
+                            <Address
+                              address={receipt.contractAddress}
+                              size="sm"
+                              onlyEnsOrAddress
+                              chain={targetNetwork}
+                            />
+                            <small className="absolute top-4 left-4">(Contract Creation)</small>
+                          </div>
+                        )}
+                      </td>
+                      <td className="text-right md:py-4">
+                        {formatEther(tx.value)} {targetNetwork.nativeCurrency.symbol}
+                      </td>
+                    </tr>
+                  );
+                }),
+              )}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );

--- a/packages/nextjs/app/blockexplorer/page.tsx
+++ b/packages/nextjs/app/blockexplorer/page.tsx
@@ -9,7 +9,7 @@ import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { notification } from "~~/utils/scaffold-eth";
 
 const BlockExplorer: NextPage = () => {
-  const { blocks, transactionReceipts, currentPage, totalBlocks, setCurrentPage, error } = useFetchBlocks();
+  const { blocks, transactionReceipts, currentPage, totalTransactions, setCurrentPage, error } = useFetchBlocks();
   const { targetNetwork } = useTargetNetwork();
   const [isLocalNetwork, setIsLocalNetwork] = useState(true);
   const [hasError, setHasError] = useState(false);
@@ -75,7 +75,7 @@ const BlockExplorer: NextPage = () => {
     <div className="container mx-auto my-10">
       <SearchBar />
       <TransactionsTable blocks={blocks} transactionReceipts={transactionReceipts} />
-      <PaginationButton currentPage={currentPage} totalItems={Number(totalBlocks)} setCurrentPage={setCurrentPage} />
+      <PaginationButton currentPage={currentPage} totalItems={totalTransactions} setCurrentPage={setCurrentPage} />
     </div>
   );
 };

--- a/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
@@ -12,7 +12,8 @@ import {
 import { hardhat } from "viem/chains";
 import { decodeTransactionData } from "~~/utils/scaffold-eth";
 
-const BLOCKS_PER_PAGE = 20;
+const TRANSACTIONS_PER_PAGE = 20;
+const BLOCK_BATCH_SIZE = 50;
 
 export const testClient = createTestClient({
   chain: hardhat,
@@ -22,13 +23,81 @@ export const testClient = createTestClient({
   .extend(publicActions)
   .extend(walletActions);
 
+const groupTransactionsByBlock = (items: { block: Block; tx: Transaction }[]): Block[] => {
+  const blockMap = new Map<string, Block>();
+
+  for (const { block, tx } of items) {
+    const key = block.number!.toString();
+    if (!blockMap.has(key)) {
+      blockMap.set(key, { ...block, transactions: [] });
+    }
+    (blockMap.get(key)!.transactions as Transaction[]).push(tx);
+  }
+
+  const seenBlocks = new Set<string>();
+  const groupedBlocks: Block[] = [];
+
+  for (const { block } of items) {
+    const key = block.number!.toString();
+    if (!seenBlocks.has(key)) {
+      seenBlocks.add(key);
+      groupedBlocks.push(blockMap.get(key)!);
+    }
+  }
+
+  return groupedBlocks;
+};
+
+const fetchTransactionsPage = async (
+  latestBlock: bigint,
+  page: number,
+): Promise<{ items: { block: Block; tx: Transaction }[]; totalTransactions: number }> => {
+  const skipCount = page * TRANSACTIONS_PER_PAGE;
+  const pageItems: { block: Block; tx: Transaction }[] = [];
+  let skipped = 0;
+  let totalTransactions = 0;
+
+  for (let blockNum = latestBlock; blockNum >= 0n; ) {
+    const batchEnd = blockNum - BigInt(BLOCK_BATCH_SIZE - 1);
+    const batchStart = batchEnd < 0n ? 0n : batchEnd;
+
+    const blockNumbers: bigint[] = [];
+    for (let b = blockNum; b >= batchStart; b--) {
+      blockNumbers.push(b);
+    }
+
+    const fetchedBlocks = await Promise.all(
+      blockNumbers.map(blockNumber => testClient.getBlock({ blockNumber, includeTransactions: true })),
+    );
+
+    for (const block of fetchedBlocks) {
+      for (const tx of block.transactions as Transaction[]) {
+        totalTransactions++;
+
+        if (skipped < skipCount) {
+          skipped++;
+          continue;
+        }
+
+        if (pageItems.length < TRANSACTIONS_PER_PAGE) {
+          pageItems.push({ block, tx });
+        }
+      }
+    }
+
+    blockNum = batchStart - 1n;
+  }
+
+  return { items: pageItems, totalTransactions };
+};
+
 export const useFetchBlocks = () => {
   const [blocks, setBlocks] = useState<Block[]>([]);
   const [transactionReceipts, setTransactionReceipts] = useState<{
     [key: string]: TransactionReceipt;
   }>({});
   const [currentPage, setCurrentPage] = useState(0);
-  const [totalBlocks, setTotalBlocks] = useState(0n);
+  const [totalTransactions, setTotalTransactions] = useState(0);
   const [error, setError] = useState<Error | null>(null);
 
   const fetchBlocks = useCallback(async () => {
@@ -36,43 +105,24 @@ export const useFetchBlocks = () => {
 
     try {
       const blockNumber = await testClient.getBlockNumber();
-      setTotalBlocks(blockNumber);
+      const { items, totalTransactions: totalTxCount } = await fetchTransactionsPage(blockNumber, currentPage);
 
-      const startingBlock = blockNumber - BigInt(currentPage * BLOCKS_PER_PAGE);
-      const blockNumbersToFetch = Array.from(
-        { length: Number(BLOCKS_PER_PAGE < startingBlock + 1n ? BLOCKS_PER_PAGE : startingBlock + 1n) },
-        (_, i) => startingBlock - BigInt(i),
-      );
-
-      const blocksWithTransactions = blockNumbersToFetch.map(async blockNumber => {
-        try {
-          return testClient.getBlock({ blockNumber, includeTransactions: true });
-        } catch (err) {
-          setError(err instanceof Error ? err : new Error("An error occurred."));
-          throw err;
-        }
-      });
-      const fetchedBlocks = await Promise.all(blocksWithTransactions);
-
-      fetchedBlocks.forEach(block => {
-        block.transactions.forEach(tx => decodeTransactionData(tx as Transaction));
-      });
+      items.forEach(({ tx }) => decodeTransactionData(tx));
 
       const txReceipts = await Promise.all(
-        fetchedBlocks.flatMap(block =>
-          block.transactions.map(async tx => {
-            try {
-              const receipt = await testClient.getTransactionReceipt({ hash: (tx as Transaction).hash });
-              return { [(tx as Transaction).hash]: receipt };
-            } catch (err) {
-              setError(err instanceof Error ? err : new Error("An error occurred."));
-              throw err;
-            }
-          }),
-        ),
+        items.map(async ({ tx }) => {
+          try {
+            const receipt = await testClient.getTransactionReceipt({ hash: tx.hash });
+            return { [tx.hash]: receipt };
+          } catch (err) {
+            setError(err instanceof Error ? err : new Error("An error occurred."));
+            throw err;
+          }
+        }),
       );
 
-      setBlocks(fetchedBlocks);
+      setBlocks(groupTransactionsByBlock(items));
+      setTotalTransactions(totalTxCount);
       setTransactionReceipts(prevReceipts => ({ ...prevReceipts, ...Object.assign({}, ...txReceipts) }));
     } catch (err) {
       setError(err instanceof Error ? err : new Error("An error occurred."));
@@ -84,23 +134,27 @@ export const useFetchBlocks = () => {
   }, [fetchBlocks]);
 
   useEffect(() => {
-    const handleNewBlock = async (newBlock: any) => {
+    const handleNewBlock = async (newBlock: Block) => {
       try {
-        if (currentPage === 0) {
-          if (newBlock.transactions.length > 0) {
+        setTotalTransactions(prevTotal => prevTotal + newBlock.transactions.length);
+
+        if (currentPage === 0 && newBlock.transactions.length > 0) {
+          let blockWithTxDetails = newBlock;
+
+          if (typeof newBlock.transactions[0] === "string") {
             const transactionsDetails = await Promise.all(
-              newBlock.transactions.map((txHash: string) => testClient.getTransaction({ hash: txHash as Hash })),
+              newBlock.transactions.map(txHash => testClient.getTransaction({ hash: txHash as Hash })),
             );
-            newBlock.transactions = transactionsDetails;
+            blockWithTxDetails = { ...newBlock, transactions: transactionsDetails };
           }
 
-          newBlock.transactions.forEach((tx: Transaction) => decodeTransactionData(tx as Transaction));
+          (blockWithTxDetails.transactions as Transaction[]).forEach(tx => decodeTransactionData(tx));
 
           const receipts = await Promise.all(
-            newBlock.transactions.map(async (tx: Transaction) => {
+            (blockWithTxDetails.transactions as Transaction[]).map(async tx => {
               try {
-                const receipt = await testClient.getTransactionReceipt({ hash: (tx as Transaction).hash });
-                return { [(tx as Transaction).hash]: receipt };
+                const receipt = await testClient.getTransactionReceipt({ hash: tx.hash });
+                return { [tx.hash]: receipt };
               } catch (err) {
                 setError(err instanceof Error ? err : new Error("An error occurred fetching receipt."));
                 throw err;
@@ -108,11 +162,27 @@ export const useFetchBlocks = () => {
             }),
           );
 
-          setBlocks(prevBlocks => [newBlock, ...prevBlocks.slice(0, BLOCKS_PER_PAGE - 1)]);
+          setBlocks(prevBlocks => {
+            const latestBlockNumber = blockWithTxDetails.number!;
+            const existingBlockIndex = prevBlocks.findIndex(block => block.number === latestBlockNumber);
+
+            const nextBlocks =
+              existingBlockIndex >= 0
+                ? prevBlocks.map((block, index) => (index === existingBlockIndex ? blockWithTxDetails : block))
+                : [blockWithTxDetails, ...prevBlocks];
+
+            const trimmedBlocks = [...nextBlocks];
+            while (
+              trimmedBlocks.reduce((count, block) => count + block.transactions.length, 0) > TRANSACTIONS_PER_PAGE &&
+              trimmedBlocks.length > 0
+            ) {
+              trimmedBlocks.pop();
+            }
+
+            return trimmedBlocks;
+          });
+
           setTransactionReceipts(prevReceipts => ({ ...prevReceipts, ...Object.assign({}, ...receipts) }));
-        }
-        if (newBlock.number) {
-          setTotalBlocks(newBlock.number);
         }
       } catch (err) {
         setError(err instanceof Error ? err : new Error("An error occurred."));
@@ -126,7 +196,7 @@ export const useFetchBlocks = () => {
     blocks,
     transactionReceipts,
     currentPage,
-    totalBlocks,
+    totalTransactions,
     setCurrentPage,
     error,
   };

--- a/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
@@ -178,11 +178,16 @@ export const useFetchBlocks = () => {
             }
 
             const trimmedBlocks = [...nextBlocks];
-            while (
-              trimmedBlocks.reduce((count, block) => count + block.transactions.length, 0) > TRANSACTIONS_PER_PAGE &&
-              trimmedBlocks.length > 0
-            ) {
-              trimmedBlocks.pop();
+            let transactionsInTrimmedBlocks = trimmedBlocks.reduce(
+              (count, block) => count + block.transactions.length,
+              0,
+            );
+
+            while (transactionsInTrimmedBlocks > TRANSACTIONS_PER_PAGE && trimmedBlocks.length > 0) {
+              const removedBlock = trimmedBlocks.pop();
+              if (removedBlock) {
+                transactionsInTrimmedBlocks -= removedBlock.transactions.length;
+              }
             }
 
             return trimmedBlocks;

--- a/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
@@ -136,8 +136,6 @@ export const useFetchBlocks = () => {
   useEffect(() => {
     const handleNewBlock = async (newBlock: Block) => {
       try {
-        setTotalTransactions(prevTotal => prevTotal + newBlock.transactions.length);
-
         if (currentPage === 0 && newBlock.transactions.length > 0) {
           let blockWithTxDetails = newBlock;
 
@@ -165,11 +163,19 @@ export const useFetchBlocks = () => {
           setBlocks(prevBlocks => {
             const latestBlockNumber = blockWithTxDetails.number!;
             const existingBlockIndex = prevBlocks.findIndex(block => block.number === latestBlockNumber);
+            const existingBlockTransactionsCount =
+              existingBlockIndex >= 0 ? prevBlocks[existingBlockIndex].transactions.length : 0;
+            const latestBlockTransactionsCount = blockWithTxDetails.transactions.length;
 
             const nextBlocks =
               existingBlockIndex >= 0
                 ? prevBlocks.map((block, index) => (index === existingBlockIndex ? blockWithTxDetails : block))
                 : [blockWithTxDetails, ...prevBlocks];
+
+            const transactionsDelta = latestBlockTransactionsCount - existingBlockTransactionsCount;
+            if (transactionsDelta !== 0) {
+              setTotalTransactions(prevTotal => Math.max(0, prevTotal + transactionsDelta));
+            }
 
             const trimmedBlocks = [...nextBlocks];
             while (


### PR DESCRIPTION
When the local blockchain is set to auto-mine blocks, the block explorer pagination breaks because a lot of empty blocks are created, and the pagination is based on blocks, not on transactions. 

The pagination is always done based on transactions now. It works well with auto mining set to off and on.

The faucet works ok. The error was related to the pagination issue, not the faucet itself.

_Closes #1293 _