### PR TITLE
test: cover YourContract withdraw behavior

### DIFF
--- a/packages/hardhat/test/YourContract.ts
+++ b/packages/hardhat/test/YourContract.ts
@@ -28,4 +28,31 @@ describe("YourContract", function () {
       expect(await yourContract.greeting()).to.equal(newGreeting);
     });
   });
+
+  describe("Withdraw", function () {
+    it("Should allow the owner to withdraw contract balance", async function () {
+      const { yourContract } = await networkHelpers.loadFixture(deployFixture);
+      const amount = ethers.parseEther("1");
+
+      await yourContract.setGreeting("Premium greeting", { value: amount });
+
+      const contractAddress = await yourContract.getAddress();
+      expect(await ethers.provider.getBalance(contractAddress)).to.equal(amount);
+
+      await yourContract.withdraw();
+
+      expect(await ethers.provider.getBalance(contractAddress)).to.equal(0n);
+    });
+
+    it("Should not allow non-owners to withdraw contract balance", async function () {
+      const { yourContract } = await networkHelpers.loadFixture(deployFixture);
+      const [, nonOwner] = await ethers.getSigners();
+
+      const nonOwnerContract = yourContract.connect(
+        nonOwner as unknown as Parameters<typeof yourContract.connect>[0],
+      ) as typeof yourContract;
+
+      await expect(nonOwnerContract.withdraw()).to.be.revertedWith("Not the Owner");
+    });
+  });
 });


### PR DESCRIPTION
## Description

Add test coverage for `YourContract.withdraw()`.

The new tests verify that:

- the owner can withdraw ETH held by the contract
- non-owners cannot withdraw and receive the expected revert reason

This does not change contract behavior; it only strengthens coverage for the default contract's owner-only withdrawal flow.



## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
