### PR TITLE
fix: generateTsAbis formatting

### DIFF
--- a/packages/hardhat/scripts/generateTsAbis.ts
+++ b/packages/hardhat/scripts/generateTsAbis.ts
@@ -155,6 +155,9 @@ export default async function generateTsAbis() {
  const deployedContracts = {${fileContent}} as const; \n\n export default deployedContracts satisfies GenericContractsDeclaration`,
       {
         parser: "typescript",
+        // Match the nextjs prettier config (printWidth 120) so the generated file
+        // passes the frontend lint/build instead of defaulting to printWidth 80.
+        printWidth: 120,
       },
     ),
   );


### PR DESCRIPTION
`generateTsAbis` prettier formatting takes default prettier `printWidth` which is `80`, but we have `120` in prettier config. So when we have long lines in deployment files, prettier warnings appear.

To reproduce:
```
npx create-eth@2.0.20 -e https://github.com/scaffold-eth/se-2-challenges/tree/challenge-tokenization-hhv3 -s hardhat challenge-tokenization
```

go to the instance

```
yarn chain
yarn deploy
yarn next:build
```

You'll see

```
...
672:17  warning  Delete `⏎·········`  prettier/prettier
  674:19  warning  Delete `⏎·········`  prettier/prettier
  676:21  warning  Delete `⏎·········`  prettier/prettier
  678:26  warning  Delete `⏎·········`  prettier/prettier
  681:17  warning  Delete `⏎·········`  prettier/prettier
  683:26  warning  Delete `⏎·········`  prettier/prettier
  685:27  warning  Delete `⏎·········`  prettier/prettier
  687:27  warning  Delete `⏎·········`  prettier/prettier
  689:16  warning  Delete `⏎·········`  prettier/prettier
  691:18  warning  Delete `⏎·········`  prettier/prettier
  693:22  warning  Delete `⏎·········`  prettier/prettier
  695:22  warning  Delete `⏎·········`  prettier/prettier
  697:29  warning  Delete `⏎·········`  prettier/prettier
  699:21  warning  Delete `⏎·········`  prettier/prettier
  702:27  warning  Delete `⏎·········`  prettier/prettier
  704:27  warning  Delete `⏎·········`  prettier/prettier

✖ 16 problems (0 errors, 16 warnings)
  0 errors and 16 warnings potentially fixable with the `--fix` option.
```

---

Now add to the instance the same lines as in this PR. Redeploy. Warnings will disappear