### PR TITLE
Fix duplicated logs in useContractLogs

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useContractLogs.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useContractLogs.ts
@@ -9,31 +9,67 @@ export const useContractLogs = (address: Address) => {
   const client = usePublicClient({ chainId: targetNetwork.id });
 
   useEffect(() => {
+    setLogs([]);
+    let unwatch: (() => void) | undefined;
+    let lastFetchedBlock = 0n;
+    // Set to true on effect cleanup. Guards against in-flight fetchLogs completing after
+    // unmount or re-run (e.g. React Strict Mode, address/client change) and registering
+    // a duplicate watcher or calling setLogs with stale data.
+    let ignore = false;
+
     const fetchLogs = async () => {
       if (!client) return console.error("Client not found");
       try {
+        const latestBlock = await client.getBlockNumber();
+        if (ignore) return;
+
         const existingLogs = await client.getLogs({
           address: address,
           fromBlock: 0n,
-          toBlock: "latest",
+          toBlock: latestBlock,
         });
+        if (ignore) return;
+
+        lastFetchedBlock = latestBlock;
         setLogs(existingLogs);
+
+        unwatch = client.watchBlockNumber({
+          onBlockNumber: async blockNumber => {
+            const fromBlock = lastFetchedBlock + 1n;
+            if (fromBlock > blockNumber) return;
+
+            // Advance cursor before await so concurrent block callbacks don't overlap
+            lastFetchedBlock = blockNumber;
+
+            try {
+              const newLogs = await client.getLogs({
+                address: address,
+                fromBlock: fromBlock,
+                toBlock: blockNumber,
+              });
+              if (ignore) return;
+
+              if (newLogs.length > 0) {
+                setLogs(prevLogs => [...prevLogs, ...newLogs]);
+              }
+            } catch (error) {
+              // Roll back the cursor so the next block callback retries this range
+              lastFetchedBlock = fromBlock - 1n;
+              console.error("Failed to fetch logs:", error);
+            }
+          },
+        });
       } catch (error) {
         console.error("Failed to fetch logs:", error);
       }
     };
+
     fetchLogs();
 
-    return client?.watchBlockNumber({
-      onBlockNumber: async (_blockNumber, prevBlockNumber) => {
-        const newLogs = await client.getLogs({
-          address: address,
-          fromBlock: prevBlockNumber,
-          toBlock: "latest",
-        });
-        setLogs(prevLogs => [...prevLogs, ...newLogs]);
-      },
-    });
+    return () => {
+      ignore = true;
+      unwatch?.();
+    };
   }, [address, client]);
 
   return logs;


### PR DESCRIPTION
The block explorer's address logs tab (useContractLogs) showed duplicated log entries. Two overlapping fetch ranges caused this:

  1. The initial fetch retrieved logs from block 0 to "latest".
  2. On every new block, the watchBlockNumber callback fetched from prevBlockNumber to "latest" — a range that overlapped both the initial fetch and previous callback fetches, so boundary blocks were counted twice (and more on fast-polling chains).

  In addition, under React Strict Mode the effect's double-invocation could register a duplicate watcher, since the watcher
  was set up with no guard against the effect having already been cleaned up.

### How to test

  1. Open the block explorer, navigate to the deployed contract's address, and open the Logs tab.
  2. Trigger transactions that emit events (e.g. setGreeting from the Debug Contracts page) and verify each event appears
  exactly once, including with React Strict Mode (dev mode) and while new blocks are being mined.
  3. Navigate between different addresses and verify logs from the previous address never appear in the new list.