### PR TITLE
fix: detect standard contract creation bytecode prefix in decodeTxData

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
+++ b/packages/nextjs/utils/scaffold-eth/decodeTxData.ts
@@ -16,8 +16,15 @@ const interfaces = chainMetaData
     }, {} as ContractsInterfaces)
   : {};
 
+// Standard Solidity contract creation (init code) bytecode prefixes. These
+// transactions are deployments and can't be decoded as function calls, so we
+// skip them. `0x60806040` is the common prefix (PUSH1 0x80 PUSH1 0x40 MSTORE);
+// `0x60e06040` appears when the contract stores immutables.
+const CONTRACT_CREATION_PREFIXES = ["0x60806040", "0x60e06040"];
+
 export const decodeTransactionData = (tx: TransactionWithFunction) => {
-  if (tx.input.length >= 10 && !tx.input.startsWith("0x60e06040")) {
+  const isContractCreation = CONTRACT_CREATION_PREFIXES.some(prefix => tx.input.startsWith(prefix));
+  if (tx.input.length >= 10 && !isContractCreation) {
     let foundInterface = false;
     for (const [, contractAbi] of Object.entries(interfaces)) {
       try {


### PR DESCRIPTION
## Description

The contract-creation guard in `decodeTxData.ts` only skipped inputs starting with `0x60e06040`, but the common Solidity init code prefix is `0x60806040` (`PUSH1 0x80 PUSH1 0x40 MSTORE`).

As a result, standard contract creation transactions fell through to the function decoder, failed to match any ABI, and were mislabeled as `⚠️ Unknown` in the block explorer.

## Fix

Check the input against both known init-code prefixes:
- `0x60806040` — the common prefix
- `0x60e06040` — used when a contract stores immutables (preserves the previous behavior)

This way deployments are correctly detected and skipped, while regular function calls still decode normally.

```diff
+const CONTRACT_CREATION_PREFIXES = ["0x60806040", "0x60e06040"];
+
 export const decodeTransactionData = (tx: TransactionWithFunction) => {
-  if (tx.input.length >= 10 && !tx.input.startsWith("0x60e06040")) {
+  const isContractCreation = CONTRACT_CREATION_PREFIXES.some(prefix => tx.input.startsWith(prefix));
+  if (tx.input.length >= 10 && !isContractCreation) {
```

## Testing

- `yarn next:check-types` — passes
- `yarn next:lint` — passes
- Prettier formatting — clean
- Verified the logic against standard deploys (`0x60806040`), immutable deploys (`0x60e06040`), and normal function calls (`transfer`, `approve`): deployments are now skipped and function calls still decode.

Fixes #1246