### PR TITLE
Cache block explorer transaction total to avoid full-chain rescans on pagination

### DIFF
--- a/packages/nextjs/app/blockexplorer/_components/ContractTabs.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/ContractTabs.tsx
@@ -26,7 +26,7 @@ const publicClient = createPublicClient({
 });
 
 export const ContractTabs = ({ address, contractData }: PageProps) => {
-  const { blocks, transactionReceipts, currentPage, totalTransactions, setCurrentPage } = useFetchBlocks();
+  const { blocks, transactionReceipts, currentPage, hasNextPage, setCurrentPage } = useFetchBlocks(address);
   const [activeTab, setActiveTab] = useState("transactions");
   const [isContract, setIsContract] = useState(false);
 
@@ -38,15 +38,6 @@ export const ContractTabs = ({ address, contractData }: PageProps) => {
 
     checkIsContract();
   }, [address]);
-
-  const filteredBlocks = blocks.filter(block =>
-    block.transactions.some(tx => {
-      if (typeof tx === "string") {
-        return false;
-      }
-      return tx.from.toLowerCase() === address.toLowerCase() || tx.to?.toLowerCase() === address.toLowerCase();
-    }),
-  );
 
   return (
     <>
@@ -84,8 +75,8 @@ export const ContractTabs = ({ address, contractData }: PageProps) => {
       )}
       {activeTab === "transactions" && (
         <div className="pt-4">
-          <TransactionsTable blocks={filteredBlocks} transactionReceipts={transactionReceipts} />
-          <PaginationButton currentPage={currentPage} totalItems={totalTransactions} setCurrentPage={setCurrentPage} />
+          <TransactionsTable blocks={blocks} transactionReceipts={transactionReceipts} />
+          <PaginationButton currentPage={currentPage} hasNextPage={hasNextPage} setCurrentPage={setCurrentPage} />
         </div>
       )}
       {activeTab === "code" && contractData && (

--- a/packages/nextjs/app/blockexplorer/_components/PaginationButton.tsx
+++ b/packages/nextjs/app/blockexplorer/_components/PaginationButton.tsx
@@ -2,15 +2,13 @@ import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/24/outline";
 
 type PaginationButtonProps = {
   currentPage: number;
-  totalItems: number;
+  hasNextPage: boolean;
   setCurrentPage: (page: number) => void;
 };
 
-const ITEMS_PER_PAGE = 20;
-
-export const PaginationButton = ({ currentPage, totalItems, setCurrentPage }: PaginationButtonProps) => {
+export const PaginationButton = ({ currentPage, hasNextPage, setCurrentPage }: PaginationButtonProps) => {
   const isPrevButtonDisabled = currentPage === 0;
-  const isNextButtonDisabled = currentPage + 1 >= Math.ceil(totalItems / ITEMS_PER_PAGE);
+  const isNextButtonDisabled = !hasNextPage;
 
   const prevButtonClass = isPrevButtonDisabled ? "btn-disabled cursor-default" : "btn-primary";
   const nextButtonClass = isNextButtonDisabled ? "btn-disabled cursor-default" : "btn-primary";

--- a/packages/nextjs/app/blockexplorer/page.tsx
+++ b/packages/nextjs/app/blockexplorer/page.tsx
@@ -9,7 +9,7 @@ import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { notification } from "~~/utils/scaffold-eth";
 
 const BlockExplorer: NextPage = () => {
-  const { blocks, transactionReceipts, currentPage, totalTransactions, setCurrentPage, error } = useFetchBlocks();
+  const { blocks, transactionReceipts, currentPage, hasNextPage, setCurrentPage, error } = useFetchBlocks();
   const { targetNetwork } = useTargetNetwork();
   const [isLocalNetwork, setIsLocalNetwork] = useState(true);
   const [hasError, setHasError] = useState(false);
@@ -75,7 +75,7 @@ const BlockExplorer: NextPage = () => {
     <div className="container mx-auto my-10">
       <SearchBar />
       <TransactionsTable blocks={blocks} transactionReceipts={transactionReceipts} />
-      <PaginationButton currentPage={currentPage} totalItems={totalTransactions} setCurrentPage={setCurrentPage} />
+      <PaginationButton currentPage={currentPage} hasNextPage={hasNextPage} setCurrentPage={setCurrentPage} />
     </div>
   );
 };

--- a/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
@@ -48,14 +48,72 @@ const groupTransactionsByBlock = (items: { block: Block; tx: Transaction }[]): B
   return groupedBlocks;
 };
 
-const fetchTransactionsPage = async (
-  latestBlock: bigint,
-  page: number,
-): Promise<{ items: { block: Block; tx: Transaction }[]; totalTransactions: number }> => {
+type TransactionIndexCache = {
+  latestBlock: bigint;
+  totalTransactions: number;
+};
+
+let txIndexCache: TransactionIndexCache | null = null;
+
+const fetchBlocksWithTransactions = async (fromBlock: bigint, toBlock: bigint): Promise<Block[]> => {
+  const blocks: Block[] = [];
+
+  for (let blockNum = toBlock; blockNum >= fromBlock; ) {
+    const batchEnd = blockNum - BigInt(BLOCK_BATCH_SIZE - 1);
+    const batchStart = batchEnd < fromBlock ? fromBlock : batchEnd;
+
+    const blockNumbers: bigint[] = [];
+    for (let b = blockNum; b >= batchStart; b--) {
+      blockNumbers.push(b);
+    }
+
+    const fetchedBlocks = await Promise.all(
+      blockNumbers.map(blockNumber => testClient.getBlock({ blockNumber, includeTransactions: true })),
+    );
+
+    blocks.push(...fetchedBlocks);
+    blockNum = batchStart - 1n;
+  }
+
+  return blocks;
+};
+
+const countTransactionsInBlocks = (blocks: Block[]): number =>
+  blocks.reduce((count, block) => count + (block.transactions as Transaction[]).length, 0);
+
+const getTotalTransactions = async (latestBlock: bigint): Promise<number> => {
+  if (txIndexCache && latestBlock === txIndexCache.latestBlock) {
+    return txIndexCache.totalTransactions;
+  }
+
+  if (txIndexCache && latestBlock > txIndexCache.latestBlock) {
+    const newBlocks = await fetchBlocksWithTransactions(txIndexCache.latestBlock + 1n, latestBlock);
+    txIndexCache = {
+      latestBlock,
+      totalTransactions: txIndexCache.totalTransactions + countTransactionsInBlocks(newBlocks),
+    };
+    return txIndexCache.totalTransactions;
+  }
+
+  const allBlocks = await fetchBlocksWithTransactions(0n, latestBlock);
+  const totalTransactions = countTransactionsInBlocks(allBlocks);
+  txIndexCache = { latestBlock, totalTransactions };
+  return totalTransactions;
+};
+
+const applyTransactionDeltaToCache = (blockNumber: bigint, delta: number) => {
+  if (!txIndexCache || delta === 0) return;
+
+  txIndexCache.totalTransactions = Math.max(0, txIndexCache.totalTransactions + delta);
+  if (blockNumber > txIndexCache.latestBlock) {
+    txIndexCache.latestBlock = blockNumber;
+  }
+};
+
+const fetchPageItems = async (latestBlock: bigint, page: number): Promise<{ block: Block; tx: Transaction }[]> => {
   const skipCount = page * TRANSACTIONS_PER_PAGE;
   const pageItems: { block: Block; tx: Transaction }[] = [];
   let skipped = 0;
-  let totalTransactions = 0;
 
   for (let blockNum = latestBlock; blockNum >= 0n; ) {
     const batchEnd = blockNum - BigInt(BLOCK_BATCH_SIZE - 1);
@@ -72,15 +130,14 @@ const fetchTransactionsPage = async (
 
     for (const block of fetchedBlocks) {
       for (const tx of block.transactions as Transaction[]) {
-        totalTransactions++;
-
         if (skipped < skipCount) {
           skipped++;
           continue;
         }
 
-        if (pageItems.length < TRANSACTIONS_PER_PAGE) {
-          pageItems.push({ block, tx });
+        pageItems.push({ block, tx });
+        if (pageItems.length >= TRANSACTIONS_PER_PAGE) {
+          return pageItems;
         }
       }
     }
@@ -88,7 +145,7 @@ const fetchTransactionsPage = async (
     blockNum = batchStart - 1n;
   }
 
-  return { items: pageItems, totalTransactions };
+  return pageItems;
 };
 
 export const useFetchBlocks = () => {
@@ -105,7 +162,10 @@ export const useFetchBlocks = () => {
 
     try {
       const blockNumber = await testClient.getBlockNumber();
-      const { items, totalTransactions: totalTxCount } = await fetchTransactionsPage(blockNumber, currentPage);
+      const [items, totalTxCount] = await Promise.all([
+        fetchPageItems(blockNumber, currentPage),
+        getTotalTransactions(blockNumber),
+      ]);
 
       items.forEach(({ tx }) => decodeTransactionData(tx));
 
@@ -175,6 +235,7 @@ export const useFetchBlocks = () => {
             const transactionsDelta = latestBlockTransactionsCount - existingBlockTransactionsCount;
             if (transactionsDelta !== 0) {
               setTotalTransactions(prevTotal => Math.max(0, prevTotal + transactionsDelta));
+              applyTransactionDeltaToCache(latestBlockNumber, transactionsDelta);
             }
 
             const trimmedBlocks = [...nextBlocks];

--- a/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useFetchBlocks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import {
+  Address,
   Block,
   Hash,
   Transaction,
@@ -48,69 +49,14 @@ const groupTransactionsByBlock = (items: { block: Block; tx: Transaction }[]): B
   return groupedBlocks;
 };
 
-type TransactionIndexCache = {
-  latestBlock: bigint;
-  totalTransactions: number;
-};
-
-let txIndexCache: TransactionIndexCache | null = null;
-
-const fetchBlocksWithTransactions = async (fromBlock: bigint, toBlock: bigint): Promise<Block[]> => {
-  const blocks: Block[] = [];
-
-  for (let blockNum = toBlock; blockNum >= fromBlock; ) {
-    const batchEnd = blockNum - BigInt(BLOCK_BATCH_SIZE - 1);
-    const batchStart = batchEnd < fromBlock ? fromBlock : batchEnd;
-
-    const blockNumbers: bigint[] = [];
-    for (let b = blockNum; b >= batchStart; b--) {
-      blockNumbers.push(b);
-    }
-
-    const fetchedBlocks = await Promise.all(
-      blockNumbers.map(blockNumber => testClient.getBlock({ blockNumber, includeTransactions: true })),
-    );
-
-    blocks.push(...fetchedBlocks);
-    blockNum = batchStart - 1n;
-  }
-
-  return blocks;
-};
-
-const countTransactionsInBlocks = (blocks: Block[]): number =>
-  blocks.reduce((count, block) => count + (block.transactions as Transaction[]).length, 0);
-
-const getTotalTransactions = async (latestBlock: bigint): Promise<number> => {
-  if (txIndexCache && latestBlock === txIndexCache.latestBlock) {
-    return txIndexCache.totalTransactions;
-  }
-
-  if (txIndexCache && latestBlock > txIndexCache.latestBlock) {
-    const newBlocks = await fetchBlocksWithTransactions(txIndexCache.latestBlock + 1n, latestBlock);
-    txIndexCache = {
-      latestBlock,
-      totalTransactions: txIndexCache.totalTransactions + countTransactionsInBlocks(newBlocks),
-    };
-    return txIndexCache.totalTransactions;
-  }
-
-  const allBlocks = await fetchBlocksWithTransactions(0n, latestBlock);
-  const totalTransactions = countTransactionsInBlocks(allBlocks);
-  txIndexCache = { latestBlock, totalTransactions };
-  return totalTransactions;
-};
-
-const applyTransactionDeltaToCache = (blockNumber: bigint, delta: number) => {
-  if (!txIndexCache || delta === 0) return;
-
-  txIndexCache.totalTransactions = Math.max(0, txIndexCache.totalTransactions + delta);
-  if (blockNumber > txIndexCache.latestBlock) {
-    txIndexCache.latestBlock = blockNumber;
-  }
-};
-
-const fetchPageItems = async (latestBlock: bigint, page: number): Promise<{ block: Block; tx: Transaction }[]> => {
+// Collects the requested page plus one extra transaction (the cheap "is there a next page?"
+// signal), counting only transactions that pass matchesFilter — so address views paginate over
+// the address's own transactions instead of slicing a global page.
+const fetchPageItems = async (
+  latestBlock: bigint,
+  page: number,
+  matchesFilter: (tx: Transaction) => boolean,
+): Promise<{ block: Block; tx: Transaction }[]> => {
   const skipCount = page * TRANSACTIONS_PER_PAGE;
   const pageItems: { block: Block; tx: Transaction }[] = [];
   let skipped = 0;
@@ -130,13 +76,17 @@ const fetchPageItems = async (latestBlock: bigint, page: number): Promise<{ bloc
 
     for (const block of fetchedBlocks) {
       for (const tx of block.transactions as Transaction[]) {
+        if (!matchesFilter(tx)) {
+          continue;
+        }
+
         if (skipped < skipCount) {
           skipped++;
           continue;
         }
 
         pageItems.push({ block, tx });
-        if (pageItems.length >= TRANSACTIONS_PER_PAGE) {
+        if (pageItems.length > TRANSACTIONS_PER_PAGE) {
           return pageItems;
         }
       }
@@ -148,24 +98,31 @@ const fetchPageItems = async (latestBlock: bigint, page: number): Promise<{ bloc
   return pageItems;
 };
 
-export const useFetchBlocks = () => {
+export const useFetchBlocks = (addressFilter?: Address) => {
   const [blocks, setBlocks] = useState<Block[]>([]);
   const [transactionReceipts, setTransactionReceipts] = useState<{
     [key: string]: TransactionReceipt;
   }>({});
   const [currentPage, setCurrentPage] = useState(0);
-  const [totalTransactions, setTotalTransactions] = useState(0);
+  const [hasNextPage, setHasNextPage] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+
+  const matchesAddressFilter = useCallback(
+    (tx: Transaction) => {
+      if (!addressFilter) return true;
+      const filter = addressFilter.toLowerCase();
+      return tx.from.toLowerCase() === filter || tx.to?.toLowerCase() === filter;
+    },
+    [addressFilter],
+  );
 
   const fetchBlocks = useCallback(async () => {
     setError(null);
 
     try {
       const blockNumber = await testClient.getBlockNumber();
-      const [items, totalTxCount] = await Promise.all([
-        fetchPageItems(blockNumber, currentPage),
-        getTotalTransactions(blockNumber),
-      ]);
+      const fetchedItems = await fetchPageItems(blockNumber, currentPage, matchesAddressFilter);
+      const items = fetchedItems.slice(0, TRANSACTIONS_PER_PAGE);
 
       items.forEach(({ tx }) => decodeTransactionData(tx));
 
@@ -182,12 +139,12 @@ export const useFetchBlocks = () => {
       );
 
       setBlocks(groupTransactionsByBlock(items));
-      setTotalTransactions(totalTxCount);
+      setHasNextPage(fetchedItems.length > TRANSACTIONS_PER_PAGE);
       setTransactionReceipts(prevReceipts => ({ ...prevReceipts, ...Object.assign({}, ...txReceipts) }));
     } catch (err) {
       setError(err instanceof Error ? err : new Error("An error occurred."));
     }
-  }, [currentPage]);
+  }, [currentPage, matchesAddressFilter]);
 
   useEffect(() => {
     fetchBlocks();
@@ -206,6 +163,12 @@ export const useFetchBlocks = () => {
             blockWithTxDetails = { ...newBlock, transactions: transactionsDetails };
           }
 
+          const matchingTransactions = (blockWithTxDetails.transactions as Transaction[]).filter(matchesAddressFilter);
+          if (matchingTransactions.length === 0) {
+            return;
+          }
+          blockWithTxDetails = { ...blockWithTxDetails, transactions: matchingTransactions };
+
           (blockWithTxDetails.transactions as Transaction[]).forEach(tx => decodeTransactionData(tx));
 
           const receipts = await Promise.all(
@@ -223,26 +186,22 @@ export const useFetchBlocks = () => {
           setBlocks(prevBlocks => {
             const latestBlockNumber = blockWithTxDetails.number!;
             const existingBlockIndex = prevBlocks.findIndex(block => block.number === latestBlockNumber);
-            const existingBlockTransactionsCount =
-              existingBlockIndex >= 0 ? prevBlocks[existingBlockIndex].transactions.length : 0;
-            const latestBlockTransactionsCount = blockWithTxDetails.transactions.length;
 
             const nextBlocks =
               existingBlockIndex >= 0
                 ? prevBlocks.map((block, index) => (index === existingBlockIndex ? blockWithTxDetails : block))
                 : [blockWithTxDetails, ...prevBlocks];
 
-            const transactionsDelta = latestBlockTransactionsCount - existingBlockTransactionsCount;
-            if (transactionsDelta !== 0) {
-              setTotalTransactions(prevTotal => Math.max(0, prevTotal + transactionsDelta));
-              applyTransactionDeltaToCache(latestBlockNumber, transactionsDelta);
-            }
-
             const trimmedBlocks = [...nextBlocks];
             let transactionsInTrimmedBlocks = trimmedBlocks.reduce(
               (count, block) => count + block.transactions.length,
               0,
             );
+
+            // More than one page of transactions are now in view, so a next page exists.
+            if (transactionsInTrimmedBlocks > TRANSACTIONS_PER_PAGE) {
+              setHasNextPage(true);
+            }
 
             while (transactionsInTrimmedBlocks > TRANSACTIONS_PER_PAGE && trimmedBlocks.length > 0) {
               const removedBlock = trimmedBlocks.pop();
@@ -262,13 +221,13 @@ export const useFetchBlocks = () => {
     };
 
     return testClient.watchBlocks({ onBlock: handleNewBlock, includeTransactions: true });
-  }, [currentPage]);
+  }, [currentPage, matchesAddressFilter]);
 
   return {
     blocks,
     transactionReceipts,
     currentPage,
-    totalTransactions,
+    hasNextPage,
     setCurrentPage,
     error,
   };


### PR DESCRIPTION
Fixes a performance bug where the block explorer walked from latestBlock down to block 0 on every page change and refetch, issuing a getBlock({ includeTransactions: true }) for every block just to compute totalTransactions — even after the current page's 20 transactions were already collected.

With auto-mining (~1 block/s), a day-old local chain is ~86k blocks. Each pagination click previously triggered ~86k RPC calls. On page 0, the scan continued all the way to genesis even after 20 transactions were found, solely to count the total.

This is related to the fix applied at https://github.com/scaffold-eth/scaffold-eth-2/pull/1295

It adds some complexity to the code. We have to take into account whether fixing this is worth the added complexity, since this is only an issue on the local chain.
